### PR TITLE
[Fix #1093] exclude some directories by default from DescribeClass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 * Fix each example for `RSpec/HookArgument`. ([@lokhi][])
+* Exclude unrelated Rails directories from `RSpec/DescribeClass`. ([@MothOnMars][])
 
 ## 2.4.0 (2021-06-09)
 
@@ -627,3 +628,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@paydaylight]: https://github.com/paydaylight
 [@topalovic]: https://github.com/topalovic
 [@lokhi]: https://github.com/lokhi
+[@MothOnMars]: https://github.com/MothOnMars

--- a/config/default.yml
+++ b/config/default.yml
@@ -148,6 +148,12 @@ RSpec/ContextWording:
 RSpec/DescribeClass:
   Description: Check that the first argument to the top-level describe is a constant.
   Enabled: true
+  Exclude:
+    - "**/spec/features/**/*"
+    - "**/spec/requests/**/*"
+    - "**/spec/routing/**/*"
+    - "**/spec/system/**/*"
+    - "**/spec/views/**/*"
   IgnoredMetadata:
     type:
       - channel
@@ -164,7 +170,7 @@ RSpec/DescribeClass:
       - mailbox
       - aruba
   VersionAdded: '1.0'
-  VersionChanged: '1.44'
+  VersionChanged: 2.4.1
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
 
 RSpec/DescribeMethod:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -399,7 +399,7 @@ end
 | Yes
 | No
 | 1.0
-| 1.44
+| 2.4.1
 |===
 
 Check that the first argument to the top-level describe is a constant.
@@ -445,6 +445,10 @@ end
 
 |===
 | Name | Default value | Configurable values
+
+| Exclude
+| `+**/spec/features/**/*+`, `+**/spec/requests/**/*+`, `+**/spec/routing/**/*+`, `+**/spec/system/**/*+`, `+**/spec/views/**/*+`
+| Array
 
 | IgnoredMetadata
 | `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox", "aruba"]}`


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop-rspec/issues/1093

This PR excludes several directories whose specs are not associated with a specific class or module from the `DescribeClass` cop. This supports projects using the `infer_spec_type_from_file_location!` RSpec configuration, whose spec files do not specify the spec `type` in the spec file itself.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. - _I did not add any specs, but wasn't sure if they were necessary for config-only changes...? Happy to add if necessary._
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
