### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix merging RSpec DSL configuration from third-party gems. ([@pirj][])
 * Fix `RSpec/ExcessiveDocstringSpacing` false positive for multi-line indented strings. ([@G-Rath][])
+* Fix `Include` configuration for sub-departments. ([@pirj][])
 
 ## 2.5.0 (2021-09-21)
 
@@ -24,7 +25,6 @@
 * Add new `RSpec/IdenticalEqualityAssertion` cop. ([@tejasbubane][])
 * Add `RSpec/Rails/AvoidSetupHook` cop. ([@paydaylight][])
 * Fix false negative in `RSpec/ExpectChange` cop with block style and chained method call. ([@tejasbubane][])
-* Fix `Include` configuration for sub-departments. ([@pirj][])
 
 ## 2.3.0 (2021-04-28)
 


### PR DESCRIPTION
#1163's changelog entry went under 2.4 somehow https://github.com/rubocop/rubocop-rspec/pull/1163/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR27

---

Before submitting the PR make sure the following are checked:

* [-] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).