### PR TITLE
Allow `RSpec/ContextWording` to accept multi-word prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Allow `RSpec/ContextWording` to accept multi-word prefixes. ([@hosamaly][])
+
 ## 2.2.0 (2021-02-02)
 
 * Fix `HooksBeforeExamples`, `LeadingSubject`, `LetBeforeExamples` and `ScatteredLet` autocorrection to take into account inline comments and comments immediately before the moved node. ([@Darhazer][])
@@ -603,3 +605,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@sl4vr]: https://github.com/sl4vr
 [@ahukkanen]: https://github.com/ahukkanen
 [@dvandersluis]: https://github.com/dvandersluis
+[@hosamaly]: https://github.com/hosamaly

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -344,6 +344,7 @@ Checks that `context` docstring starts with an allowed prefix.
 The default list of prefixes is minimal. Users are encouraged to tailor
 the configuration to meet project needs. Other acceptable prefixes may
 include `if`, `unless`, `for`, `before`, `after`, or `during`.
+They may consist of multiple words if desired.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -8,6 +8,7 @@ module RuboCop
       # The default list of prefixes is minimal. Users are encouraged to tailor
       # the configuration to meet project needs. Other acceptable prefixes may
       # include `if`, `unless`, `for`, `before`, `after`, or `during`.
+      # They may consist of multiple words if desired.
       #
       # @see https://rspec.rubystyle.guide/#context-descriptions
       # @see http://www.betterspecs.org/#contexts
@@ -52,7 +53,7 @@ module RuboCop
         private
 
         def bad_prefix?(description)
-          !prefixes.include?(description.split(/\b/).first)
+          !prefix_regex.match?(description)
         end
 
         def joined_prefixes
@@ -65,6 +66,10 @@ module RuboCop
 
         def prefixes
           cop_config['Prefixes'] || []
+        end
+
+        def prefix_regex
+          /^#{Regexp.union(prefixes)}\b/
         end
       end
     end

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -95,5 +95,35 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
         end
       RUBY
     end
+
+    context 'with a multi-word prefix' do
+      let(:cop_config) { { 'Prefixes' => ['assuming that'] } }
+
+      it 'skips descriptions with allowed multi-word prefixes' do
+        expect_no_offenses(<<-RUBY)
+          context 'assuming that display name is present' do
+          end
+        RUBY
+      end
+    end
+
+    context 'with special regex characters' do
+      let(:cop_config) { { 'Prefixes' => ['a$b\d'] } }
+
+      it 'matches the full prefix' do
+        expect_offense(<<-RUBY)
+          context 'a' do
+                  ^^^ Start context description with 'a$b\\d'.
+          end
+        RUBY
+      end
+
+      it 'matches special characters' do
+        expect_no_offenses(<<-RUBY)
+          context 'a$b\\d something' do
+          end
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow the `ContextWording` cop to accept multi-word prefixes.

The new logic uses a regular expression. To preserve existing behaviour, configured prefixes are escaped.

---

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes. (Waiting for CI)