### PR TITLE
Add  `CountAsOne` config option to `RSpec/ExampleLength`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Allow `RSpec/ContextWording` to accept multi-word prefixes. ([@hosamaly][])
 * Drop support for ruby 2.4. ([@bquorning][])
 
+* Add `CountAsOne` configuration option to `RSpec/ExampleLength`. ([@stephannv][])
+
 ## 2.2.0 (2021-02-02)
 
 * Fix `HooksBeforeExamples`, `LeadingSubject`, `LetBeforeExamples` and `ScatteredLet` autocorrection to take into account inline comments and comments immediately before the moved node. ([@Darhazer][])
@@ -607,3 +609,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@ahukkanen]: https://github.com/ahukkanen
 [@dvandersluis]: https://github.com/dvandersluis
 [@hosamaly]: https://github.com/hosamaly
+[@stephannv]: https://github.com/stephannv

--- a/config/default.yml
+++ b/config/default.yml
@@ -253,7 +253,9 @@ RSpec/ExampleLength:
   Description: Checks for long examples.
   Enabled: true
   Max: 5
+  CountAsOne: []
   VersionAdded: '1.5'
+  VersionChanged: '2.3'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength
 
 RSpec/ExampleWithoutDescription:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1051,7 +1051,7 @@ let(:foo) { bar }
 | Yes
 | No
 | 1.5
-| -
+| 2.3
 |===
 
 Checks for long examples.
@@ -1059,6 +1059,10 @@ Checks for long examples.
 A long example is usually more difficult to understand. Consider
 extracting out some behaviour, e.g. with a `let` block, or a helper
 method.
+
+You can set literals you want to fold with `CountAsOne`.
+Available are: 'array', 'hash', and 'heredoc'. Each literal
+will be counted as one line regardless of its actual size.
 
 === Examples
 
@@ -1081,6 +1085,27 @@ it do
 end
 ----
 
+==== CountAsOne: ['array', 'heredoc']
+
+[source,ruby]
+----
+it do
+  array = [         # +1
+    1,
+    2
+  ]
+
+  hash = {          # +3
+    key: 'value'
+  }
+
+  msg = <<~HEREDOC  # +1
+    Heredoc
+    content.
+  HEREDOC
+end                 # 5 points
+----
+
 === Configurable attributes
 
 |===
@@ -1089,6 +1114,10 @@ end
 | Max
 | `5`
 | Integer
+
+| CountAsOne
+| `[]`
+| Array
 |===
 
 === References

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -25,29 +25,43 @@ module RuboCop
       #     result = service.call
       #     expect(result).to be(true)
       #   end
+      #
+      # You can set literals you want to fold with `CountAsOne`.
+      # Available are: 'array', 'hash', and 'heredoc'. Each literal
+      # will be counted as one line regardless of its actual size.
+      #
+      # @example CountAsOne: ['array', 'heredoc']
+      #
+      #   it do
+      #     array = [         # +1
+      #       1,
+      #       2
+      #     ]
+      #
+      #     hash = {          # +3
+      #       key: 'value'
+      #     }
+      #
+      #     msg = <<~HEREDOC  # +1
+      #       Heredoc
+      #       content.
+      #     HEREDOC
+      #   end                 # 5 points
       class ExampleLength < Base
         include CodeLength
 
-        MSG = 'Example has too many lines [%<total>d/%<max>d].'
+        LABEL = 'Example'
 
         def on_block(node)
           return unless example?(node)
 
-          length = code_length(node)
-
-          return unless length > max_length
-
-          add_offense(node, message: message(length))
+          check_code_length(node)
         end
 
         private
 
-        def code_length(node)
-          node.source.lines[1..-2].count { |line| !irrelevant_line(line) }
-        end
-
-        def message(length)
-          format(MSG, total: length, max: max_length)
+        def cop_label
+          LABEL
         end
       end
     end

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
     it 'flags the example' do
       expect_offense(<<-RUBY)
         it do
-        ^^^^^ Example has too many lines [4/3].
+        ^^^^^ Example has too many lines. [4/3]
           line 1
           line 2
           line 3
@@ -64,11 +64,33 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
     it 'flags the example' do
       expect_offense(<<-RUBY)
         it do
-        ^^^^^ Example has too many lines [4/3].
+        ^^^^^ Example has too many lines. [4/3]
           line 1
           line 2
           # comment
           line 3
+        end
+      RUBY
+    end
+  end
+
+  context 'when `CountAsOne` is not empty' do
+    before { cop_config['CountAsOne'] = ['array'] }
+
+    it 'folds array into one line' do
+      expect_no_offenses(<<~RUBY)
+        it do
+          a = 1
+          a = [
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9
+          ]
         end
       RUBY
     end


### PR DESCRIPTION
To add `CountAsOne` configuration I had to adapt ExampleLength cop to use `CodeLength` methods like `Metrics/BlockLength`, `Metrics/MethodLength`, `Metrics/ClassLength` already uses. 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
