### PR TITLE
Add autocorrect support for `RSpec/VariableDefinition`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix `Include` configuration for sub-departments. ([@pirj][])
 * Ignore heredocs in `RSpec/ExcessiveDocstringSpacing`. ([@G-Rath][])
 * Stop `RSpec/ExampleWording` from trying to correct heredocs. ([@G-Rath][])
+* Add autocorrect support for `RSpec/VariableDefinition`. ([@r7kamura][])
 
 ## 2.5.0 (2021-09-21)
 
@@ -647,3 +648,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@G-Rath]: https://github.com/G-Rath
 [@dswij]: https://github.com/dswij
 [@francois-ferrandis]: https://github.com/francois-ferrandis
+[@r7kamura]: https://github.com/r7kamura

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4062,7 +4062,7 @@ expect { do_something }.not_to raise_error
 
 | Enabled
 | Yes
-| No
+| Yes
 | 1.40
 | -
 |===

--- a/spec/rubocop/cop/rspec/variable_definition_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_definition_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe RuboCop::Cop::RSpec::VariableDefinition do
         let('user_name') { 'Adam' }
             ^^^^^^^^^^^ Use symbols for variable names.
       RUBY
+
+      expect_correction(<<~RUBY)
+        let(:user_name) { 'Adam' }
+      RUBY
     end
 
     it 'does not register offense for interpolated string' do
@@ -39,12 +43,20 @@ RSpec.describe RuboCop::Cop::RSpec::VariableDefinition do
         let(:user_name) { 'Adam' }
             ^^^^^^^^^^ Use strings for variable names.
       RUBY
+
+      expect_correction(<<~RUBY)
+        let("user_name") { 'Adam' }
+      RUBY
     end
 
     it 'registers an offense for interpolated symbol' do
       expect_offense(<<~'RUBY')
         let(:"user-#{id}") { 'Adam' }
             ^^^^^^^^^^^^^ Use strings for variable names.
+      RUBY
+
+      expect_correction(<<~'RUBY')
+        let("user-#{id}") { 'Adam' }
       RUBY
     end
 


### PR DESCRIPTION
Added an autocorrect support for `RSpec/VariableDefinition`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

<!--

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.

-->