### PR TITLE
Fix inherit_mode for third-party gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix merging RSpec DSL configuration from third-party gems. ([@pirj][])
+
 ## 2.5.0 (2021-09-21)
 
 * Declare autocorrect as unsafe for `ExpectChange`. ([@francois-ferrandis][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,7 +5,20 @@ RSpec:
     - "**/*_spec.rb"
     - "**/spec/**/*"
   Language:
+    inherit_mode:
+      merge:
+        - Expectations
+        - Helpers
+        - Hooks
+        - HookScopes
+        - Runners
+        - Subjects
     ExampleGroups:
+      inherit_mode:
+        merge:
+          - Regular
+          - Skipped
+          - Focused
       Regular:
         - describe
         - context
@@ -20,6 +33,12 @@ RSpec:
         - fcontext
         - ffeature
     Examples:
+      inherit_mode:
+        merge:
+          - Regular
+          - Skipped
+          - Focused
+          - Pending
       Regular:
         - it
         - specify
@@ -62,6 +81,10 @@ RSpec:
       - all
       - suite
     Includes:
+      inherit_mode:
+        merge:
+          - Examples
+          - Context
       Examples:
         - it_behaves_like
         - it_should_behave_like
@@ -73,6 +96,10 @@ RSpec:
       - to_not
       - not_to
     SharedGroups:
+      inherit_mode:
+        merge:
+          - Examples
+          - Context
       Examples:
         - shared_examples
         - shared_examples_for

--- a/docs/modules/ROOT/pages/third_party_rspec_syntax_extensions.adoc
+++ b/docs/modules/ROOT/pages/third_party_rspec_syntax_extensions.adoc
@@ -8,6 +8,8 @@ RuboCop https://docs.rubocop.org/rubocop/configuration.html#inheriting-configura
 
 == Packaging configuration for RuboCop RSpec
 
+NOTE: Due to a [bug](https://github.com/rubocop/rubocop-rspec/issues/1126), this feature doesn't work properly for `rubocop-rspec` 2.5.0 and earlier versions.
+
 For a third-party gem, it's sufficient to follow three steps:
 
 1. Provide a configuration file (e.g. `.rubocop_rspec_alias_config.yml` or `config/rubocop-rspec.yml`).


### PR DESCRIPTION
fixes #1126

See https://github.com/palkan/action_policy/issues/103#issuecomment-932886450

If a third-party gem, e.g. `action_policy`, defines their `config/default.yml` and supplements to the default RSpec DSL that we provide in our `config/default.yml`, `rubocop`'s behaviour is to actually override the configuration, as `inherit_mode` is `override` for lists by default.

RuboCop has recently [fixed the problem with ignored `inherit_mode`](https://github.com/rubocop/rubocop/pull/9952) and we've [bumped to use `rubocop` version that includes the fix](https://github.com/rubocop/rubocop-rspec/pull/1181), but we haven't adjusted our `config/default.yml` to merge by default.

This is causing both user project RSpec DSL configuration and third-party gem RSpec DSL configuration to override our default, rendering our cops blind.

A little more context and reasoning for this fix https://github.com/palkan/action_policy/issues/103#issuecomment-932886450

### Example

A new project

```ruby
# Gemfile
source 'https://rubygems.org'

gem 'action_policy'
gem 'rubocop-rspec'
```

```yml
# .rubocop.yml
require:
  - rubocop-rspec

inherit_gem:
  action_policy: config/rubocop-rspec.yml
```

```ruby
# spec/a_spec.rb
RSpec.describe 'A' do
  it_behaves_like 'a'
  it_behaves_like 'a'

  describe_rule :show? do
    succeed 'when post is published'
    succeed 'when post is published'
  end
end
```

Ideally, both the duplicated `it_behaves_like` and `succeed` should be detected. However, `action_policy`'s `Includes/Examples` setting overrides ours, and `it_behaves_like` disappears from this list. As a result, `rubocop` only detects the duplication of `succeed`, but not of `it_behaves_like`.

### References

RSpec DSL configuration ticket https://github.com/rubocop/rubocop-rspec/issues/333
RSpec DSL configuration PR https://github.com/rubocop/rubocop-rspec/pull/956
Problem with merging https://github.com/rubocop/rubocop-rspec/issues/1126
Fix for ignored `inherit_mode` https://github.com/rubocop/rubocop/pull/9952
https://github.com/rubocop/rubocop-rspec/pull/1181
https://docs.rubocop.org/rubocop/1.0/configuration.html#merging-arrays-using-inherit_mode
https://docs.rubocop.org/rubocop/1.9/configuration.html#unusual-files-that-would-not-be-included-by-default
Documentation for third-party gems to work with `rubocop-rspec` https://docs.rubocop.org/rubocop-rspec/third_party_rspec_syntax_extensions.html
https://github.com/rubocop/rubocop-rspec/issues/1077
Example third-party gem RSpec DSL configuration https://github.com/palkan/action_policy/pull/138


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).