### PR TITLE
Fixes RSpec/ExpectChange to work with nested class names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Drop Ruby 2.5 support. ([@ydah][])
 * Add new `RSpec/ChangeByZero` cop. ([@ydah][])
+* Improve `RSpec/ExpectChange` to detect namespaced and top-level constants. ([@M-Yamashita01][])
 
 ## 2.10.0 (2022-04-19)
 
@@ -684,3 +685,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@oshiro3]: https://github.com/oshiro3
 [@ydah]: https://github.com/ydah
 [@t3h2mas]: https://github.com/t3h2mas
+[@M-Yamashita01]: https://github.com/M-Yamashita01

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         # @!method expect_change_with_arguments(node)
         def_node_matcher :expect_change_with_arguments, <<-PATTERN
-          (send nil? :change $_ (sym $_))
+          (send nil? :change $_ ({sym str} $_))
         PATTERN
 
         # @!method expect_change_with_block(node)
@@ -47,7 +47,7 @@ module RuboCop
           (block
             (send nil? :change)
             (args)
-            (send ({const send} nil? $_) $_)
+            (send $_ $_)
           )
         PATTERN
 
@@ -67,9 +67,9 @@ module RuboCop
           return unless style == :method_call
 
           expect_change_with_block(node) do |receiver, message|
-            msg = format(MSG_BLOCK, obj: receiver, attr: message)
+            msg = format(MSG_BLOCK, obj: receiver.source, attr: message)
             add_offense(node, message: msg) do |corrector|
-              replacement = "change(#{receiver}, :#{message})"
+              replacement = "change(#{receiver.source}, :#{message})"
               corrector.replace(node, replacement)
             end
           end


### PR DESCRIPTION
fixes #1037

When we use `RSpec/ExpectChange` with `EnforcedStyle: block`,
we expect RuboCop leaves comments to use `change { Token.count }` for all codes below:

1 `expect { subject }.to change(Token, :count).by(1)`
2 `expect { subject }.to change(::Token, :count).by(1)`
3 `expect { subject }.to change(User::Token, :count).by(1)`

However,  RuboCop raises an offence only for the first.

The AST of `expect { subject }.to change(User::Token, :count).by(1)` is like below

```
                (send
                  (block
                    (send nil :expect)
                    (args)
                    (send nil :subject)) :to
                  (send
                    (send nil :change
                      (const
                        (const nil :User) :Token)
                      (sym :count)) :by
                    (int 1))))))))
```

and RSpec::ExpectChange checks it with the Regex below:

```
                      (const
                        (const nil :User) :Token)
```

I fixed the `RSpec::ExpectChange` to match the AST of `change(User::Token, :count)` and added some tests about it. 

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).