### PR TITLE
Fix default config for sub-departments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Add new `RSpec/IdenticalEqualityAssertion` cop. ([@tejasbubane][])
 * Add `RSpec/Rails/AvoidSetupHook` cop. ([@paydaylight][])
 * Fix false negative in `RSpec/ExpectChange` cop with block style and chained method call. ([@tejasbubane][])
+* Fix `Include` configuration for sub-departments. ([@pirj][])
 
 ## 2.3.0 (2021-04-28)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,10 +1,10 @@
 ---
 RSpec:
   Enabled: true
-  Include:
+  Include: &1
     - "**/*_spec.rb"
     - "**/spec/**/*"
-  Language:
+  Language: &2
     inherit_mode:
       merge:
         - Expectations
@@ -745,6 +745,11 @@ RSpec/Yield:
   VersionAdded: '1.32'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Yield
 
+RSpec/Capybara:
+  Enabled: true
+  Include: *1
+  Language: *2
+
 RSpec/Capybara/CurrentPathExpectation:
   Description: Checks that no expectations are set on Capybara's `current_path`.
   Enabled: true
@@ -766,6 +771,11 @@ RSpec/Capybara/VisibilityMatcher:
   VersionAdded: '1.39'
   VersionChanged: '2.0'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/VisibilityMatcher
+
+RSpec/FactoryBot:
+  Enabled: true
+  Include: *1
+  Language: *2
 
 RSpec/FactoryBot/AttributeDefinedStatically:
   Description: Always declare attribute values as blocks.
@@ -805,6 +815,11 @@ RSpec/FactoryBot/FactoryClassName:
   VersionAdded: '1.37'
   VersionChanged: '2.0'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName
+
+RSpec/Rails:
+  Enabled: true
+  Include: *1
+  Language: *2
 
 RSpec/Rails/AvoidSetupHook:
   Description: Checks that tests use RSpec `before` hook over Rails `setup` method.

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -7,6 +7,7 @@ module RuboCop
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
       EXTENSION_ROOT_DEPARTMENT = %r{^(RSpec/)}.freeze
+      SUBDEPARTMENTS = %(RSpec/Capybara RSpec/FactoryBot RSpec/Rails)
       STYLE_GUIDE_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'
 
       def initialize(config, descriptions)
@@ -24,6 +25,8 @@ module RuboCop
 
       def unified_config
         cops.each_with_object(config.dup) do |cop, unified|
+          next if SUBDEPARTMENTS.include?(cop)
+
           unified[cop] = config.fetch(cop)
             .merge(descriptions.fetch(cop))
             .merge('StyleGuide' => STYLE_GUIDE_BASE_URL + cop.sub('RSpec/', ''))

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'config/default.yml' do
   end
 
   let(:config_keys) do
-    cop_names + %w[RSpec]
+    cop_names + %w[RSpec RSpec/Capybara RSpec/FactoryBot RSpec/Rails]
   end
 
   def cop_configuration(config_key)


### PR DESCRIPTION
It turns out that the default config does not apply for sub-departments.
It is weird on many levels:
 - RSpec DSL configuration didn't work
 - - RSpec DSL doesn't work as intended anyway #1126
 - if users would re-define RSpec DSL, they would have to do it for all sub-departments, as YAML defaults are only for the default config
 - if users would re-define RSpec DSL and use YAML defaults, too, the merging of the resulting config is undetermined

Still, I believe having `Include` to work correctly is the most important.

fixes #1160


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).