### PR TITLE
Move non-literal attributes to a block

### DIFF
--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -155,53 +155,80 @@ module RuboCop
 
             def call_with_block_replacement(node)
               block = node.body
-              arguments = build_arguments(block, node.receiver.source)
+
+              factory, *options = *block.send_node.arguments
+
               replacement = format_receiver(block.send_node.receiver)
-              replacement += format_method_call(block, 'create_list', arguments)
-              replacement += format_block(block)
+
+              process_arguments(options) do |traits, static, dynamic|
+                arguments = "#{factory.source}, #{node.receiver.source}"
+                arguments += ", #{build_options_string(traits)}" if traits.any?
+                arguments += ", #{build_options_string(static)}" if static.any?
+
+                replacement += format_method_call(block, 'create_list', arguments)
+                replacement += format_block(block, dynamic)
+              end
+
               replacement
-            end
-
-            def build_arguments(node, count)
-              factory, *options = *node.send_node.arguments
-
-              arguments = ":#{factory.value}, #{count}"
-              options = build_options_string(options)
-              arguments += ", #{options}" unless options.empty?
-              arguments
             end
 
             def call_replacement(node)
               block = node.body
               factory, *options = *block.arguments
 
-              arguments = "#{factory.source}, #{node.receiver.source}"
-              options = build_options_string(options)
-              arguments += ", #{options}" unless options.empty?
-
               replacement = format_receiver(block.receiver)
-              replacement += format_method_call(block, 'create_list', arguments)
+
+              process_arguments(options) do |traits, static, dynamic|
+                arguments = "#{factory.source}, #{node.receiver.source}"
+                arguments += ", #{build_options_string(traits)}" if traits.any?
+                arguments += ", #{build_options_string(static)}" if static.any?
+                replacement += format_method_call(block, 'create_list', arguments)
+                replacement += create_block(factory.value, dynamic) if dynamic.any?
+              end
+
               replacement
             end
 
-            def format_block(node)
-              if node.body.begin_type?
-                format_multiline_block(node)
+            def create_block(factory, arguments)
+              block = " do |#{factory}|\n"
+              arguments.each do |pair|
+                block += "#{factory}.#{pair.key.source} = #{pair.value.source}\n"
+              end
+              block += "end"
+            end
+
+
+            def format_block(node, dynamic)
+              if node.body.begin_type? || dynamic.any?
+                format_multiline_block(node, dynamic)
               else
                 format_singeline_block(node)
               end
             end
 
-            def format_multiline_block(node)
+            def format_multiline_block(node, dynamic)
               indent = ' ' * node.body.loc.column
               indent_end = ' ' * node.parent.loc.column
-              " do #{node.arguments.source}\n" \
-              "#{indent}#{node.body.source}\n" \
-              "#{indent_end}end"
+              factory = node.arguments.first.source
+
+              block = " do |#{factory}|\n"
+              dynamic.each do |pair|
+                block += "#{indent}#{factory}.#{pair.key.source} = #{pair.value.source}\n"
+              end
+              block += "#{indent}#{node.body.source}\n"
+              block += "#{indent_end}end"
             end
 
             def format_singeline_block(node)
               " { #{node.arguments.source} #{node.body.source} }"
+            end
+
+            def process_arguments(options)
+              traits = options.reject(&:hash_type?)
+              properties = options.select(&:hash_type?).flat_map(&:pairs)
+              static, dynamic = properties.partition { |pair| pair.value.literal? }
+
+              yield traits, static, dynamic
             end
           end
         end


### PR DESCRIPTION
Solves #1087 by moving all dynamic attributes out of the `create` call and into a block

This is the first step: tests passing after @pirj confirms that this is a direction we want to go, I'll refactor and open the PR for review

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
