### PR TITLE
Update GitHub repo URLs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-If you encounter problems or have ideas for improvements or new features, please report them to the [issue tracker](https://github.com/rubocop-hq/rubocop-rspec/issues) or submit a pull request. Please, try to follow these guidelines when you do so.
+If you encounter problems or have ideas for improvements or new features, please report them to the [issue tracker](https://github.com/rubocop/rubocop-rspec/issues) or submit a pull request. Please, try to follow these guidelines when you do so.
 
 ## Issue reporting
 
@@ -18,7 +18,7 @@ If you encounter problems or have ideas for improvements or new features, please
 2.  Create a feature branch.
 3.  Make sure to add tests.
 4.  Make sure the test suite passes (run `rake`).
-5.  Add a [changelog](https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md) entry.
+5.  Add a [changelog](https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md) entry.
 6.  Commit your changes.
 7.  Push to the branch.
 8.  Create new Pull Request.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - 'tmp/**/*'
     - 'spec/smoke_tests/**/*.rb'
 
-# See https://github.com/rubocop-hq/rubocop/issues/6410
+# See https://github.com/rubocop/rubocop/issues/6410
 Layout/HashAlignment:
   Enabled: false
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/8ffaabf633c968c22bdd/maintainability)](https://codeclimate.com/github/rubocop-hq/rubocop-rspec/maintainability)
 
 RSpec-specific analysis for your projects, as an extension to
-[RuboCop](https://github.com/rubocop-hq/rubocop).
+[RuboCop](https://github.com/rubocop/rubocop).
 
 ## Installation
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,7 +1,7 @@
 = RuboCop RSpec
 
 RSpec-specific analysis for your projects, as an extension to
-https://github.com/rubocop-hq/rubocop[RuboCop].
+https://github.com/rubocop/rubocop[RuboCop].
 
 RuboCop RSpec follows the https://docs.rubocop.org/rubocop/versioning.html[RuboCop versioning guide].
 In a nutshell, between major versions new cops are introduced in a special `pending` status.

--- a/docs/modules/ROOT/pages/upgrade_to_version_2.adoc
+++ b/docs/modules/ROOT/pages/upgrade_to_version_2.adoc
@@ -66,7 +66,7 @@ RSpec/EmptyExampleGroup:
   Enabled: false
 ----
 
-https://github.com/rubocop-hq/rubocop/pull/8490[Learn more about this change].
+https://github.com/rubocop/rubocop/pull/8490[Learn more about this change].
 
 
 === Use the RuboCop standard `Include` option to filter inspected files
@@ -93,7 +93,7 @@ RSpec/FactoryBot:
 
 NOTE: Please keep in mind that `Include`’s merge mode is set to override the default settings, so if you intend to add a path while keeping the default paths, you should include the default `Include` paths in your configuration.
 
-https://github.com/rubocop-hq/rubocop-rspec/pull/1063[Learn more about this change].
+https://github.com/rubocop/rubocop-rspec/pull/1063[Learn more about this change].
 
 == Custom Cop Update Guide
 
@@ -130,7 +130,7 @@ module RuboCop
       class FightPowerty < Base
 ----
 
-https://github.com/rubocop-hq/rubocop-rspec/pull/962[Example pull request].
+https://github.com/rubocop/rubocop-rspec/pull/962[Example pull request].
 
 
 === Replace `TopLevelDescribe`
@@ -143,7 +143,7 @@ There’s no need yet for `on_top_level_shared_group` for RuboCop core cops, but
 Additionally, `single_top_level_describe?` is removed with no direct replacement.
 You may use `top_level_groups` query method instead, e.g. `top_level_groups.one?`.
 
-Example pull requests to replace `TopLevelDescribe` with `TopLevelGroup` [https://github.com/rubocop-hq/rubocop-rspec/pull/978[1], https://github.com/rubocop-hq/rubocop-rspec/pull/932[2], https://github.com/rubocop-hq/rubocop-rspec/pull/977[3]].
+Example pull requests to replace `TopLevelDescribe` with `TopLevelGroup` [https://github.com/rubocop/rubocop-rspec/pull/978[1], https://github.com/rubocop/rubocop-rspec/pull/932[2], https://github.com/rubocop/rubocop-rspec/pull/977[3]].
 
 
 === Change the `Language` Module Usages
@@ -216,7 +216,7 @@ Examples::EXAMPLES
 Examples.regular
 ----
 
-https://github.com/rubocop-hq/rubocop-rspec/pull/956[Pull request with more examples].
+https://github.com/rubocop/rubocop-rspec/pull/956[Pull request with more examples].
 
 === Always call `super` from `on_new_investigation` in your cops
 
@@ -240,7 +240,7 @@ module RuboCop
 end
 ----
 
-https://github.com/rubocop-hq/rubocop-rspec/pull/956[Pull request with more examples].
+https://github.com/rubocop/rubocop-rspec/pull/956[Pull request with more examples].
 
 === Use `:config` RSpec metadata in cop specs
 
@@ -264,7 +264,7 @@ RSpec.describe 'MyMightyCop', :config do
 end
 ----
 
-https://github.com/rubocop-hq/rubocop/blob/51ff1d7e29c985732fe129082c98d66c531a2611/lib/rubocop/rspec/shared_contexts.rb#L56[RuboCop takes care of defining everything for your cop specs].
+https://github.com/rubocop/rubocop/blob/51ff1d7e29c985732fe129082c98d66c531a2611/lib/rubocop/rspec/shared_contexts.rb#L56[RuboCop takes care of defining everything for your cop specs].
 
 === Conform with RuboCop API Changes
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -72,7 +72,7 @@ RSpec:
 
 NOTE: the default merge mode is to inherit, so you won't remove any of the default settings.
 
-RuboCop RSpec's https://github.com/rubocop-hq/rubocop-rspec/blob/a43424527c09fae2e6ddb133f4b2988f6c46bb2e/config/default.yml#L6[default configuration] is a good source of information on what can be configured.
+RuboCop RSpec's https://github.com/rubocop/rubocop-rspec/blob/a43424527c09fae2e6ddb133f4b2988f6c46bb2e/config/default.yml#L6[default configuration] is a good source of information on what can be configured.
 
 == Command line
 

--- a/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
+++ b/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
@@ -18,7 +18,7 @@ module RuboCop
       #     # ...
       #   end
       #
-      # @see https://github.com/rubocop-hq/rubocop-rspec/issues/735
+      # @see https://github.com/rubocop/rubocop-rspec/issues/735
       class DescribedClassModuleWrapping < Base
         MSG = 'Avoid opening modules and defining specs within them.'
 

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
     Code style checking for RSpec files.
     A plugin for the RuboCop code style enforcing & linting tool.
   DESCRIPTION
-  spec.homepage = 'https://github.com/rubocop-hq/rubocop-rspec'
+  spec.homepage = 'https://github.com/rubocop/rubocop-rspec'
   spec.authors = ['John Backus', 'Ian MacLeod', 'Nils Gemeinhardt']
   spec.email = [
     'johncbackus@gmail.com',
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
   spec.metadata = {
-    'changelog_uri' => 'https://github.com/rubocop-hq/rubocop-rspec/blob/master/CHANGELOG.md',
+    'changelog_uri' => 'https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md',
     'documentation_uri' => 'https://docs.rubocop.org/rubocop-rspec/'
   }
 


### PR DESCRIPTION
The GitHub repo URL has been changed from rubocop-hq/rubocop-rspec to rubocop/rubocop-rspec and from rubocop-hq/rubocop to rubocop/rubocop.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [n/a] Added tests.
* [x] Updated documentation.
* [n/a] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
