### PR TITLE
Bump version to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.5.0 (2021-09-21)
+
 * Declare autocorrect as unsafe for `ExpectChange`. ([@francois-ferrandis][])
 * Fix each example for `RSpec/HookArgument`. ([@lokhi][])
 * Exclude unrelated Rails directories from `RSpec/DescribeClass`. ([@MothOnMars][])
@@ -9,7 +11,7 @@
 * Add `RSpec/SubjectDeclaration` cop. ([@dswij][])
 * Fix excessive whitespace removal in `RSpec/EmptyHook` autocorrection. ([@pirj][])
 * Bump RuboCop requirement to v1.19.0. ([@pirj][])
-* Fix false positive in `RSpec/IteratedExpectation` when there is single, non-espectation statement in the block body. ([@Darhazer][])
+* Fix false positive in `RSpec/IteratedExpectation` when there is single, non-expectation statement in the block body. ([@Darhazer][])
 
 ## 2.4.0 (2021-06-09)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -170,7 +170,7 @@ RSpec/DescribeClass:
       - mailbox
       - aruba
   VersionAdded: '1.0'
-  VersionChanged: 2.4.1
+  VersionChanged: '2.5'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
 
 RSpec/DescribeMethod:
@@ -311,7 +311,7 @@ RSpec/ExpectChange:
     - block
   SafeAutoCorrect: false
   VersionAdded: '1.22'
-  VersionChanged: 2.5.0
+  VersionChanged: '2.5'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
 
 RSpec/ExpectInHook:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: master
+version: '2.5'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -399,7 +399,7 @@ end
 | Yes
 | No
 | 1.0
-| 2.4.1
+| 2.5
 |===
 
 Check that the first argument to the top-level describe is a constant.
@@ -1368,7 +1368,7 @@ expect(name).to eq("John")
 | Yes
 | Yes (Unsafe)
 | 1.22
-| 2.5.0
+| 2.5
 |===
 
 Checks for consistent style of change matcher.

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.4.0'
+      STRING = '2.5.0'
     end
   end
 end


### PR DESCRIPTION
We haven't had a release for the past 3 months :shipit: 

## 2.5.0 (2021-09-21)
* Declare autocorrect as unsafe for `ExpectChange`. ([@francois-ferrandis][])
* Fix each example for `RSpec/HookArgument`. ([@lokhi][])
* Exclude unrelated Rails directories from `RSpec/DescribeClass`. ([@MothOnMars][])
* Add `RSpec/ExcessiveDocstringSpacing` cop. ([@G-Rath][])
* Add `RSpec/SubjectDeclaration` cop. ([@dswij][])
* Fix excessive whitespace removal in `RSpec/EmptyHook` autocorrection. ([@pirj][])
* Bump RuboCop requirement to v1.19.0. ([@pirj][])
* Fix false positive in `RSpec/IteratedExpectation` when there is single, non-expectation statement in the block body. ([@Darhazer][])
