### PR TITLE
Fix doc rspec hook argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Master (Unreleased)
+* Fix each example for `RSpec/HookArgument`. ([@lokhi][])
 
 ## 2.4.0 (2021-06-09)
 
@@ -625,3 +626,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@rrosenblum]: https://github.com/rrosenblum
 [@paydaylight]: https://github.com/paydaylight
 [@topalovic]: https://github.com/topalovic
+[@lokhi]: https://github.com/lokhi

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1635,7 +1635,7 @@ before(:example) do
   # ...
 end
 
-# good
+# bad
 before do
   # ...
 end

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -32,7 +32,7 @@ module RuboCop
       #     # ...
       #   end
       #
-      #   # good
+      #   # bad
       #   before do
       #     # ...
       #   end


### PR DESCRIPTION
I think there is an issue with the example of EnforcedStyle: each for Rspec/HookArgument.
The before do should be bad imo.


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).