### PR TITLE
[Fix #1184] false positive when block do not have child nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 * Exclude unrelated Rails directories from `RSpec/DescribeClass`. ([@MothOnMars][])
 * Add `RSpec/ExcessiveDocstringSpacing` cop. ([@G-Rath][])
 * Add `RSpec/SubjectDeclaration` cop. ([@dswij][])
-* Fix excessive whitespace removal in `RSpec/EmptyHook' autocorrection. ([@pirj][])
+* Fix excessive whitespace removal in `RSpec/EmptyHook` autocorrection. ([@pirj][])
 * Bump RuboCop requirement to v1.19.0. ([@pirj][])
+* Fix false positive in `RSpec/IteratedExpectation` when there is single, non-espectation statement in the block body. ([@Darhazer][])
 
 ## 2.4.0 (2021-06-09)
 

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -48,6 +48,8 @@ module RuboCop
         end
 
         def only_expectations?(body, arg)
+          return false unless body.each_child_node.any?
+
           body.each_child_node.all? { |child| expectation?(child, arg) }
         end
       end

--- a/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
     RUBY
   end
 
+  it 'ignores `each` with unused variable' do
+    expect_no_offenses(<<-RUBY)
+      it 'validates users' do
+        [user1, user2, user3].each { |_user| do_something }
+      end
+    RUBY
+  end
+
   it 'flags `each` with multiple expectations' do
     expect_offense(<<-RUBY)
       it 'validates users' do


### PR DESCRIPTION
When the block contains a single node with no children, the cop wrongly marks it as expectation, as it runs `.all?` on the empty children set.

Thanks @pirj for debugging it

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] ~Updated documentation.~
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
