### PR TITLE
Fix `InternalAffairs/ExampleDescription` offenses on master

### DIFF
--- a/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
   end
   # rubocop:enable RSpec/ExampleLength
 
-  it 'does not register offense for let with proc argument' do
+  it 'does not register an offense for let with proc argument' do
     expect_no_offenses(<<-RUBY)
       let(:user, &args[:build_user])
     RUBY
   end
 
-  it 'works with empty file' do
+  it 'does not register an offense with empty file' do
     expect_no_offenses('')
   end
 end

--- a/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
   end
   # rubocop:enable RSpec/ExampleLength
 
-  it 'does not register offense for let with proc argument' do
+  it 'does not register an offense for let with proc argument' do
     expect_no_offenses(<<-RUBY)
       let(:user, &args[:build_user])
     RUBY
   end
 
-  it 'works with empty file' do
+  it 'does not register an offense with empty file' do
     expect_no_offenses('')
   end
 end

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
-  it 'checks for empty line after last let' do
+  it 'registers an offense for empty line after last let' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'check for empty line after the last `let!`' do
+  it 'registers an offense for empty line after the last `let!`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'checks for empty line after let with proc argument' do
+  it 'registers an offense for empty line after let with proc argument' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -65,30 +65,32 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'approves empty line after let' do
+  it 'does not register an offense for empty line after let' do
     expect_no_offenses(<<-RUBY)
-    RSpec.describe User do
-      let(:a) { a }
-      let(:b) { b }
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
 
-      it { expect(a).to eq(b) }
-    end
+        it { expect(a).to eq(b) }
+      end
     RUBY
   end
 
-  it 'allows comment followed by an empty line after let' do
+  it 'does not register an offense for comment '\
+     'followed by an empty line after let' do
     expect_no_offenses(<<-RUBY)
-    RSpec.describe User do
-      let(:a) { a }
-      let(:b) { b }
-      # end of setup
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
+        # end of setup
 
-      it { expect(a).to eq(b) }
-    end
+        it { expect(a).to eq(b) }
+      end
     RUBY
   end
 
-  it 'flags missing empty line after the comment that comes after last let' do
+  it 'registers an offense for missing empty line after the comment '\
+     'that comes after last let' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -110,7 +112,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'flags missing empty line after a multiline comment after last let' do
+  it 'registers an offense for missing empty line after a multiline comment '\
+     'after last let' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -134,20 +137,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'ignores empty lines between the lets' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        let(:a) { a }
-
-        subject { described_class }
-
-        let!(:b) { b }
-        ^^^^^^^^^^^^^^ Add an empty line after the last `let!`.
-        it { expect(a).to eq(b) }
-      end
-    RUBY
-
-    expect_correction(<<-RUBY)
+  it 'does not register an offense for empty lines between the lets' do
+    expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
 
@@ -160,7 +151,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'handles let in tests' do
+  it 'does not register an offense for let in tests' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         # This shouldn't really ever happen in a sane codebase but I still
@@ -173,7 +164,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'handles multiline let block' do
+  it 'does not register an offense for multiline let block' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -186,7 +177,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'handles let being the latest node' do
+  it 'does not register an offense for let being the latest node' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -195,7 +186,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'handles HEREDOC for let' do
+  it 'does not register an offense for HEREDOC for let' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:foo) do
@@ -212,7 +203,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'handles silly HEREDOC syntax for let' do
+  it 'does not register an offense for silly HEREDOC syntax for let' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe 'silly heredoc syntax' do
         let(:foo) { <<-BAR }
@@ -227,7 +218,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'handles silly HEREDOC offense' do
+  it 'registers an offense for silly HEREDOC offense' do
     expect_offense(<<-RUBY)
       RSpec.describe 'silly heredoc syntax' do
         let(:foo) { <<-BAR }

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
-  it 'checks for empty line after `before` hook' do
+  it 'registers an offense for empty line after `before` hook' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         before { do_something }
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'checks for empty line after `after` hook' do
+  it 'registers an offense for empty line after `after` hook' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         after { do_something }
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'checks for empty line after `around` hook' do
+  it 'registers an offense for empty line after `around` hook' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         around { |test| test.run }
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'approves empty line after `before` hook' do
+  it 'does not register an offense for empty line after `before` hook' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         before { do_something }
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'approves empty line after `after` hook' do
+  it 'does not register an offense for empty line after `after` hook' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         after { do_something }
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'approves empty line after `around` hook' do
+  it 'does not register an offense for empty line after `around` hook' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         around { |test| test.run }
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'handles multiline `before` block' do
+  it 'does not register an offense for multiline `before` block' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         before do
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'handles multiline `after` block' do
+  it 'does not register an offense for multiline `after` block' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         after do
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'handles multiline `around` block' do
+  it 'does not register an offense for multiline `around` block' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         around do |test|
@@ -121,7 +121,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     RUBY
   end
 
-  it 'handles `before` being the latest node' do
+  it 'does not register an offense for `before` being the latest node' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         before { do_something }

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
-  it 'checks for empty line after subject' do
+  it 'registers an offense for empty line after subject' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     RUBY
   end
 
-  it 'checks for empty line after subject!' do
+  it 'registers an offense for empty line after subject!' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         subject! { described_class.new }
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     RUBY
   end
 
-  it 'approves empty line after subject' do
+  it 'does not register an offense for empty line after subject' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     RUBY
   end
 
-  it 'approves empty line after subject!' do
+  it 'does not register an offense for empty line after subject!' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject! { described_class.new }
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     RUBY
   end
 
-  it 'handles subjects in tests' do
+  it 'does not register an offense for subjects in tests' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         # This shouldn't really ever happen in a sane codebase but I still
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     RUBY
   end
 
-  it 'handles multiline subject block' do
+  it 'does not register an offense for multiline subject block' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject do
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     RUBY
   end
 
-  it 'handles subject being the latest node' do
+  it 'does not register an offense for subject being the latest node' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject { described_user }

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -71,119 +71,121 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'ignores shared examples' do
+  it 'does not register an offense for shared examples' do
     expect_no_offenses(<<-RUBY, 'spec/models/user.rb')
       shared_examples_for 'foo' do; end
     RUBY
   end
 
-  it 'skips specs that do not describe a class / method' do
+  it 'does not register an offence for example groups '\
+     'do not describe a class / method' do
     expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
       describe 'Test something' do; end
     RUBY
   end
 
-  it 'skips specs that do have multiple top level describes' do
+  it 'does not register an offense for multiple top level describes' do
     expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
       describe MyClass, 'do_this' do; end
       describe MyClass, 'do_that' do; end
     RUBY
   end
 
-  it 'checks class specs' do
+  it 'does not register an offense for class specs' do
     expect_no_offenses(<<-RUBY, 'some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
-  it 'allows different parent directories' do
+  it 'does not register an offense for different parent directories' do
     expect_no_offenses(<<-RUBY, 'parent_dir/some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
-  it 'handles CamelCaps class names' do
+  it 'does not register an offense for CamelCaps class names' do
     expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
       describe MyClass do; end
     RUBY
   end
 
-  it 'handles ACRONYMClassNames' do
+  it 'does not register an offense for ACRONYMClassNames' do
     expect_no_offenses(<<-RUBY, 'abc_one/two_spec.rb')
       describe ABCOne::Two do; end
     RUBY
   end
 
-  it 'handles ALLCAPS class names' do
+  it 'does not register an offense for ALLCAPS class names' do
     expect_no_offenses(<<-RUBY, 'allcaps_spec.rb')
       describe ALLCAPS do; end
     RUBY
   end
 
-  it 'handles alphanumeric class names' do
+  it 'does not register an offense for alphanumeric class names' do
     expect_no_offenses(<<-RUBY, 'ipv4_and_ipv6_spec.rb')
       describe IPV4AndIPV6 do; end
     RUBY
   end
 
-  it 'checks instance methods' do
+  it 'does not register an offense for instance methods' do
     expect_no_offenses(<<-RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
-  it 'checks class methods' do
+  it 'does not register an offense for class methods' do
     expect_no_offenses(<<-RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
-  it 'allows flat hierarchies for instance methods' do
+  it 'does not register an offense for flat hierarchies for instance methods' do
     expect_no_offenses(<<-RUBY, 'some/class_inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
-  it 'allows flat hierarchies for class methods' do
+  it 'does not register an offense for flat hierarchies for class methods' do
     expect_no_offenses(<<-RUBY, 'some/class_inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
-  it 'allows subdirs for instance methods' do
+  it 'does not register an offense for subdirs for instance methods' do
     filename = 'some/class/instance_methods/inst_spec.rb'
     expect_no_offenses(<<-RUBY, filename)
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
-  it 'allows subdirs for class methods' do
+  it 'does not register an offense for subdirs for class methods' do
     filename = 'some/class/class_methods/inst_spec.rb'
     expect_no_offenses(<<-RUBY, filename)
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
-  it 'ignores non-alphanumeric characters' do
+  it 'does not register an offense for non-alphanumeric characters' do
     expect_no_offenses(<<-RUBY, 'some/class/pred_spec.rb')
       describe Some::Class, '#pred?' do; end
     RUBY
   end
 
-  it 'allows bang method' do
+  it 'does not register an offense for bang method' do
     expect_no_offenses(<<-RUBY, 'some/class/bang_spec.rb')
       describe Some::Class, '#bang!' do; end
     RUBY
   end
 
-  it 'allows flexibility with predicates' do
+  it 'does not register an offence for an arbitrary spec suffix' do
     filename = 'some/class/thing_predicate_spec.rb'
     expect_no_offenses(<<-RUBY, filename)
       describe Some::Class, '#thing?' do; end
     RUBY
   end
 
-  it 'allows flexibility with operators' do
+  it 'does not register an offence for an arbitrary spec name '\
+     'for an operator method' do
     filename = 'my_little_class/spaceship_operator_spec.rb'
     expect_no_offenses(<<-RUBY, filename)
       describe MyLittleClass, '#<=>' do; end
@@ -197,14 +199,14 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'detects the path based on a class name with long module' do
+  it 'registers an offense for path based on a class name with long module' do
     expect_offense(<<-RUBY, '/home/foo/spec/very/my_class_spec.rb')
       describe Very::Long::Namespace::MyClass do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `very/long/namespace/my_class*_spec.rb`.
     RUBY
   end
 
-  it 'detects the path based the absolute path of the file' do
+  it 'does not register offense for absolute file path' do
     allow(File).to receive(:expand_path).with('my_class_spec.rb').and_return(
       '/home/foo/spec/very/long/namespace/my_class_spec.rb'
     )
@@ -214,7 +216,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
   end
 
   # RSpec/FilePath runs on all files - not only **/*_spec.rb
-  it 'works on files defining an empty class' do
+  it 'does not register an offense for files defining an empty class' do
     expect_no_offenses(<<-RUBY)
       class Foo
       end
@@ -224,13 +226,13 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
   context 'when configured with CustomTransform' do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 
-    it 'respects custom module name transformation' do
+    it 'does not register an offense for custom module name transformation' do
       expect_no_offenses(<<-RUBY, 'foofoo/some/class/bar_spec.rb')
         describe FooFoo::Some::Class, '#bar' do; end
       RUBY
     end
 
-    it 'ignores routing specs' do
+    it 'does not register an offense for routing specs' do
       expect_no_offenses(<<-RUBY, 'foofoo/some/class/bar_spec.rb')
         describe MyController, "#foo", type: :routing do; end
       RUBY
@@ -240,7 +242,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
   context 'when configured with IgnoreMethods' do
     let(:cop_config) { { 'IgnoreMethods' => true } }
 
-    it 'does not care about the described method' do
+    it 'does not register an offense for the described method' do
       expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
         describe MyClass, '#look_here_a_method' do; end
       RUBY
@@ -250,7 +252,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
   context 'when configured with SpecSuffixOnly' do
     let(:cop_config) { { 'SpecSuffixOnly' => true } }
 
-    it 'does not care about the described class' do
+    it 'does not register an offense for the described class' do
       expect_no_offenses(<<-RUBY, 'whatever_spec.rb')
         describe MyClass do; end
       RUBY

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
-  it 'checks subject below let' do
+  it 'registers an offense for subject below let' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:params) { foo }
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'checks subject below let!' do
+  it 'registers an offense for subject below let!' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let!(:params) { foo }
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'checks subject below let with proc argument' do
+  it 'registers an offense for subject below let with proc argument' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:user, &args[:build_user])
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'approves of subject above let' do
+  it 'does not register an offense for subject above let' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject { described_class.new }
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'handles subjects in contexts' do
+  it 'does not register an offense for subjects in contexts' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:params) { foo }
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'handles subjects in tests' do
+  it 'does not register an offense for subjects in tests' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         # This shouldn't really ever happen in a sane codebase but I still
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'checks subject below hook' do
+  it 'registers an offense for subject below hook' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         before { allow(Foo).to receive(:bar) }
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'checks subject below example' do
+  it 'registers an offense for subject below example' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         it { is_expected.to be_present }
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'checks also when subject is below a non-offending node' do
+  it 'registers an offense when subject is below a non-offending node' do
     expect_offense(<<~RUBY)
       RSpec.describe do
         def helper_method
@@ -159,7 +159,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'flags subject below example group' do
+  it 'registers an offense for subject below example group' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         describe do
@@ -182,7 +182,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'flags subject below shared example group' do
+  it 'registers an offense for subject below shared example group' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         shared_examples_for 'used later' do
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'flags subject below include' do
+  it 'registers an offense for subject below include' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         it_behaves_like 'a good citizen'
@@ -224,7 +224,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'flags subject below include with a block' do
+  it 'registers an offense for subject below include with a block' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         it_behaves_like 'a good citizen' do
@@ -247,7 +247,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'flags subject below include with a blockpass' do
+  it 'registers an offense for subject below include with a blockpass' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         block = ->{ }
@@ -268,7 +268,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'ignores subject nested inside a block' do
+  it 'does not register an offense for subject nested inside a block' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:foo) { 'bar' }

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
-  it 'finds overwriten `let`' do
+  it 'registers an offense for overwriten `let`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
-  it 'finds overwriten `subject`' do
+  it 'registers an offense for overwriten `subject`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         subject(:a) { a }
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
-  it 'works with `subject!` and `let!`' do
+  it 'registers an offense for `subject!` and `let!`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         subject!(:a) { a }
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
-  it 'finds `let!` overwriting `let`' do
+  it 'registers an offense for `let!` overwriting `let`' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { b }
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
-  it 'ignores overwriting in different context' do
+  it 'does not register an offense for overwriting in different context' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
-  it 'handles unnamed subjects' do
+  it 'registers an offense for overriding an unnamed subject' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         subject { a }
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
-  it 'handles dynamic names for `let`' do
+  it 'does not register an offense for dynamic names for `let`' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
         subject(:name) { a }
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
     RUBY
   end
 
-  it 'handles string arguments' do
+  it 'registers an offense for string arguments' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         subject(:name) { a }

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
       RUBY
     end
 
-    it 'finds concatenated strings with no variables' do
+    it 'registers an offense for concatenated strings with no variables' do
       expect_offense(<<-RUBY)
         it do
           allow(Foo).to receive(:bar) do
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
       RUBY
     end
 
-    it 'ignores stubs without return value' do
+    it 'does not register an offense for a stub without return value' do
       expect_no_offenses(<<-RUBY)
         it do
           allow(Foo).to receive(:bar)
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
       RUBY
     end
 
-    it 'handles stubs in a method' do
+    it 'does not register an offense for stub in a method' do
       expect_no_offenses(<<-RUBY)
         def stub_foo
           allow(Foo).to receive(:bar)
@@ -196,7 +196,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
   context 'with EnforcedStyle `block`' do
     let(:enforced_style) { 'block' }
 
-    it 'finds static values returned from method' do
+    it 'registers an offense for static values returned from method' do
       expect_offense(<<-RUBY)
         it do
           allow(Foo).to receive(:bar).and_return(42)
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
       RUBY
     end
 
-    it 'finds static values returned from chained method' do
+    it 'registers an offense for static values returned from chained method' do
       expect_offense(<<-RUBY)
         it do
           allow(Foo).to receive(:bar).with(1).and_return(42)
@@ -214,7 +214,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
       RUBY
     end
 
-    it 'ignores dynamic values returned from method' do
+    it 'does not register an offense for dynamic values returned from method' do
       expect_no_offenses(<<-RUBY)
         it do
           allow(Foo).to receive(:bar).and_return(baz)


### PR DESCRIPTION
CI is failing with latest rubocop https://app.circleci.com/pipelines/github/rubocop/rubocop-rspec/887/workflows/cb3ac5d9-a753-42fd-a26d-86b9e5bd8c69/jobs/20828

Rubocop change: https://github.com/rubocop/rubocop/pull/9797 - Released in rubocop `v1.15.0`

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
