### PR TITLE
fix(ExcessiveDocstringSpacing): ignore multi-line indenting whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix merging RSpec DSL configuration from third-party gems. ([@pirj][])
+* Fix `RSpec/ExcessiveDocstringSpacing` false positive for multi-line indented strings. ([@G-Rath][])
 
 ## 2.5.0 (2021-09-21)
 

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -49,7 +49,9 @@ module RuboCop
 
         # @param text [String]
         def excessive_whitespace?(text)
-          text.start_with?(' ') || text.include?('  ') || text.end_with?(' ')
+          return true if text.start_with?(' ') || text.end_with?(' ')
+
+          text.match?(/[^\n ]  +[^ ]/)
         end
 
         # @param text [String]

--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -581,4 +581,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing, only: true do
       RUBY
     end
   end
+
+  it 'does not consider indented whitespace excessive' do
+    expect_no_offenses(<<-RUBY)
+      context "some context" do
+        [].each do |i|
+          it "does something, lala1: #\{i[:a].first} - #\{i[:a].last},
+              lala2: #\{i[:a].first} - #\{i[:a].last}" do
+            # something
+
+            # expect
+          end
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #1193

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
