### PR TITLE
Cop for consistent usage of parens in FactoryBot calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add new `RSpec/Capybara/NegationMatcher` cop. ([@ydah][])
 * Add `AllowedPatterns` configuration option to `RSpec/NoExpectationExample`.  ([@ydah][])
 * Improve `RSpec/NoExpectationExample` cop to ignore examples skipped or pending via metatada.  ([@pirj][])
+* Add `RSpec/FactoryBot/ConsistentParenthesesStyle` cop. ([@Liberatys][])
 
 ## 2.13.2 (2022-09-23)
 
@@ -704,6 +705,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@koic]: https://github.com/koic
 [@lazycoder9]: https://github.com/lazycoder9
 [@leoarnold]: https://github.com/leoarnold
+[@Liberatys]: https://github.com/Liberatys
 [@lokhi]: https://github.com/lokhi
 [@luke-hill]: https://github.com/luke-hill
 [@M-Yamashita01]: https://github.com/M-Yamashita01

--- a/config/default.yml
+++ b/config/default.yml
@@ -918,6 +918,16 @@ RSpec/FactoryBot/AttributeDefinedStatically:
   VersionChanged: '2.0'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/AttributeDefinedStatically
 
+RSpec/FactoryBot/ConsistentParenthesesStyle:
+  Description: Use a consistent style for parentheses in factory bot calls.
+  Enabled: pending
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - omit_parentheses
+  VersionAdded: "<<next>>"
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/ConsistentParenthesesStyle
+
 RSpec/FactoryBot/CreateList:
   Description: Checks for create_list usage.
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -103,6 +103,7 @@
 === Department xref:cops_rspec_factorybot.adoc[RSpec/FactoryBot]
 
 * xref:cops_rspec_factorybot.adoc#rspecfactorybot/attributedefinedstatically[RSpec/FactoryBot/AttributeDefinedStatically]
+* xref:cops_rspec_factorybot.adoc#rspecfactorybot/consistentparenthesesstyle[RSpec/FactoryBot/ConsistentParenthesesStyle]
 * xref:cops_rspec_factorybot.adoc#rspecfactorybot/createlist[RSpec/FactoryBot/CreateList]
 * xref:cops_rspec_factorybot.adoc#rspecfactorybot/factoryclassname[RSpec/FactoryBot/FactoryClassName]
 * xref:cops_rspec_factorybot.adoc#rspecfactorybot/syntaxmethods[RSpec/FactoryBot/SyntaxMethods]

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -51,6 +51,67 @@ count { 1 }
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/AttributeDefinedStatically
 
+== RSpec/FactoryBot/ConsistentParenthesesStyle
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| Yes
+| <<next>>
+| -
+|===
+
+Use a consistent style for parentheses in factory bot calls.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+create :user
+build(:user)
+create(:login)
+create :login
+----
+
+==== `EnforcedStyle: require_parentheses` (default)
+
+[source,ruby]
+----
+# good
+create(:user)
+create(:user)
+create(:login)
+build(:login)
+----
+
+==== `EnforcedStyle: omit_parentheses`
+
+[source,ruby]
+----
+# good
+create :user
+build :user
+create :login
+create :login
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| EnforcedStyle
+| `require_parentheses`
+| `require_parentheses`, `omit_parentheses`
+|===
+
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/ConsistentParenthesesStyle
+
 == RSpec/FactoryBot/CreateList
 
 |===

--- a/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module FactoryBot
+        # Use a consistent style for parentheses in factory bot calls.
+        #
+        # @example
+        #
+        #   # bad
+        #   create :user
+        #   build(:user)
+        #   create(:login)
+        #   create :login
+        #
+        # @example `EnforcedStyle: require_parentheses` (default)
+        #
+        #   # good
+        #   create(:user)
+        #   create(:user)
+        #   create(:login)
+        #   build(:login)
+        #
+        # @example `EnforcedStyle: omit_parentheses`
+        #
+        #   # good
+        #   create :user
+        #   build :user
+        #   create :login
+        #   create :login
+        #
+        class ConsistentParenthesesStyle < Base
+          extend AutoCorrector
+          include ConfigurableEnforcedStyle
+          include RuboCop::RSpec::FactoryBot::Language
+          include RuboCop::Cop::Util
+
+          def self.autocorrect_incompatible_with
+            [Style::MethodCallWithArgsParentheses]
+          end
+
+          MSG_REQUIRE_PARENS = 'Prefer method call with parentheses'
+          MSG_OMIT_PARENS = 'Prefer method call without parentheses'
+
+          FACTORY_CALLS = RuboCop::RSpec::FactoryBot::Language::METHODS
+
+          # @!method factory_call(node)
+          def_node_matcher :factory_call, <<-PATTERN
+              (send
+                ${#factory_bot? nil?} %FACTORY_CALLS
+              $...)
+          PATTERN
+
+          def on_send(node)
+            return if nested_call?(node) # prevent from nested matching
+
+            factory_call(node) do
+              if node.parenthesized?
+                process_with_parentheses(node)
+              else
+                process_without_parentheses(node)
+              end
+            end
+          end
+
+          def process_with_parentheses(node)
+            return unless style == :omit_parentheses
+
+            add_offense(node.loc.selector,
+                        message: MSG_OMIT_PARENS) do |corrector|
+              remove_parentheses(corrector, node)
+            end
+          end
+
+          def process_without_parentheses(node)
+            return unless style == :require_parentheses
+
+            add_offense(node.loc.selector,
+                        message: MSG_REQUIRE_PARENS) do |corrector|
+              add_parentheses(node, corrector)
+            end
+          end
+
+          def nested_call?(node)
+            node.parent&.send_type?
+          end
+
+          private
+
+          def remove_parentheses(corrector, node)
+            corrector.replace(node.location.begin, ' ')
+            corrector.remove(node.location.end)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec/factory_bot/syntax_methods.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/syntax_methods.rb
@@ -54,25 +54,7 @@ module RuboCop
 
           MSG = 'Use `%<method>s` from `FactoryBot::Syntax::Methods`.'
 
-          RESTRICT_ON_SEND = %i[
-            attributes_for
-            attributes_for_list
-            attributes_for_pair
-            build
-            build_list
-            build_pair
-            build_stubbed
-            build_stubbed_list
-            build_stubbed_pair
-            create
-            create_list
-            create_pair
-            generate
-            generate_list
-            null
-            null_list
-            null_pair
-          ].to_set.freeze
+          RESTRICT_ON_SEND = RuboCop::RSpec::FactoryBot::Language::METHODS
 
           def on_send(node)
             return unless factory_bot?(node.receiver)

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -8,6 +8,7 @@ require_relative 'rspec/capybara/specific_matcher'
 require_relative 'rspec/capybara/visibility_matcher'
 
 require_relative 'rspec/factory_bot/attribute_defined_statically'
+require_relative 'rspec/factory_bot/consistent_parentheses_style'
 require_relative 'rspec/factory_bot/create_list'
 require_relative 'rspec/factory_bot/factory_class_name'
 require_relative 'rspec/factory_bot/syntax_methods'

--- a/lib/rubocop/rspec/factory_bot/language.rb
+++ b/lib/rubocop/rspec/factory_bot/language.rb
@@ -7,6 +7,26 @@ module RuboCop
       module Language
         extend RuboCop::NodePattern::Macros
 
+        METHODS = %i[
+          attributes_for
+          attributes_for_list
+          attributes_for_pair
+          build
+          build_list
+          build_pair
+          build_stubbed
+          build_stubbed_list
+          build_stubbed_pair
+          create
+          create_list
+          create_pair
+          generate
+          generate_list
+          null
+          null_list
+          null_pair
+        ].to_set.freeze
+
         # @!method factory_bot?(node)
         def_node_matcher :factory_bot?, <<~PATTERN
           (const {nil? cbase} {:FactoryGirl :FactoryBot})

--- a/spec/rubocop/cop/rspec/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/consistent_parentheses_style_spec.rb
@@ -1,0 +1,279 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::FactoryBot::ConsistentParenthesesStyle do
+  let(:cop_config) do
+    { 'EnforcedStyle' => enforced_style }
+  end
+
+  context 'when EnforcedStyle is :enforce_parentheses' do
+    let(:enforced_style) { :require_parentheses }
+
+    context 'with create' do
+      it 'flags the call to use parentheses' do
+        expect_offense(<<~RUBY)
+          create :user
+          ^^^^^^ Prefer method call with parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create(:user)
+        RUBY
+      end
+    end
+
+    context 'with multiline method calls' do
+      it 'expects parentheses around multiline call' do
+        expect_offense(<<~RUBY)
+          create :user,
+          ^^^^^^ Prefer method call with parentheses
+            username: "PETER",
+            peter: "USERNAME"
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create(:user,
+            username: "PETER",
+            peter: "USERNAME")
+        RUBY
+      end
+    end
+
+    context 'with build' do
+      it 'flags the call to use parentheses' do
+        expect_offense(<<~RUBY)
+          build :user
+          ^^^^^ Prefer method call with parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          build(:user)
+        RUBY
+      end
+    end
+
+    context 'with mixed tests' do
+      it 'flags the call to use parentheses' do
+        expect_offense(<<~RUBY)
+          build_list :user, 10
+          ^^^^^^^^^^ Prefer method call with parentheses
+          build_list "user", 10
+          ^^^^^^^^^^ Prefer method call with parentheses
+          create_list :user, 10
+          ^^^^^^^^^^^ Prefer method call with parentheses
+          build_stubbed :user
+          ^^^^^^^^^^^^^ Prefer method call with parentheses
+          build_stubbed_list :user, 10
+          ^^^^^^^^^^^^^^^^^^ Prefer method call with parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          build_list(:user, 10)
+          build_list("user", 10)
+          create_list(:user, 10)
+          build_stubbed(:user)
+          build_stubbed_list(:user, 10)
+        RUBY
+      end
+    end
+
+    context 'with nested calling' do
+      it 'flags the call to use parentheses' do
+        expect_offense(<<~RUBY)
+          build :user, build(:yester)
+          ^^^^^ Prefer method call with parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          build(:user, build(:yester))
+        RUBY
+      end
+
+      it 'works in a bigger context' do
+        expect_offense(<<~RUBY)
+          context 'with context' do
+            let(:build) { create :user, build(:user) }
+                          ^^^^^^ Prefer method call with parentheses
+
+            it 'test in test' do
+              user = create :user, first: name, peter: miller
+                     ^^^^^^ Prefer method call with parentheses
+            end
+
+            let(:build) { create :user, build(:user, create(:user, create(:first_name))) }
+                          ^^^^^^ Prefer method call with parentheses
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          context 'with context' do
+            let(:build) { create(:user, build(:user)) }
+
+            it 'test in test' do
+              user = create(:user, first: name, peter: miller)
+            end
+
+            let(:build) { create(:user, build(:user, create(:user, create(:first_name)))) }
+          end
+        RUBY
+      end
+    end
+
+    context 'with already valid usage of parentheses' do
+      it 'does not flag as invalid - create' do
+        expect_no_offenses(<<~RUBY)
+          create(:user)
+        RUBY
+      end
+
+      it 'does not flag as invalid - build' do
+        expect_no_offenses(<<~RUBY)
+          build(:user)
+        RUBY
+      end
+    end
+  end
+
+  context 'when EnforcedStyle is :omit_parentheses' do
+    let(:enforced_style) { :omit_parentheses }
+
+    context 'with create' do
+      it 'flags the call to not use parentheses' do
+        expect_offense(<<~RUBY)
+          create(:user)
+          ^^^^^^ Prefer method call without parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create :user
+        RUBY
+      end
+    end
+
+    context 'with nest call' do
+      it 'inner call is ignored and not fixed' do
+        expect_no_offenses(<<~RUBY)
+          puts(1, create(:user))
+        RUBY
+      end
+    end
+
+    context 'with multiline method calls' do
+      it 'removes parentheses around multiline call' do
+        expect_offense(<<~RUBY)
+          create(:user,
+          ^^^^^^ Prefer method call without parentheses
+            username: "PETER",
+            peter: "USERNAME")
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create :user,
+            username: "PETER",
+            peter: "USERNAME"
+        RUBY
+      end
+    end
+
+    context 'with mixed tests' do
+      it 'flags the call not to use parentheses' do
+        expect_offense(<<~RUBY)
+          build_list(:user, 10)
+          ^^^^^^^^^^ Prefer method call without parentheses
+          build_list("user", 10)
+          ^^^^^^^^^^ Prefer method call without parentheses
+          create_list(:user, 10)
+          ^^^^^^^^^^^ Prefer method call without parentheses
+          build_stubbed(:user)
+          ^^^^^^^^^^^^^ Prefer method call without parentheses
+          build_stubbed_list(:user, 10)
+          ^^^^^^^^^^^^^^^^^^ Prefer method call without parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          build_list :user, 10
+          build_list "user", 10
+          create_list :user, 10
+          build_stubbed :user
+          build_stubbed_list :user, 10
+        RUBY
+      end
+    end
+
+    context 'with build' do
+      it 'flags the call to not use parentheses' do
+        expect_offense(<<~RUBY)
+          build(:user)
+          ^^^^^ Prefer method call without parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          build :user
+        RUBY
+      end
+    end
+
+    context 'with nested calling' do
+      it 'flags the call to use parentheses' do
+        expect_offense(<<~RUBY)
+          build(:user, build(:yester))
+          ^^^^^ Prefer method call without parentheses
+        RUBY
+
+        expect_correction(<<~RUBY)
+          build :user, build(:yester)
+        RUBY
+      end
+    end
+
+    context 'with nested calling that does not require fixing' do
+      it 'does not flag the nested call' do
+        expect_no_offenses(<<~RUBY)
+          build :user, build(:yester)
+        RUBY
+      end
+    end
+
+    context 'with already valid usage of parentheses' do
+      it 'does not flag as invalid - create' do
+        expect_no_offenses(<<~RUBY)
+          create :user
+        RUBY
+      end
+
+      it 'does not flag as invalid - build' do
+        expect_no_offenses(<<~RUBY)
+          build :user
+        RUBY
+      end
+    end
+
+    it 'works in a bigger context' do
+      expect_offense(<<~RUBY)
+        RSpec.describe Context do
+          let(:build) { create(:user, build(:user)) }
+                        ^^^^^^ Prefer method call without parentheses
+
+          it 'test in test' do
+            user = create(:user, first: name, peter: miller)
+                   ^^^^^^ Prefer method call without parentheses
+          end
+
+          let(:build) { create(:user, build(:user, create(:user, create(:first_name)))) }
+                        ^^^^^^ Prefer method call without parentheses
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Context do
+          let(:build) { create :user, build(:user) }
+
+          it 'test in test' do
+            user = create :user, first: name, peter: miller
+          end
+
+          let(:build) { create :user, build(:user, create(:user, create(:first_name))) }
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Implement a new cop that enables the enforcement of parentheses in factory bot calls.

This cop attempts to solve the "issue" outlined in #416
edit: fixes #416

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
* [x] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
