### PR TITLE
Add named_only style for RSpec/NamedSubject cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])
+
 ## 2.14.0 (2022-10-23)
 
 - Add `require_implicit` style to `RSpec/ImplicitSubject`. ([@r7kamura])
@@ -712,6 +714,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@jtannas]: https://github.com/jtannas
 [@kellysutton]: https://github.com/kellysutton
 [@koic]: https://github.com/koic
+[@kuahyeow]: https://github.com/kuahyeow
 [@lazycoder9]: https://github.com/lazycoder9
 [@leoarnold]: https://github.com/leoarnold
 [@liberatys]: https://github.com/Liberatys

--- a/config/default.yml
+++ b/config/default.yml
@@ -624,8 +624,13 @@ RSpec/MultipleSubjects:
 RSpec/NamedSubject:
   Description: Checks for explicitly referenced test subjects.
   Enabled: true
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - named_only
   IgnoreSharedExamples: true
   VersionAdded: 1.5.3
+  VersionChanged: "<<next>>"
   StyleGuide: https://rspec.rubystyle.guide/#use-subject
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3317,7 +3317,7 @@ end
 | Yes
 | No
 | 1.5.3
-| -
+| <<next>>
 |===
 
 Checks for explicitly referenced test subjects.
@@ -3329,11 +3329,13 @@ name it using `subject(:your_subject_name) { ... }`. Your test subjects
 should be the most important object in your tests so they deserve
 a descriptive name.
 
-This cop can be configured in your configuration using the
-`IgnoreSharedExamples` which will not report offenses for implicit
+This cop can be configured in your configuration using `EnforcedStyle`,
+and `IgnoreSharedExamples` which will not report offenses for implicit
 subjects in shared example groups.
 
 === Examples
+
+==== `EnforcedStyle: always` (default)
 
 [source,ruby]
 ----
@@ -3347,7 +3349,7 @@ RSpec.describe User do
 end
 
 # good
-RSpec.describe Foo do
+RSpec.describe User do
   subject(:user) { described_class.new }
 
   it 'is valid' do
@@ -3356,10 +3358,49 @@ RSpec.describe Foo do
 end
 
 # also good
-RSpec.describe Foo do
+RSpec.describe User do
   subject(:user) { described_class.new }
 
   it { is_expected.to be_valid }
+end
+----
+
+==== `EnforcedStyle: named_only`
+
+[source,ruby]
+----
+# bad
+RSpec.describe User do
+  subject(:user) { described_class.new }
+
+  it 'is valid' do
+    expect(subject.valid?).to be(true)
+  end
+end
+
+# good
+RSpec.describe User do
+  subject(:user) { described_class.new }
+
+  it 'is valid' do
+    expect(user.valid?).to be(true)
+  end
+end
+
+# also good
+RSpec.describe User do
+  subject { described_class.new }
+
+  it { is_expected.to be_valid }
+end
+
+# acceptable
+RSpec.describe User do
+  subject { described_class.new }
+
+  it 'is valid' do
+    expect(subject.valid?).to be(true)
+  end
 end
 ----
 
@@ -3367,6 +3408,10 @@ end
 
 |===
 | Name | Default value | Configurable values
+
+| EnforcedStyle
+| `always`
+| `always`, `named_only`
 
 | IgnoreSharedExamples
 | `true`


### PR DESCRIPTION
This adds `named_only` style for the RSpec/NamedSubject cop. It is intended as a smaller step to first catch explicit subject references where the `subject(:name) { .. }`  is named.

We keep the default style (I have named it `always`). 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `default/config.yml` to the next major version.
