### PR TITLE
Add rubocop-rake

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ inherit_from: .rubocop_todo.yml
 
 require:
   - rubocop-performance
+  - rubocop-rake
   - rubocop-rspec
   - rubocop/cop/internal_affairs
 

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'
   spec.add_development_dependency 'rubocop-performance', '~> 1.7'
+  spec.add_development_dependency 'rubocop-rake', '~> 0.6'
   # Workaround for cc-test-reporter with SimpleCov 0.18.
   # Stop upgrading SimpleCov until the following issue will be resolved.
   # https://github.com/codeclimate/test-reporter/issues/418


### PR DESCRIPTION
RuboCop keeps suggesting it on every run, and I cannot think of a reason not to add this gem.

- https://rubygems.org/gems/rubocop-rake
- https://github.com/rubocop/rubocop-rake