### PR TITLE
Bump version to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Master (Unreleased)
 
+## 2.4.0 (2021-06-09)
+
 * Update `RSpec/FilePath` to check suffix when given a non-constant top-level node (e.g. features). ([@topalovic][])
 * Add missing documentation for `single_statement_only` style of `RSpec/ImplicitSubject` cop. ([@tejasbubane][])
 * Fix an exception in `DescribedClass` when accessing a constant on a variable in a spec that is nested in a namespace. ([@rrosenblum][])
 * Add new `RSpec/IdenticalEqualityAssertion` cop. ([@tejasbubane][])
-* Add `RSpec/Rails/AvoidSetupHook cop. ([@paydaylight][])
+* Add `RSpec/Rails/AvoidSetupHook` cop. ([@paydaylight][])
 * Fix false negative in `RSpec/ExpectChange` cop with block style and chained method call. ([@tejasbubane][])
 
 ## 2.3.0 (2021-04-28)

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: master
+version: '2.4'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.3.0'
+      STRING = '2.4.0'
     end
   end
 end


### PR DESCRIPTION
## 2.4.0 (2021-06-09)

* Update `RSpec/FilePath` to check suffix when given a non-constant top-level node (e.g. features). ([@topalovic][])
* Add missing documentation for `single_statement_only` style of `RSpec/ImplicitSubject` cop. ([@tejasbubane][])
* Fix an exception in `DescribedClass` when accessing a constant on a variable in a spec that is nested in a namespace. ([@rrosenblum][])
* Add new `RSpec/IdenticalEqualityAssertion` cop. ([@tejasbubane][])
* Add `RSpec/Rails/AvoidSetupHook` cop. ([@paydaylight][])
* Fix false negative in `RSpec/ExpectChange` cop with block style and chained method call. ([@tejasbubane][])

[@tejasbubane]: https://github.com/tejasbubane
[@rrosenblum]: https://github.com/rrosenblum
[@paydaylight]: https://github.com/paydaylight
[@topalovic]: https://github.com/topalovic
