### PR TITLE
Fix a false positive for `RSpec/RepeatedExampleGroupBody` when `pending` or `skip` have argument(s).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 * Allow `RSpec/ContextWording` to accept multi-word prefixes. ([@hosamaly][])
 * Drop support for ruby 2.4. ([@bquorning][])
-
 * Add `CountAsOne` configuration option to `RSpec/ExampleLength`. ([@stephannv][])
+* Fix a false positive for `RSpec/RepeatedExampleGroupBody` when `pending` or `skip` have argument(s). ([@Tietew][])
 
 ## 2.2.0 (2021-02-02)
 
@@ -610,3 +610,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@dvandersluis]: https://github.com/dvandersluis
 [@hosamaly]: https://github.com/hosamaly
 [@stephannv]: https://github.com/stephannv
+[@Tietew]: https://github.com/Tietew

--- a/lib/rubocop/cop/rspec/repeated_example_group_body.rb
+++ b/lib/rubocop/cop/rspec/repeated_example_group_body.rb
@@ -62,7 +62,7 @@ module RuboCop
 
         # @!method skip_or_pending?(node)
         def_node_matcher :skip_or_pending?, <<-PATTERN
-          (block <(send nil? {:skip :pending}) ...>)
+          (block <(send nil? {:skip :pending} ...) ...>)
         PATTERN
 
         def on_begin(node)

--- a/spec/rubocop/cop/rspec/repeated_example_group_body_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_group_body_spec.rb
@@ -224,6 +224,50 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
     RUBY
   end
 
+  it 'skips `skip` and `pending` statements with arguments' do
+    expect_no_offenses(<<-RUBY)
+      describe '#load' do
+        skip 'storage feature needed'
+      end
+
+      describe '#save' do
+        skip 'storage feature needed'
+      end
+
+      describe '#get_foo' do
+        pending 'foo feature is broken'
+      end
+
+      describe '#set_foo' do
+        pending 'foo feature is broken'
+      end
+    RUBY
+  end
+
+  it 'registers offense correctly if `skip` and `pending` have block' do
+    expect_offense(<<-RUBY)
+      describe '#load' do
+      ^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [5]
+        skip { cool_predicate_method }
+      end
+
+      describe '#save' do
+      ^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [1]
+        skip { cool_predicate_method }
+      end
+
+      describe '#get_foo' do
+      ^^^^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [13]
+        pending { cool_predicate_method }
+      end
+
+      describe '#set_foo' do
+      ^^^^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [9]
+        pending { cool_predicate_method }
+      end
+    RUBY
+  end
+
   it 'registers offense correctly if example groups are separated' do
     expect_offense(<<-RUBY)
       describe 'repeated' do


### PR DESCRIPTION
`RSpec/RepeatedExampleGroupBody` does not register offenses when example group body is `skip` or `pending`.

```ruby
describe 'alpha' do
  skip
end

describe 'bravo' do
  skip
end
```

But each of them has a same argument, registers offenses.

```ruby
describe 'alpha' do
^^^^^^^^^^^^^^^^^^^ Repeated describe block body
  skip 'something needed'
end

describe 'bravo' do
^^^^^^^^^^^^^^^^^^^ Repeated describe block body
  skip 'something needed'
end
```

I thinks this is a false positive.
This PR allows this.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
