### PR TITLE
Ignore CreateList offense on method call detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix incorrect path suggested by `RSpec/FilePath` cop when second argument contains spaces. ([@tejasbubane][])
 * Fix autocorrect for EmptyLineSeparation. ([@johnny-miyake][])
 * Add new `RSpec/Capybara/SpecificMatcher` cop. ([@ydah][])
+* Fixed false offense detection in `FactoryBot/CreateList` when a n.times block is including method calls in the factory create arguments. ([@ngouy][])
 
 ## 2.11.1 (2022-05-18)
 
@@ -699,3 +700,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@M-Yamashita01]: https://github.com/M-Yamashita01
 [@luke-hill]: https://github.com/luke-hill
 [@johnny-miyake]: https://github.com/johnny-miyake
+[@ngouy]: https://github.com/ngouy

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -79,8 +79,14 @@ This cop can be configured using the `EnforcedStyle` option
 # good
 create_list :user, 3
 
-# good
-3.times { |n| create :user, created_at: n.months.ago }
+# bad
+3.times { create :user, age: 18 }
+
+# good - index is used to alter the created models attributes
+3.times { |n| create :user, age: n }
+
+# good - contains a method call, may return different values
+3.times { create :user, age: rand }
 ----
 
 ==== `EnforcedStyle: n_times`

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -53,9 +53,26 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList do
       RUBY
     end
 
-    it 'ignores n.times with argument' do
+    it 'ignores n.times with n as argument' do
       expect_no_offenses(<<~RUBY)
-        3.times { |n| create :user, created_at: n.days.ago }
+        3.times { |n| create :user, position: n }
+      RUBY
+    end
+
+    it 'flags n.times when create call doesn\'t have method calls' do
+      expect_offense(<<~RUBY)
+        3.times { |n| create :user, :active }
+        ^^^^^^^ Prefer create_list.
+        3.times { |n| create :user, password: '123' }
+        ^^^^^^^ Prefer create_list.
+        3.times { |n| create :user, :active, password: '123' }
+        ^^^^^^^ Prefer create_list.
+      RUBY
+    end
+
+    it 'ignores n.times when create call does have method calls' do
+      expect_no_offenses(<<~RUBY)
+        3.times { |n| create :user, repositories_count: rand }
       RUBY
     end
 


### PR DESCRIPTION
As soon as a method call happens in a `n.times { create(:my_factory, ...}` block, nothing ensures that the method will return the same n times, so `create_list` and `create` will not nessecarly have the same output (ae `create(:something, position: rand)`)

fixes #1087 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
