### PR TITLE
Trigger GitHub Actions workflow on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   confirm_config_and_documentation:


### PR DESCRIPTION
The `push` event alone doesn't work when making changed on a forked repository – see how the workflow currently doesn’t run for https://github.com/rubocop/rubocop-rspec/pull/1205. So now the main workflow runs when a pull request is opened, re-opened or "synchronized" which I assume is when you push new changes.

There is some documentation at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request, but I cannot find anything that says exactly that `push` doesn't trigger on a forked repository. But I tried it out in #1209 where it seems to fix the problem.