### PR TITLE
Make FilePath check suffix when given a non-constant top-level node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Update `RSpec/FilePath` to check suffix when given a non-constant top-level node (e.g. features). ([@topalovic][])
 * Add missing documentation for `single_statement_only` style of `RSpec/ImplicitSubject` cop. ([@tejasbubane][])
 * Fix an exception in `DescribedClass` when accessing a constant on a variable in a spec that is nested in a namespace. ([@rrosenblum][])
 * Add new `RSpec/IdenticalEqualityAssertion` cop. ([@tejasbubane][])
@@ -621,3 +622,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@Tietew]: https://github.com/Tietew
 [@rrosenblum]: https://github.com/rrosenblum
 [@paydaylight]: https://github.com/paydaylight
+[@topalovic]: https://github.com/topalovic

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -64,6 +64,13 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
+  it 'registers an offense for a feature file missing _spec' do
+    expect_offense(<<-RUBY, 'spec/features/my_feature.rb')
+      feature "my feature" do; end
+      ^^^^^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
+    RUBY
+  end
+
   it 'registers an offense for a file without the .rb extension' do
     expect_offense(<<-RUBY, 'spec/models/user_specxrb')
       describe User do; end
@@ -262,6 +269,13 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
       expect_offense(<<-RUBY, 'spec/whatever.rb')
         describe MyClass do; end
         ^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
+      RUBY
+    end
+
+    it 'registers an offense when a feature file is missing _spec.rb suffix' do
+      expect_offense(<<-RUBY, 'spec/my_feature.rb')
+        feature "my feature" do; end
+        ^^^^^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
       RUBY
     end
 


### PR DESCRIPTION
Currently, `RSpec/FilePath` matcher ignores non-constant top-level nodes.

However, the standard feature format assumes string descriptions:

```ruby
RSpec.feature "Some feature" do
end
```

This can make feature files without a proper suffix go unnoticed and then ignored by the runner. Test it by creating a feature file without a suffix, e.g. `spec/features/some_feature.rb`.

This PR makes the matcher more general by matching `_` instead of `const`. If the top-level node is not a constant, we'll simply fall back to the basic `spec_suffix_only?` check, regardless of the actual config flag.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

