### PR TITLE
Fix typo in NestedGroups doc

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2957,7 +2957,7 @@ end
 Checks for nested example groups.
 
 This cop is configurable using the `Max` option
-and supports `--auto-gen-config
+and supports `--auto-gen-config`.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks for nested example groups.
       #
       # This cop is configurable using the `Max` option
-      # and supports `--auto-gen-config
+      # and supports `--auto-gen-config`.
       #
       # @example
       #   # bad


### PR DESCRIPTION
This change aims to fix just a typo in the `RSpec/NestedGroups` document.
See <https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecnestedgroups>

<img width="621" alt="image" src="https://user-images.githubusercontent.com/473530/129347593-0335fc9b-638c-41ce-b105-ad42bbdf4fae.png">

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
