### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,12 +95,12 @@ workflows:
           requires: [confirm_config_and_documentation]
           matrix:
             parameters:
-              ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
+              ruby: ['2.5', '2.6', '2.7', '3.0']
       - rubocop:
           requires: [confirm_config_and_documentation]
           matrix:
             parameters:
-              ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
+              ruby: ['2.5', '2.6', '2.7', '3.0']
       - edge-rubocop:
           requires: [confirm_config_and_documentation]
       - jruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ require:
 
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   NewCops: disable
   Exclude:
     - 'vendor/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Allow `RSpec/ContextWording` to accept multi-word prefixes. ([@hosamaly][])
+* Drop support for ruby 2.4. ([@bquorning][])
 
 ## 2.2.0 (2021-02-02)
 

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.version = RuboCop::RSpec::Version::STRING
   spec.platform = Gem::Platform::RUBY
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
   spec.require_paths = ['lib']
   spec.files = Dir[

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -33,17 +33,15 @@ task documentation_syntax_check: :yard_for_generate_documentation do
     end
 
     examples.to_a.each do |example|
-      begin
-        buffer = Parser::Source::Buffer.new('<code>', 1)
-        buffer.source = example.text
-        parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
-        parser.diagnostics.all_errors_are_fatal = true
-        parser.parse(buffer)
-      rescue Parser::SyntaxError => e
-        path = example.object.file
-        puts "#{path}: Syntax Error in an example. #{e}"
-        ok = false
-      end
+      buffer = Parser::Source::Buffer.new('<code>', 1)
+      buffer.source = example.text
+      parser = Parser::Ruby25.new(RuboCop::AST::Builder.new)
+      parser.diagnostics.all_errors_are_fatal = true
+      parser.parse(buffer)
+    rescue Parser::SyntaxError => e
+      path = example.object.file
+      puts "#{path}: Syntax Error in an example. #{e}"
+      ok = false
     end
   end
   abort unless ok


### PR DESCRIPTION
Ruby 2.4 has been EOL’ed for a while, and RuboCop recently merged in a PR to drop Ruby 2.4 support. I don’t think it makes sense for RuboCop-RSpec to support Ruby 2.4 now.

See rubocop/rubocop#9648 (and last year’s #901)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
