### PR TITLE
Add missing documentation for `single_statement_only` style of `RSpec/ImplicitSubject` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Add missing documentation for `single_statement_only` style of `RSpec/ImplicitSubject` cop. ([@tejasbubane][])
+
 ## 2.3.0 (2021-04-28)
 
 * Allow `RSpec/ContextWording` to accept multi-word prefixes. ([@hosamaly][])

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1827,7 +1827,7 @@ This cop can be configured using the `EnforcedStyle` option
 
 === Examples
 
-==== `EnforcedStyle: single_line_only`
+==== `EnforcedStyle: single_line_only` (default)
 
 [source,ruby]
 ----
@@ -1840,6 +1840,26 @@ end
 it { is_expected.to be_truthy }
 it do
   expect(subject).to be_truthy
+end
+----
+
+==== `EnforcedStyle: single_statement_only`
+
+[source,ruby]
+----
+# bad
+it do
+  foo = 1
+  is_expected.to be_truthy
+end
+
+# good
+it do
+  foo = 1
+  expect(subject).to be_truthy
+end
+it do
+  is_expected.to be_truthy
 end
 ----
 

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -7,7 +7,7 @@ module RuboCop
       #
       # This cop can be configured using the `EnforcedStyle` option
       #
-      # @example `EnforcedStyle: single_line_only`
+      # @example `EnforcedStyle: single_line_only` (default)
       #   # bad
       #   it do
       #     is_expected.to be_truthy
@@ -17,6 +17,22 @@ module RuboCop
       #   it { is_expected.to be_truthy }
       #   it do
       #     expect(subject).to be_truthy
+      #   end
+      #
+      # @example `EnforcedStyle: single_statement_only`
+      #   # bad
+      #   it do
+      #     foo = 1
+      #     is_expected.to be_truthy
+      #   end
+      #
+      #   # good
+      #   it do
+      #     foo = 1
+      #     expect(subject).to be_truthy
+      #   end
+      #   it do
+      #     is_expected.to be_truthy
       #   end
       #
       # @example `EnforcedStyle: disallow`


### PR DESCRIPTION

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
