### PR TITLE
Add Rails/PersistenceCalledOutsideExample cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add `IgnoredMetadata` configuration option to `RSpec/DescribeClass`. ([@Rafix02][])
 * Fix false positives in `RSpec/EmptyExampleGroup`. ([@pirj][])
 * Fix a false positive for `RSpec/EmptyExampleGroup` when example is defined in an `if` branch. ([@koic][])
-* Add RSpec/PersistenceCalledOutsideExample cop.([@thijsnado][])
+* Add RSpec/Rails/PersistenceCalledOutsideExample cop.([@thijsnado][])
 
 ## 1.43.2 (2020-08-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `IgnoredMetadata` configuration option to `RSpec/DescribeClass`. ([@Rafix02][])
 * Fix false positives in `RSpec/EmptyExampleGroup`. ([@pirj][])
 * Fix a false positive for `RSpec/EmptyExampleGroup` when example is defined in an `if` branch. ([@koic][])
+* Add RSpec/PersistenceCalledOutsideExample cop.([@thijsnado][])
 
 ## 1.43.2 (2020-08-25)
 
@@ -565,3 +566,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@biinari]: https://github.com/biinari
 [@koic]: https://github.com/koic
 [@Rafix02]: https://github.com/Rafix02
+[@thijsnado]: https://github.com/thijsnado

--- a/config/default.yml
+++ b/config/default.yml
@@ -676,8 +676,6 @@ Rails/PersistenceCalledOutsideExample:
   Description: Checks for persistence calls outside example blocks.
   Enabled: true
   VersionAdded: '1.43'
-  AllowedBlockNames: []
-  AllowedReceivers: []
   AllowedMethods: []
   ForbiddenMethods:
   - create

--- a/config/default.yml
+++ b/config/default.yml
@@ -680,40 +680,16 @@ Rails/PersistenceCalledOutsideExample:
   ForbiddenMethods:
   - create
   - create!
+  - build
+  - create_list
+  - build_list
+  - save
+  - save!
   - create_or_find_by
   - create_or_find_by!
-  - decrement!
-  - delete_all
-  - delete_by
-  - destroy_all
-  - destroy_by
   - find_or_create_by
   - find_or_create_by!
   - first_or_create
   - first_or_create!
-  - increment!
-  - save
-  - save!
-  - toggle!
-  - touch_all
-  - update
-  - update!
-  - update_all
-  - update_attribute
-  - update_attributes
-  - update_column
-  - update_columns
-  - attributes_for
-  - attributes_for_list
-  - build
-  - build_list
-  - build_stubbed
-  - build_stubbed_list
-  - create_list
   - Fabricate
-  ForbiddenMethodsWithoutArguments:
-  - delete
-  - destroy
-  - destroy!
-  - touch
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/PersistenceCalledOutsideExample

--- a/config/default.yml
+++ b/config/default.yml
@@ -671,3 +671,51 @@ Rails/HttpStatus:
   - symbolic
   VersionAdded: '1.23'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus
+
+Rails/PersistenceCalledOutsideExample:
+  Description: Checks for persistence calls outside example blocks.
+  Enabled: true
+  VersionAdded: '1.43'
+  AllowedBlockNames: []
+  AllowedReceivers: []
+  AllowedMethods: []
+  ForbiddenMethods:
+  - create
+  - create!
+  - create_or_find_by
+  - create_or_find_by!
+  - decrement!
+  - delete_all
+  - delete_by
+  - destroy_all
+  - destroy_by
+  - find_or_create_by
+  - find_or_create_by!
+  - first_or_create
+  - first_or_create!
+  - increment!
+  - save
+  - save!
+  - toggle!
+  - touch_all
+  - update
+  - update!
+  - update_all
+  - update_attribute
+  - update_attributes
+  - update_column
+  - update_columns
+  - attributes_for
+  - attributes_for_list
+  - build
+  - build_list
+  - build_stubbed
+  - build_stubbed_list
+  - create_list
+  - Fabricate
+  ForbiddenMethodsWithoutArguments:
+  - delete
+  - destroy
+  - destroy!
+  - touch
+  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/PersistenceCalledOutsideExample

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -98,5 +98,6 @@
 === Department xref:cops_rails.adoc[Rails]
 
 * xref:cops_rails.adoc#railshttpstatus[Rails/HttpStatus]
+* xref:cops_rails.adoc#railspersistencecalledoutsideexample[Rails/PersistenceCalledOutsideExample]
 
 // END_COP_LIST

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -59,3 +59,72 @@ it { is_expected.to have_http_status :error }
 === References
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus
+
+== Rails/PersistenceCalledOutsideExample
+
+|===
+| Enabled by default | Safe | Supports autocorrection | VersionAdded | VersionChanged
+
+| Enabled
+| Yes
+| No
+| 1.43
+| -
+|===
+
+Checks for persistence calls outside example blocks.
+
+Prevents persistence calls outside examples which usually run
+with some sort of cleanup hook. Saving outside of example causes
+records to leak into other tests.
+
+@ example
+  # bad - records created outside example group
+  describe User do
+    User.create!
+  end
+
+  describe User do
+    user = User.new
+    user.save!
+  end
+
+  # good - records created inside an example group
+  describe User do
+    it do
+      User.create!
+    end
+  end
+
+  describe User do
+    it do
+      user = User.new
+      user.save!
+    end
+  end
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedReceivers
+| `[]`
+| Array
+
+| AllowedMethods
+| `[]`
+| Array
+
+| ForbiddenMethods
+| `create`, `create!`, `create_or_find_by`, `create_or_find_by!`, `decrement!`, `delete_all`, `delete_by`, `destroy_all`, `destroy_by`, `find_or_create_by`, `find_or_create_by!`, `first_or_create`, `first_or_create!`, `increment!`, `save`, `save!`, `toggle!`, `touch_all`, `update`, `update!`, `update_all`, `update_attribute`, `update_attributes`, `update_column`, `update_columns`, `attributes_for`, `attributes_for_list`, `build`, `build_list`, `build_stubbed`, `build_stubbed_list`, `create_list`, `Fabricate`
+| Array
+
+| ForbiddenMethodsWithoutArguments
+| `delete`, `destroy`, `destroy!`, `touch`
+| Array
+|===
+
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/PersistenceCalledOutsideExample

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -108,6 +108,10 @@ records to leak into other tests.
 |===
 | Name | Default value | Configurable values
 
+| AllowedBlockNames
+| `[]`
+| Array
+
 | AllowedReceivers
 | `[]`
 | Array

--- a/docs/modules/ROOT/pages/cops_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rails.adoc
@@ -108,24 +108,12 @@ records to leak into other tests.
 |===
 | Name | Default value | Configurable values
 
-| AllowedBlockNames
-| `[]`
-| Array
-
-| AllowedReceivers
-| `[]`
-| Array
-
 | AllowedMethods
 | `[]`
 | Array
 
 | ForbiddenMethods
-| `create`, `create!`, `create_or_find_by`, `create_or_find_by!`, `decrement!`, `delete_all`, `delete_by`, `destroy_all`, `destroy_by`, `find_or_create_by`, `find_or_create_by!`, `first_or_create`, `first_or_create!`, `increment!`, `save`, `save!`, `toggle!`, `touch_all`, `update`, `update!`, `update_all`, `update_attribute`, `update_attributes`, `update_column`, `update_columns`, `attributes_for`, `attributes_for_list`, `build`, `build_list`, `build_stubbed`, `build_stubbed_list`, `create_list`, `Fabricate`
-| Array
-
-| ForbiddenMethodsWithoutArguments
-| `delete`, `destroy`, `destroy!`, `touch`
+| `create`, `create!`, `build`, `create_list`, `build_list`, `save`, `save!`, `create_or_find_by`, `create_or_find_by!`, `find_or_create_by`, `find_or_create_by!`, `first_or_create`, `first_or_create!`, `Fabricate`
 | Array
 |===
 

--- a/lib/rubocop/cop/rspec/rails/persistence_called_outside_example.rb
+++ b/lib/rubocop/cop/rspec/rails/persistence_called_outside_example.rb
@@ -40,12 +40,12 @@ module RuboCop
           # rubocop:disable Metrics/CyclomaticComplexity
           # rubocop:disable Metrics/PerceivedComplexity
           def on_send(node)
-            return if inside_example_scope?(node)
-            return if inside_method_definition?(node)
-            return if inside_proc_or_lambda?(node)
-            return if inside_allowed_block?(node)
-            return if allowed_receiver?(node)
-            return if allowed_method?(node)
+            return if inside_example_scope?(node) ||
+              inside_method_definition?(node) ||
+              inside_proc_or_lambda?(node) ||
+              inside_allowed_block?(node) ||
+              allowed_receiver?(node) ||
+              allowed_method?(node)
             return unless inside_describe_block?(node)
             return unless persistent_call?(node)
 

--- a/lib/rubocop/cop/rspec/rails/persistence_called_outside_example.rb
+++ b/lib/rubocop/cop/rspec/rails/persistence_called_outside_example.rb
@@ -84,17 +84,11 @@ module RuboCop
           def persistent_call?(node)
             method_name = node.method_name.to_s
 
-            forbidden_methods.include?(method_name) ||
-              forbidden_methods_without_arguments.include?(method_name) &&
-                !node.arguments?
+            forbidden_methods.include?(method_name)
           end
 
           def forbidden_methods
             cop_config['ForbiddenMethods'] || []
-          end
-
-          def forbidden_methods_without_arguments
-            cop_config['ForbiddenMethodsWithoutArguments'] || []
           end
         end
       end

--- a/lib/rubocop/cop/rspec/rails/persistence_called_outside_example.rb
+++ b/lib/rubocop/cop/rspec/rails/persistence_called_outside_example.rb
@@ -37,22 +37,16 @@ module RuboCop
         class PersistenceCalledOutsideExample < Base
           MSG = 'Persistence called outside of example.'
 
-          # rubocop:disable Metrics/CyclomaticComplexity
-          # rubocop:disable Metrics/PerceivedComplexity
           def on_send(node)
             return if inside_example_scope?(node) ||
               inside_method_definition?(node) ||
               inside_proc_or_lambda?(node) ||
-              inside_allowed_block?(node) ||
-              allowed_receiver?(node) ||
               allowed_method?(node)
             return unless inside_describe_block?(node)
             return unless persistent_call?(node)
 
             add_offense(node)
           end
-          # rubocop:enable Metrics/CyclomaticComplexity
-          # rubocop:enable Metrics/PerceivedComplexity
 
           private
 
@@ -73,25 +67,6 @@ module RuboCop
 
           def inside_proc_or_lambda?(node)
             node.each_ancestor(:block).any?(&:lambda_or_proc?)
-          end
-
-          def inside_allowed_block?(node)
-            node.each_ancestor(:block).any?(&method(:allowed_block?))
-          end
-
-          def allowed_block?(node)
-            allowed_block_names = (cop_config['AllowedBlockNames'] || [])
-            allowed_block_names.include?(node.method_name.to_s)
-          end
-
-          def allowed_receiver?(node)
-            return unless node.receiver.respond_to?(:const_name)
-
-            allowed_receivers.include?(node.receiver.const_name)
-          end
-
-          def allowed_receivers
-            cop_config['AllowedReceivers'] || []
           end
 
           def allowed_method?(node)

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -13,6 +13,7 @@ begin
 rescue LoadError
   # Rails/HttpStatus cannot be loaded if rack/utils is unavailable.
 end
+require_relative 'rspec/rails/persistence_called_outside_example'
 
 require_relative 'rspec/align_left_let_brace'
 require_relative 'rspec/align_right_let_brace'

--- a/spec/rubocop/cop/rspec/rails/persistence_called_outside_example_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/persistence_called_outside_example_spec.rb
@@ -244,56 +244,6 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::PersistenceCalledOutsideExample, :con
     end
   end
 
-  context 'when configured with AllowedReceivers', :config do
-    let(:cop_config) do
-      { 'AllowedReceivers' => ['Allowed'] }
-    end
-
-    it 'flags offenses that are not allowed' do
-      expect_offense(<<-RUBY)
-        describe User do
-          User.create!
-          ^^^^^^^^^^^^ Persistence called outside of example.
-        end
-      RUBY
-    end
-
-    it 'does not flag calls on AllowedReceivers', :config do
-      expect_no_offenses(<<-RUBY)
-        describe Allowed do
-          Allowed.create!
-        end
-      RUBY
-    end
-  end
-
-  context 'when configured with AllowedBlockNames', :config do
-    let(:cop_config) do
-      { 'AllowedBlockNames' => ['let_once'] }
-    end
-
-    it 'flags offenses if not included in list' do
-      expect_offense(<<-RUBY)
-        describe User do
-          let_many_times do
-            User.create!
-            ^^^^^^^^^^^^ Persistence called outside of example.
-          end
-        end
-      RUBY
-    end
-
-    it 'does not flag offense if included in list' do
-      expect_no_offenses(<<-RUBY)
-        describe User do
-          let_once do
-            User.create!
-          end
-        end
-      RUBY
-    end
-  end
-
   context 'when configured with ForbiddenMethodsWithoutArguments' do
     let(:cop_config) do
       { 'ForbiddenMethodsWithoutArguments' => ['delete'] }

--- a/spec/rubocop/cop/rspec/rails/persistence_called_outside_example_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/persistence_called_outside_example_spec.rb
@@ -1,0 +1,319 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::Rails::PersistenceCalledOutsideExample, :config do # rubocop:disable Layout/LineLength
+  describe 'flagged methods' do
+    it 'flags create!' do
+      expect_offense(<<-RUBY)
+        describe User do
+          User.create!
+          ^^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'flags save!' do
+      expect_offense(<<-RUBY)
+        describe User do
+          user = User.new
+          user.save!
+          ^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'flags Fabricate' do
+      expect_offense(<<-RUBY)
+        describe User do
+          Fabricate(:user)
+          ^^^^^^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'flags assignment' do
+      expect_offense(<<-RUBY)
+        describe User do
+          user = User.create
+                 ^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'flags shared example parameters' do
+      expect_offense(<<-RUBY)
+        describe User do
+          it_behaves_like "user", User.create
+                                  ^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'flags inside context' do
+      expect_offense(<<-RUBY)
+        describe User do
+          context "when" do
+            User.create!
+            ^^^^^^^^^^^^ Persistence called outside of example.
+          end
+        end
+      RUBY
+    end
+
+    it 'flags inside shared examples' do
+      expect_offense(<<-RUBY)
+        shared_examples "user tests" do
+          User.create!
+          ^^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'flags inside blocks inside describe' do
+      expect_offense(<<-RUBY)
+        describe User do
+          5.times do
+            User.create!
+            ^^^^^^^^^^^^ Persistence called outside of example.
+          end
+        end
+      RUBY
+    end
+  end
+
+  describe 'allowed contexts' do
+    it 'does not flag outside describe' do
+      expect_no_offenses(<<-RUBY)
+        User.create!
+      RUBY
+    end
+
+    it 'does not flag inside method' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          def create_user
+            User.create!
+          end
+        end
+      RUBY
+    end
+
+    it 'does not flag inside spec helper hook' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.configure do |config|
+          config.before(:each) do
+            User.create!
+          end
+        end
+      RUBY
+    end
+
+    it 'does not flag inside example' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          it do
+            User.create!
+          end
+        end
+      RUBY
+    end
+
+    it 'does not flag inside let' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          let(:user) { User.create! }
+
+          it do
+            user
+          end
+        end
+      RUBY
+    end
+
+    it 'does not flag inside hook' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          before do
+            User.create!
+          end
+
+          it do
+            expect(User.count).to eq(1)
+          end
+        end
+      RUBY
+    end
+
+    it 'does not flag inside subject' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          subject do
+            User.create!
+          end
+        end
+      RUBY
+    end
+
+    it 'does not flag inside proc' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          examples = [
+            proc {
+              User.create!
+            }
+          ]
+        end
+      RUBY
+
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          examples = [
+            Proc.new {
+              User.create!
+            }
+          ]
+        end
+      RUBY
+    end
+
+    it 'does not flag inside lambda' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          examples = [
+            lambda {
+              User.create!
+            }
+          ]
+        end
+      RUBY
+
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          examples = [
+            -> {
+              User.create!
+            }
+          ]
+        end
+      RUBY
+    end
+  end
+
+  context 'when configured with ForbiddenMethods', :config do
+    let(:cop_config) do
+      { 'ForbiddenMethods' => ['seed_db'] }
+    end
+
+    it 'flags offenses in config' do
+      expect_offense(<<-RUBY)
+        describe User do
+          User.seed_db
+          ^^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'does not flag default offenses' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          User.create!
+        end
+      RUBY
+    end
+  end
+
+  context 'when configured with AllowedMethods', :config do
+    let(:cop_config) do
+      { 'AllowedMethods' => ['create!'] }
+    end
+
+    it 'flags offenses that are not allowed' do
+      expect_offense(<<-RUBY)
+        describe User do
+          User.create
+          ^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'does not flag AllowedMethods' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          User.create!
+        end
+      RUBY
+    end
+  end
+
+  context 'when configured with AllowedReceivers', :config do
+    let(:cop_config) do
+      { 'AllowedReceivers' => ['Allowed'] }
+    end
+
+    it 'flags offenses that are not allowed' do
+      expect_offense(<<-RUBY)
+        describe User do
+          User.create!
+          ^^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+
+    it 'does not flag calls on AllowedReceivers', :config do
+      expect_no_offenses(<<-RUBY)
+        describe Allowed do
+          Allowed.create!
+        end
+      RUBY
+    end
+  end
+
+  context 'when configured with AllowedBlockNames', :config do
+    let(:cop_config) do
+      { 'AllowedBlockNames' => ['let_once'] }
+    end
+
+    it 'flags offenses if not included in list' do
+      expect_offense(<<-RUBY)
+        describe User do
+          let_many_times do
+            User.create!
+            ^^^^^^^^^^^^ Persistence called outside of example.
+          end
+        end
+      RUBY
+    end
+
+    it 'does not flag offense if included in list' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          let_once do
+            User.create!
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when configured with ForbiddenMethodsWithoutArguments' do
+    let(:cop_config) do
+      { 'ForbiddenMethodsWithoutArguments' => ['delete'] }
+    end
+
+    it 'does not flag offense if arguments passed' do
+      expect_no_offenses(<<-RUBY)
+        describe User do
+          array.delete("element")
+        end
+      RUBY
+    end
+
+    it 'does flag offense if no arguments passed' do
+      expect_offense(<<-RUBY)
+        describe User do
+          User.delete
+          ^^^^^^^^^^^ Persistence called outside of example.
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/rails/persistence_called_outside_example_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/persistence_called_outside_example_spec.rb
@@ -243,27 +243,4 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::PersistenceCalledOutsideExample, :con
       RUBY
     end
   end
-
-  context 'when configured with ForbiddenMethodsWithoutArguments' do
-    let(:cop_config) do
-      { 'ForbiddenMethodsWithoutArguments' => ['delete'] }
-    end
-
-    it 'does not flag offense if arguments passed' do
-      expect_no_offenses(<<-RUBY)
-        describe User do
-          array.delete("element")
-        end
-      RUBY
-    end
-
-    it 'does flag offense if no arguments passed' do
-      expect_offense(<<-RUBY)
-        describe User do
-          User.delete
-          ^^^^^^^^^^^ Persistence called outside of example.
-        end
-      RUBY
-    end
-  end
 end


### PR DESCRIPTION
Prevents persistence calls from being called outside example or hook. https://github.com/rubocop-hq/rubocop-rspec/issues/991

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
* [x] Set `VersionAdded` in `default/config.yml` to the next minor version.
