### PR TITLE
Add `EnforcedStyle` config to RSpec/MultipleDescribes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master (Unreleased)
 
-* Add `Splitting` configuration option to `RSpec/MultipleDescribes`. ([@M-Yamashita01][])
+* Add EnforcedStyle configuration to `RSpec/MultipleDescribes`. ([@M-Yamashita01][])
 
 ## 2.3.0 (2021-04-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Add `Splitting` configuration option to `RSpec/MultipleDescribes`. ([@M-Yamashita01][])
+
 ## 2.3.0 (2021-04-28)
 
 * Allow `RSpec/ContextWording` to accept multi-word prefixes. ([@hosamaly][])
@@ -613,3 +615,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@hosamaly]: https://github.com/hosamaly
 [@stephannv]: https://github.com/stephannv
 [@Tietew]: https://github.com/Tietew
+[@M-Yamashita01]: https://github.com/M-Yamashita01

--- a/config/default.yml
+++ b/config/default.yml
@@ -471,7 +471,10 @@ RSpec/MissingExampleGroupArgument:
 RSpec/MultipleDescribes:
   Description: Checks for multiple top-level example groups or nested example groups.
   Enabled: true
-  Splitting: false
+  EnforcedStyle: nesting
+  SupportedStyles:
+    - nesting
+    - splitting
   VersionAdded: '1.0'
   VersionChanged: '2.4'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleDescribes

--- a/config/default.yml
+++ b/config/default.yml
@@ -469,9 +469,11 @@ RSpec/MissingExampleGroupArgument:
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExampleGroupArgument
 
 RSpec/MultipleDescribes:
-  Description: Checks for multiple top-level example groups.
+  Description: Checks for multiple top-level example groups or nested example groups.
   Enabled: true
+  Splitting: false
   VersionAdded: '1.0'
+  VersionChanged: '2.4'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleDescribes
 
 RSpec/MultipleExpectations:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2510,12 +2510,12 @@ Checks for multiple top-level example groups or nested example groups.
 
 This cop can be configured using the `EnforcedStyle` option.
 
-Using the `EnforcedStyle: nesting`, multiple descriptions for the
+Using the `EnforcedStyle: nesting`, multiple example groups for the
 same class or module should either be nested or separated into different
 test files.
 
-Using the `EnforcedStyle: splitting`, nested describe for the same class
-or module must be either nested or split into separate test files.
+Using the `EnforcedStyle: splitting`, nested example group for the
+same class or module should be split into separate test files.
 
 === Examples
 
@@ -2554,28 +2554,6 @@ end
 describe MyClass, '.do_something' do
 end
 describe MyClass, '.do_something_else' do
-end
-
-# allowed
-RSpec.describe MyClass do
-  shared_examples 'behaves' do;end
-
-  describe '#do_something' do
-    subject { my_class_instance.foo }
-  end
-end
-
-# allowed
-RSpec.describe MyClass do
-  RSpec::Matchers.define :be_a_multiple_of do |expected|
-    match do |actual|
-      actual % expected == 0
-    end
-  end
-
-  describe '#do_something' do
-    subject { my_class_instance.foo }
-  end
 end
 ----
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2508,15 +2508,18 @@ end
 
 Checks for multiple top-level example groups or nested example groups.
 
-In the default configuration, multiple descriptions for the same class
-or module should either be nested or separated into different test
-files.
+This cop can be configured using the `EnforcedStyle` option.
 
-This cop can be configured with the option `Splitting` which will
-check that nested describe for the same class or module must be either
-nested or split into separate test files.
+Using the `EnforcedStyle: nesting`, multiple descriptions for the
+same class or module should either be nested or separated into different
+test files.
+
+Using the `EnforcedStyle: splitting`, nested describe for the same class
+or module must be either nested or split into separate test files.
 
 === Examples
+
+==== `EnforcedStyle: nesting`
 
 [source,ruby]
 ----
@@ -2535,14 +2538,10 @@ describe MyClass do
 end
 ----
 
-==== with Splitting configuration
+==== `EnforcedStyle: splitting`
 
 [source,ruby]
 ----
-# rubocop.yml
-# RSpec/InstanceVariable:
-#   AssignmentOnly: false
-
 # bad
 describe MyClass do
   describe '.do_something' do
@@ -2585,9 +2584,9 @@ end
 |===
 | Name | Default value | Configurable values
 
-| Splitting
-| `false`
-| Boolean
+| EnforcedStyle
+| `nesting`
+| `nesting`, `splitting`
 |===
 
 === References

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2503,13 +2503,18 @@ end
 | Yes
 | No
 | 1.0
-| -
+| 2.4
 |===
 
-Checks for multiple top-level example groups.
+Checks for multiple top-level example groups or nested example groups.
 
-Multiple descriptions for the same class or module should either
-be nested or separated into different test files.
+In the default configuration, multiple descriptions for the same class
+or module should either be nested or separated into different test
+files.
+
+This cop can be configured with the option `Splitting` which will
+check that nested describe for the same class or module must be either
+nested or split into separate test files.
 
 === Examples
 
@@ -2529,6 +2534,61 @@ describe MyClass do
   end
 end
 ----
+
+==== with Splitting configuration
+
+[source,ruby]
+----
+# rubocop.yml
+# RSpec/InstanceVariable:
+#   AssignmentOnly: false
+
+# bad
+describe MyClass do
+  describe '.do_something' do
+  end
+  describe '.do_something_else' do
+  end
+end
+
+# good
+describe MyClass, '.do_something' do
+end
+describe MyClass, '.do_something_else' do
+end
+
+# allowed
+RSpec.describe MyClass do
+  shared_examples 'behaves' do;end
+
+  describe '#do_something' do
+    subject { my_class_instance.foo }
+  end
+end
+
+# allowed
+RSpec.describe MyClass do
+  RSpec::Matchers.define :be_a_multiple_of do |expected|
+    match do |actual|
+      actual % expected == 0
+    end
+  end
+
+  describe '#do_something' do
+    subject { my_class_instance.foo }
+  end
+end
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| Splitting
+| `false`
+| Boolean
+|===
 
 === References
 

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -3,10 +3,15 @@
 module RuboCop
   module Cop
     module RSpec
-      # Checks for multiple top-level example groups.
+      # Checks for multiple top-level example groups or nested example groups.
       #
-      # Multiple descriptions for the same class or module should either
-      # be nested or separated into different test files.
+      # In the default configuration, multiple descriptions for the same class
+      # or module should either be nested or separated into different test
+      # files.
+      #
+      # This cop can be configured with the option `Splitting` which will
+      # check that nested describe for the same class or module must be either
+      # nested or split into separate test files.
       #
       # @example
       #   # bad
@@ -22,12 +27,74 @@ module RuboCop
       #     describe '.do_something_else' do
       #     end
       #   end
+      #
+      # @example with Splitting configuration
+      #
+      #   # rubocop.yml
+      #   # RSpec/InstanceVariable:
+      #   #   AssignmentOnly: false
+      #
+      #   # bad
+      #   describe MyClass do
+      #     describe '.do_something' do
+      #     end
+      #     describe '.do_something_else' do
+      #     end
+      #   end
+      #
+      #   # good
+      #   describe MyClass, '.do_something' do
+      #   end
+      #   describe MyClass, '.do_something_else' do
+      #   end
+      #
+      #   # allowed
+      #   RSpec.describe MyClass do
+      #     shared_examples 'behaves' do;end
+      #
+      #     describe '#do_something' do
+      #       subject { my_class_instance.foo }
+      #     end
+      #   end
+      #
+      #   # allowed
+      #   RSpec.describe MyClass do
+      #     RSpec::Matchers.define :be_a_multiple_of do |expected|
+      #       match do |actual|
+      #         actual % expected == 0
+      #       end
+      #     end
+      #
+      #     describe '#do_something' do
+      #       subject { my_class_instance.foo }
+      #     end
+      #   end
+      #
       class MultipleDescribes < Base
         include TopLevelGroup
 
         MSG = 'Do not use multiple top-level example groups - try to nest them.'
+        MSG_SPLIT = 'Do not use nested describe - try to split them.'
+
+        # @!method describe?(node)
+        def_node_matcher :describe?, <<~PATTERN
+          (send nil? :describe _ ...)
+        PATTERN
+
+        # @!method custom_matcher?(node)
+        def_node_matcher :custom_matcher?, <<-PATTERN
+          (block {
+            (send nil? :matcher sym)
+            (send (const (const nil? :RSpec) :Matchers) :define sym)
+          } ...)
+        PATTERN
+
+        # @!method shared_example?(node)
+        def_node_matcher :shared_example?, block_pattern('#SharedGroups.all')
 
         def on_top_level_group(node)
+          return if splitting?
+
           top_level_example_groups =
             top_level_groups.select(&method(:example_group?))
 
@@ -35,6 +102,63 @@ module RuboCop
           return unless top_level_example_groups.first.equal?(node)
 
           add_offense(node.send_node)
+        end
+
+        def on_send(node)
+          return unless splitting?
+
+          return unless describe?(node)
+
+          return if includes_common_codes?(node)
+
+          block_node = node.parent
+          return if root_node?(block_node)
+          return if includes_describe_in_previous_node?(block_node)
+
+          add_offense(node, message: MSG_SPLIT)
+        end
+
+        private
+
+        def splitting?
+          cop_config['Splitting']
+        end
+
+        def includes_describe_in_previous_node?(block_node)
+          previous_block_node = previous_sibling(block_node)
+          return false if previous_block_node.nil?
+
+          if previous_block_node.child_nodes.any? { |child| describe?(child) }
+            return true
+          end
+
+          includes_describe_in_previous_node?(previous_block_node)
+        end
+
+        def includes_common_codes?(node)
+          root = root_node_for_current_node(node)
+
+          root.each_descendant(:block).any? do |child|
+            shared_example?(child) || custom_matcher?(child)
+          end
+        end
+
+        def previous_sibling(block_node)
+          return nil if (block_node.sibling_index - 1).negative?
+
+          block_node.parent.child_nodes[block_node.sibling_index - 1]
+        end
+
+        def root_node_for_current_node(node)
+          node.ancestors.find { |parent| root_node?(parent) }
+        end
+
+        def root_node?(node)
+          node.parent.nil? || root_with_siblings?(node.parent)
+        end
+
+        def root_with_siblings?(node)
+          node.begin_type? && node.parent.nil?
         end
       end
     end

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -7,12 +7,12 @@ module RuboCop
       #
       # This cop can be configured using the `EnforcedStyle` option.
       #
-      # Using the `EnforcedStyle: nesting`, multiple descriptions for the
+      # Using the `EnforcedStyle: nesting`, multiple example groups for the
       # same class or module should either be nested or separated into different
       # test files.
       #
-      # Using the `EnforcedStyle: splitting`, nested describe for the same class
-      # or module must be either nested or split into separate test files.
+      # Using the `EnforcedStyle: splitting`, nested example group for the
+      # same class or module should be split into separate test files.
       #
       # @example `EnforcedStyle: nesting`
       #   # bad
@@ -45,28 +45,6 @@ module RuboCop
       #   describe MyClass, '.do_something_else' do
       #   end
       #
-      #   # allowed
-      #   RSpec.describe MyClass do
-      #     shared_examples 'behaves' do;end
-      #
-      #     describe '#do_something' do
-      #       subject { my_class_instance.foo }
-      #     end
-      #   end
-      #
-      #   # allowed
-      #   RSpec.describe MyClass do
-      #     RSpec::Matchers.define :be_a_multiple_of do |expected|
-      #       match do |actual|
-      #         actual % expected == 0
-      #       end
-      #     end
-      #
-      #     describe '#do_something' do
-      #       subject { my_class_instance.foo }
-      #     end
-      #   end
-      #
       class MultipleDescribes < Base
         include TopLevelGroup
         include ConfigurableEnforcedStyle
@@ -81,14 +59,21 @@ module RuboCop
 
         # @!method custom_matcher?(node)
         def_node_matcher :custom_matcher?, <<-PATTERN
-          (block {
+          {
             (send nil? :matcher sym)
             (send (const (const nil? :RSpec) :Matchers) :define sym)
-          } ...)
+          }
         PATTERN
 
-        # @!method shared_example?(node)
-        def_node_matcher :shared_example?, block_pattern('#SharedGroups.all')
+        # @!method negated_matcher?(node)
+        def_node_matcher :negated_matcher?, <<-PATTERN
+          (send (const (const nil? :RSpec) :Matchers) :define_negated_matcher sym sym)
+        PATTERN
+
+        # @!method expectation?(node)
+        def_node_matcher :expectation?, <<~PATTERN
+          (send (send nil? #Expectations.all ...) {:to :not_to} _)
+        PATTERN
 
         def on_top_level_group(node)
           return unless style == :nesting
@@ -104,48 +89,19 @@ module RuboCop
 
         def on_send(node)
           return unless style == :splitting
-
           return unless describe?(node)
-
-          return if includes_common_codes?(node)
 
           block_node = node.parent
           return if root_node?(block_node)
-          return if includes_describe_in_previous_node?(block_node)
+
+          return if use_common_code?(node)
+
+          return if check_all_previous_example_groups?(block_node)
 
           add_offense(node, message: MSG_SPLIT)
         end
 
         private
-
-        def includes_describe_in_previous_node?(block_node)
-          previous_block_node = previous_sibling(block_node)
-          return false if previous_block_node.nil?
-
-          if previous_block_node.child_nodes.any? { |child| describe?(child) }
-            return true
-          end
-
-          includes_describe_in_previous_node?(previous_block_node)
-        end
-
-        def includes_common_codes?(node)
-          root = root_node_for_current_node(node)
-
-          root.each_descendant(:block).any? do |child|
-            shared_example?(child) || custom_matcher?(child)
-          end
-        end
-
-        def previous_sibling(block_node)
-          return nil if (block_node.sibling_index - 1).negative?
-
-          block_node.parent.child_nodes[block_node.sibling_index - 1]
-        end
-
-        def root_node_for_current_node(node)
-          node.ancestors.find { |parent| root_node?(parent) }
-        end
 
         def root_node?(node)
           node.parent.nil? || root_with_siblings?(node.parent)
@@ -153,6 +109,82 @@ module RuboCop
 
         def root_with_siblings?(node)
           node.begin_type? && node.parent.nil?
+        end
+
+        def use_common_code?(node)
+          use_shared_group?(node) || use_custom_matcher?(node) ||
+            example_group_in_shared_group(node)
+        end
+
+        def use_shared_group?(node)
+          shared_group_method_names = shared_group_method_names(node)
+
+          node.parent.each_descendant(:send).any? do |send_node|
+            include?(send_node) &&
+              shared_group_method_names.include?(send_node.first_argument)
+          end
+        end
+
+        def shared_group_method_names(node)
+          node.each_ancestor(:block).map do |block_node|
+            parent = block_node.parent
+            next if parent.nil?
+
+            parent.child_nodes.each_with_object([]) do |child_node, result|
+              if shared_group?(child_node)
+                shared_group = child_node.child_nodes.first
+                result << shared_group.first_argument
+              end
+            end
+          end.flatten
+        end
+
+        def use_custom_matcher?(node)
+          custom_matcher_method_names =
+            matcher_method_names_in_ancestor_nodes(node)
+
+          block_node = node.each_ancestor(:block).first
+          block_node.parent.each_descendant(:send).any? do |send_node|
+            next unless expectation?(send_node)
+
+            send_node.each_descendant(:send).any? do |child_send_node|
+              custom_matcher_method_names.include?(child_send_node.method_name)
+            end
+          end
+        end
+
+        def matcher_method_names_in_ancestor_nodes(node)
+          node.each_ancestor(:block).map do |block_node|
+            parent = block_node.parent
+            next if parent.nil?
+
+            matcher_method_names(parent)
+          end.flatten
+        end
+
+        def matcher_method_names(node)
+          node.child_nodes.each_with_object([]) do |child_node, result|
+            send_node = child_node.each_descendant(:send).first
+            if custom_matcher?(send_node)
+              result << send_node.first_argument.value
+            elsif negated_matcher?(child_node)
+              result << child_node.arguments.map(&:value)
+            end
+          end
+        end
+
+        def example_group_in_shared_group(node)
+          node.each_ancestor(:block).any? do |block_node|
+            shared_group?(block_node)
+          end
+        end
+
+        def check_all_previous_example_groups?(block_node)
+          block_node.parent.child_nodes.any? do |child_node|
+            break if child_node.equal?(block_node)
+
+            child_node.child_nodes.any? { |child| describe?(child) }
+          end
         end
       end
     end

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -50,4 +50,139 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
       end
     RUBY
   end
+
+  context 'with CopConfig `Splitting' do
+    let(:cop_config) { { 'Splitting' => true } }
+
+    it 'check first describe in nested describe' do
+      expect_offense(<<-RUBY)
+        RSpec.describe MyClass do
+          describe '#do_something' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^ Do not use nested describe - try to split them.
+            subject { my_class_instance.foo }
+          end
+        end
+      RUBY
+    end
+
+    it 'check first describe in each nested describe' do
+      expect_offense(<<-RUBY)
+        describe MyClassController, type: :controller do
+          describe 'do_something' do
+          ^^^^^^^^^^^^^^^^^^^^^^^ Do not use nested describe - try to split them.
+            describe 'do_something_in_describe' do; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use nested describe - try to split them.
+          end
+          describe 'do_something_else' do; end
+        end
+      RUBY
+    end
+
+    it 'ignores describe in top level groups' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe MyClass, '#do_something' do
+          subject { my_class_instance.foo }
+        end
+        RSpec.describe MyClass, '#do_something_else' do
+          subject { my_class_instance.bar }
+        end
+      RUBY
+    end
+
+    it 'ignores describe when rspec matcher exists' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe MyClass do
+          RSpec::Matchers.define :be_a_multiple_of do |expected|
+            match do |actual|
+              actual % expected == 0
+            end
+          end
+
+          describe '#do_something' do
+            subject { my_class_instance.foo }
+          end
+
+          describe '#do_something_else' do
+            subject { my_class_instance.bar }
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores describe when shared example group exists' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe MyClass do
+          shared_examples 'behaves' do;end
+
+          describe '#do_something' do
+            subject { my_class_instance.foo }
+          end
+
+          describe '#do_something_else' do
+            subject { my_class_instance.bar }
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores describe when shared example for group exists' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe MyClass do
+          shared_examples_for 'behaves' do;end
+
+          describe '#do_something' do
+            subject { my_class_instance.foo }
+          end
+
+          describe '#do_something_else' do
+            subject { my_class_instance.bar }
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores describe when shared context group exists' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe MyClass do
+          shared_context 'behaves' do;end
+
+          describe '#do_something' do
+            subject { my_class_instance.foo }
+          end
+
+          describe '#do_something_else' do
+            subject { my_class_instance.bar }
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores describe when shared context group includes describe' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe MyClass do
+          RSpec.shared_examples 'behaves' do
+            describe '#do_something_in_behaves' do;end
+            describe '#do_something_else_in_behaves' do;end
+          end
+
+          describe '#do_something' do;end
+          describe '#do_something_else' do;end
+        end
+      RUBY
+    end
+
+    it 'ignores describe when describe includes shared example group' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe MyClass do
+          describe '#foo' do
+            RSpec.shared_examples 'behaves' do
+              describe '#do_something_in_behaves' do;end
+              describe '#do_something_else_in_behaves' do;end
+            end
+          end
+          describe '#do_something' do;end
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
     RUBY
   end
 
-  context 'with CopConfig `Splitting' do
-    let(:cop_config) { { 'Splitting' => true } }
+  context 'when EnforcedStyle is :splitting' do
+    let(:cop_config) { { 'EnforcedStyle' => :splitting } }
 
     it 'check first describe in nested describe' do
       expect_offense(<<-RUBY)


### PR DESCRIPTION
Added EnforcedStyle config to RSpec/MultipleDescribes.

This cop can be configured using the `EnforcedStyle` option.
Using the `EnforcedStyle: nesting`, multiple descriptions for the same class or module should either be nested or separated into different test files.
Using the `EnforcedStyle: splitting`, nested describe for the same class or module must be either nested or split into separate test files.

I got the following comments on the last pull request I made, so I made a new pull request.

> I suggest incorporating your changes to MultipleDescribes cop.
https://github.com/rubocop/rubocop-rspec/pull/1138#issuecomment-818599929

```
# @example `EnforcedStyle: nesting`

# bad
describe MyClass, '.do_something' do
end
describe MyClass, '.do_something_else' do
end

# good
describe MyClass do
  describe '.do_something' do
  end
  describe '.do_something_else' do
  end
end

# @example `EnforcedStyle: splitting`

# bad
describe MyClass do
  describe '.do_something' do
  end
  describe '.do_something_else' do
  end
end

# good
describe MyClass, '.do_something' do
end
describe MyClass, '.do_something_else' do
end

# allowed
RSpec.describe MyClass do
  shared_examples 'behaves' do;end

  describe '#do_something' do
    subject { my_class_instance.foo }
  end
end

# allowed
RSpec.describe MyClass do
  RSpec::Matchers.define :be_a_multiple_of do |expected|
    match do |actual|
      actual % expected == 0
    end
  end

  describe '#do_something' do
    subject { my_class_instance.foo }
  end
end
```

Let me know if anything is unclear, or could be improved. Thank you.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
