### PR TITLE
Update CircleCI badge for new repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/rubocop-rspec/Lobby](https://badges.gitter.im/rubocop-rspec/Lobby.svg)](https://gitter.im/rubocop-rspec/Lobby)
 [![Gem Version](https://badge.fury.io/rb/rubocop-rspec.svg)](https://rubygems.org/gems/rubocop-rspec)
-[![CircleCI](https://circleci.com/gh/rubocop-hq/rubocop-rspec.svg?style=svg)](https://circleci.com/gh/rubocop-hq/rubocop-rspec)
+[![CircleCI](https://circleci.com/gh/rubocop/rubocop-rspec.svg?style=svg)](https://circleci.com/gh/rubocop/rubocop-rspec)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/8ffaabf633c968c22bdd/test_coverage)](https://codeclimate.com/github/rubocop-hq/rubocop-rspec/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/8ffaabf633c968c22bdd/maintainability)](https://codeclimate.com/github/rubocop-hq/rubocop-rspec/maintainability)
 


### PR DESCRIPTION
Badge and link are now dead as the GitHub repo URL has been changed from rubocop-hq to rubocop. CircleCI does not look like supporting redirecting from the old one to the current one.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [n/a] Added tests.
* [x] Updated documentation.
* [n/a] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [n/a] Added the new cop to `config/default.yml`.
* [n/a] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [n/a] The cop documents examples of good and bad code.
* [n/a] The tests assert both that bad code is reported and that good code is not reported.
* [n/a] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [n/a] Set `VersionChanged` in `config/default.yml` to the next major version.
