### PR TITLE
Fix internal affair of edge-rubocop

### DIFF
--- a/lib/rubocop/rspec/align_let_brace.rb
+++ b/lib/rubocop/rspec/align_let_brace.rb
@@ -5,6 +5,7 @@ module RuboCop
     # Shared behavior for aligning braces for single line lets
     class AlignLetBrace
       include RuboCop::RSpec::Language
+      include RuboCop::Cop::Util
 
       def initialize(root, token)
         @root  = root
@@ -34,7 +35,7 @@ module RuboCop
       def let_group_for(let)
         adjacent_let_chunks.detect do |chunk|
           chunk.any? do |member|
-            member == let && member.loc.line == let.loc.line
+            member == let && same_line?(member, let)
           end
         end
       end


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/rubocop/rubocop-rspec/997/workflows/2bdf0dff-c7d0-47fe-9180-545ae81ffb0a/jobs/21952

```
Offenses:

lib/rubocop/rspec/align_let_brace.rb:37:30: C: [Correctable] InternalAffairs/LocationLineEqualityComparison: Use same_line?(member, let).
            member == let && member.loc.line == let.loc.line
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

224 files inspected, 1 offense detected, 1 offense auto-correctable
```


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).