### PR TITLE
Fix a build error for Ruby 3.1.0-dev

### DIFF
--- a/bin/build_config
+++ b/bin/build_config
@@ -20,7 +20,11 @@ rspec_cop_path = File.join('lib', 'rubocop', 'cop', 'rspec', 'base.rb')
 YARD.parse(Dir[glob].prepend(rspec_cop_path), [])
 
 descriptions = RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all).to_h
-current_config = YAML.load_file('config/default.yml')
+current_config = if Psych::VERSION >= '4.0.0' # RUBY_VERSION >= '3.1.0'
+                   YAML.unsafe_load_file('config/default.yml')
+                 else
+                   YAML.load_file('config/default.yml')
+                 end
 
 File.write(
   'config/default.yml',


### PR DESCRIPTION
Follow up to https://github.com/ruby/psych/pull/487.

This PR fixes the following Ruby 3.1.0-dev build error.

```console
% ruby -v
ruby 3.1.0dev (2021-10-26T00:30:42Z master 7d4c59203f) [x86_64-darwin19]

% bundle exec rake
bin/build_config
/Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:430:in
`visit_Psych_Nodes_Alias': Unknown alias: 1 (Psych::BadAlias)
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych/visitors/visitor.rb:30:in `visit'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych/visitors/visitor.rb:6:in `accept'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
(snip)

        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych/visitors/to_ruby.rb:35:in `accept'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych.rb:335:in `safe_load'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych.rb:370:in `load'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych.rb:671:in `block in load_file'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych.rb:670:in `open'
        from /Users/koic/.rbenv/versions/3.1.0-dev/lib/ruby/3.1.0/psych.rb:670:in `load_file'
        from bin/build_config:23:in `<main>'
rake aborted!
Command failed with status (1): [bin/build_config...]
/Users/koic/src/github.com/rubocop/rubocop-rspec/Rakefile:37:in `block
in <top (required)>'
/Users/koic/.rbenv/versions/3.1.0-dev/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/3.1.0-dev/bin/bundle:23:in `<main>'
Tasks: TOP => default => build_config
(See full trace by running task with --trace)
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
