### PR TITLE
Declare autocorrect as unsafe for `ExpectChange`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Declare autocorrect as unsafe for `ExpectChange`. ([@francois-ferrandis][])
 * Fix each example for `RSpec/HookArgument`. ([@lokhi][])
 * Exclude unrelated Rails directories from `RSpec/DescribeClass`. ([@MothOnMars][])
 * Add `RSpec/ExcessiveDocstringSpacing` cop. ([@G-Rath][])
@@ -635,3 +636,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@MothOnMars]: https://github.com/MothOnMars
 [@G-Rath]: https://github.com/G-Rath
 [@dswij]: https://github.com/dswij
+[@francois-ferrandis]: https://github.com/francois-ferrandis

--- a/config/default.yml
+++ b/config/default.yml
@@ -309,7 +309,9 @@ RSpec/ExpectChange:
   SupportedStyles:
     - method_call
     - block
+  SafeAutoCorrect: false
   VersionAdded: '1.22'
+  VersionChanged: 2.5.0
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
 
 RSpec/ExpectInHook:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1366,9 +1366,9 @@ expect(name).to eq("John")
 
 | Enabled
 | Yes
-| Yes
+| Yes (Unsafe)
 | 1.22
-| -
+| 2.5.0
 |===
 
 Checks for consistent style of change matcher.


### PR DESCRIPTION
This cop is unsafe, as illustrated in #1174.

fixes #1174

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
