### PR TITLE
Add AutoCorrect config support to Focus

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -371,8 +371,9 @@ RSpec/FilePath:
 RSpec/Focus:
   Description: Checks if examples are focused.
   Enabled: true
+  AutoCorrect: true
   VersionAdded: '1.5'
-  VersionChanged: '2.1'
+  VersionChanged: '2.2'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Focus
 
 RSpec/HookArgument:

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -87,6 +87,10 @@ module RuboCop
           corrector.replace(range,
                             range.source.sub(focus.method_name.to_s, unfocused))
         end
+
+        def should_autocorrect
+          cop_config['AutoCorrect']
+        end
       end
     end
   end

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -2,208 +2,369 @@
 
 RSpec.describe RuboCop::Cop::RSpec::Focus do
   # rubocop:disable RSpec/ExampleLength
-  it 'flags all rspec example blocks with that include `focus: true`' do
-    expect_offense(<<-RUBY)
-      example 'test', meta: true, focus: true do; end
-                                  ^^^^^^^^^^^ Focused spec found.
-      xit 'test', meta: true, focus: true do; end
-                              ^^^^^^^^^^^ Focused spec found.
-      describe 'test', meta: true, focus: true do; end
-                                   ^^^^^^^^^^^ Focused spec found.
-      RSpec.describe 'test', meta: true, focus: true do; end
-                                         ^^^^^^^^^^^ Focused spec found.
-      it 'test', meta: true, focus: true do; end
-                             ^^^^^^^^^^^ Focused spec found.
-      xspecify 'test', meta: true, focus: true do; end
-                                   ^^^^^^^^^^^ Focused spec found.
-      specify 'test', meta: true, focus: true do; end
-                                  ^^^^^^^^^^^ Focused spec found.
-      example_group 'test', meta: true, focus: true do; end
-                                        ^^^^^^^^^^^ Focused spec found.
-      scenario 'test', meta: true, focus: true do; end
-                                   ^^^^^^^^^^^ Focused spec found.
-      xexample 'test', meta: true, focus: true do; end
-                                   ^^^^^^^^^^^ Focused spec found.
-      xdescribe 'test', meta: true, focus: true do; end
+  context 'when autocorrect is enabled' do
+    let(:cop_config) { { 'AutoCorrect' => true } }
+
+    it 'flags all rspec example blocks with that include `focus: true`' do
+      expect_offense(<<-RUBY)
+        example 'test', meta: true, focus: true do; end
                                     ^^^^^^^^^^^ Focused spec found.
-      context 'test', meta: true, focus: true do; end
-                                  ^^^^^^^^^^^ Focused spec found.
-      xcontext 'test', meta: true, focus: true do; end
-                                   ^^^^^^^^^^^ Focused spec found.
-      feature 'test', meta: true, focus: true do; end
-                                  ^^^^^^^^^^^ Focused spec found.
-      xfeature 'test', meta: true, focus: true do; end
-                                   ^^^^^^^^^^^ Focused spec found.
-      xscenario 'test', meta: true, focus: true do; end
+        xit 'test', meta: true, focus: true do; end
+                                ^^^^^^^^^^^ Focused spec found.
+        describe 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        RSpec.describe 'test', meta: true, focus: true do; end
+                                           ^^^^^^^^^^^ Focused spec found.
+        it 'test', meta: true, focus: true do; end
+                               ^^^^^^^^^^^ Focused spec found.
+        xspecify 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        specify 'test', meta: true, focus: true do; end
                                     ^^^^^^^^^^^ Focused spec found.
-      pending 'test', meta: true, focus: true do; end
-                                  ^^^^^^^^^^^ Focused spec found.
-    RUBY
+        example_group 'test', meta: true, focus: true do; end
+                                          ^^^^^^^^^^^ Focused spec found.
+        scenario 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        xexample 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        xdescribe 'test', meta: true, focus: true do; end
+                                      ^^^^^^^^^^^ Focused spec found.
+        context 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+        xcontext 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        feature 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+        xfeature 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        xscenario 'test', meta: true, focus: true do; end
+                                      ^^^^^^^^^^^ Focused spec found.
+        pending 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+      RUBY
 
-    expect_correction(<<-RUBY)
-      example 'test', meta: true do; end
-      xit 'test', meta: true do; end
-      describe 'test', meta: true do; end
-      RSpec.describe 'test', meta: true do; end
-      it 'test', meta: true do; end
-      xspecify 'test', meta: true do; end
-      specify 'test', meta: true do; end
-      example_group 'test', meta: true do; end
-      scenario 'test', meta: true do; end
-      xexample 'test', meta: true do; end
-      xdescribe 'test', meta: true do; end
-      context 'test', meta: true do; end
-      xcontext 'test', meta: true do; end
-      feature 'test', meta: true do; end
-      xfeature 'test', meta: true do; end
-      xscenario 'test', meta: true do; end
-      pending 'test', meta: true do; end
-    RUBY
-  end
+      expect_correction(<<-RUBY)
+        example 'test', meta: true do; end
+        xit 'test', meta: true do; end
+        describe 'test', meta: true do; end
+        RSpec.describe 'test', meta: true do; end
+        it 'test', meta: true do; end
+        xspecify 'test', meta: true do; end
+        specify 'test', meta: true do; end
+        example_group 'test', meta: true do; end
+        scenario 'test', meta: true do; end
+        xexample 'test', meta: true do; end
+        xdescribe 'test', meta: true do; end
+        context 'test', meta: true do; end
+        xcontext 'test', meta: true do; end
+        feature 'test', meta: true do; end
+        xfeature 'test', meta: true do; end
+        xscenario 'test', meta: true do; end
+        pending 'test', meta: true do; end
+      RUBY
+    end
 
-  it 'flags all rspec example blocks that include `:focus`' do
-    expect_offense(<<-RUBY)
-      example_group 'test', :focus do; end
-                            ^^^^^^ Focused spec found.
-      feature 'test', :focus do; end
-                      ^^^^^^ Focused spec found.
-      xexample 'test', :focus do; end
-                       ^^^^^^ Focused spec found.
-      xdescribe 'test', :focus do; end
+    it 'flags all rspec example blocks that include `:focus`' do
+      expect_offense(<<-RUBY)
+        example_group 'test', :focus do; end
+                              ^^^^^^ Focused spec found.
+        feature 'test', :focus do; end
                         ^^^^^^ Focused spec found.
-      xscenario 'test', :focus do; end
+        xexample 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        xdescribe 'test', :focus do; end
+                          ^^^^^^ Focused spec found.
+        xscenario 'test', :focus do; end
+                          ^^^^^^ Focused spec found.
+        specify 'test', :focus do; end
                         ^^^^^^ Focused spec found.
-      specify 'test', :focus do; end
-                      ^^^^^^ Focused spec found.
-      example 'test', :focus do; end
-                      ^^^^^^ Focused spec found.
-      xfeature 'test', :focus do; end
-                       ^^^^^^ Focused spec found.
-      xspecify 'test', :focus do; end
-                       ^^^^^^ Focused spec found.
-      scenario 'test', :focus do; end
-                       ^^^^^^ Focused spec found.
-      describe 'test', :focus do; end
-                       ^^^^^^ Focused spec found.
-      RSpec.describe 'test', :focus do; end
-                             ^^^^^^ Focused spec found.
-      xit 'test', :focus do; end
-                  ^^^^^^ Focused spec found.
-      context 'test', :focus do; end
-                      ^^^^^^ Focused spec found.
-      xcontext 'test', :focus do; end
-                       ^^^^^^ Focused spec found.
-      it 'test', :focus do; end
-                 ^^^^^^ Focused spec found.
-      pending 'test', :focus do; end
-                      ^^^^^^ Focused spec found.
-    RUBY
+        example 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+        xfeature 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        xspecify 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        scenario 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        describe 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        RSpec.describe 'test', :focus do; end
+                               ^^^^^^ Focused spec found.
+        xit 'test', :focus do; end
+                    ^^^^^^ Focused spec found.
+        context 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+        xcontext 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        it 'test', :focus do; end
+                   ^^^^^^ Focused spec found.
+        pending 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+      RUBY
 
-    expect_correction(<<-RUBY)
-      example_group 'test' do; end
-      feature 'test' do; end
-      xexample 'test' do; end
-      xdescribe 'test' do; end
-      xscenario 'test' do; end
-      specify 'test' do; end
-      example 'test' do; end
-      xfeature 'test' do; end
-      xspecify 'test' do; end
-      scenario 'test' do; end
-      describe 'test' do; end
-      RSpec.describe 'test' do; end
-      xit 'test' do; end
-      context 'test' do; end
-      xcontext 'test' do; end
-      it 'test' do; end
-      pending 'test' do; end
-    RUBY
+      expect_correction(<<-RUBY)
+        example_group 'test' do; end
+        feature 'test' do; end
+        xexample 'test' do; end
+        xdescribe 'test' do; end
+        xscenario 'test' do; end
+        specify 'test' do; end
+        example 'test' do; end
+        xfeature 'test' do; end
+        xspecify 'test' do; end
+        scenario 'test' do; end
+        describe 'test' do; end
+        RSpec.describe 'test' do; end
+        xit 'test' do; end
+        context 'test' do; end
+        xcontext 'test' do; end
+        it 'test' do; end
+        pending 'test' do; end
+      RUBY
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'does not flag unfocused specs' do
+      expect_no_offenses(<<-RUBY)
+        xcontext      'test' do; end
+        xscenario     'test' do; end
+        xspecify      'test' do; end
+        describe      'test' do; end
+        example       'test' do; end
+        xexample      'test' do; end
+        scenario      'test' do; end
+        specify       'test' do; end
+        xit           'test' do; end
+        feature       'test' do; end
+        xfeature      'test' do; end
+        context       'test' do; end
+        it            'test' do; end
+        example_group 'test' do; end
+        xdescribe     'test' do; end
+      RUBY
+    end
+
+    it 'flags a method that is focused twice' do
+      expect_offense(<<-RUBY)
+        fit "foo", :focus do
+        ^^^^^^^^^^^^^^^^^ Focused spec found.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it "foo" do
+        end
+      RUBY
+    end
+
+    it 'ignores non-rspec code with :focus blocks' do
+      expect_no_offenses(<<-RUBY)
+        some_method "foo", focus: true do
+        end
+      RUBY
+    end
+
+    it 'flags focused block types' do # rubocop:disable RSpec/ExampleLength
+      expect_offense(<<-RUBY)
+        fdescribe 'test' do; end
+        ^^^^^^^^^^^^^^^^ Focused spec found.
+        RSpec.fdescribe 'test' do; end
+        ^^^^^^^^^^^^^^^^^^^^^^ Focused spec found.
+        ffeature 'test' do; end
+        ^^^^^^^^^^^^^^^ Focused spec found.
+        fcontext 'test' do; end
+        ^^^^^^^^^^^^^^^ Focused spec found.
+        fit 'test' do; end
+        ^^^^^^^^^^ Focused spec found.
+        fscenario 'test' do; end
+        ^^^^^^^^^^^^^^^^ Focused spec found.
+        fexample 'test' do; end
+        ^^^^^^^^^^^^^^^ Focused spec found.
+        fspecify 'test' do; end
+        ^^^^^^^^^^^^^^^ Focused spec found.
+        focus 'test' do; end
+        ^^^^^^^^^^^^ Focused spec found.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        describe 'test' do; end
+        RSpec.describe 'test' do; end
+        feature 'test' do; end
+        context 'test' do; end
+        it 'test' do; end
+        scenario 'test' do; end
+        example 'test' do; end
+        specify 'test' do; end
+        focus 'test' do; end
+      RUBY
+    end
+
+    it 'flags rspec example blocks that include `:focus` preceding a hash' do
+      expect_offense(<<-RUBY)
+        describe 'test', :focus, js: true do; end
+                         ^^^^^^ Focused spec found.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        describe 'test', js: true do; end
+      RUBY
+    end
   end
-  # rubocop:enable RSpec/ExampleLength
 
-  it 'does not flag unfocused specs' do
-    expect_no_offenses(<<-RUBY)
-      xcontext      'test' do; end
-      xscenario     'test' do; end
-      xspecify      'test' do; end
-      describe      'test' do; end
-      example       'test' do; end
-      xexample      'test' do; end
-      scenario      'test' do; end
-      specify       'test' do; end
-      xit           'test' do; end
-      feature       'test' do; end
-      xfeature      'test' do; end
-      context       'test' do; end
-      it            'test' do; end
-      example_group 'test' do; end
-      xdescribe     'test' do; end
-    RUBY
-  end
+  context 'when autocorrect is disabled' do
+    let(:cop_config) { { 'AutoCorrect' => false } }
 
-  it 'flags a method that is focused twice' do
-    expect_offense(<<-RUBY)
-      fit "foo", :focus do
-      ^^^^^^^^^^^^^^^^^ Focused spec found.
-      end
-    RUBY
+    it 'flags all rspec example blocks with that include `focus: true`' do
+      expect_offense(<<-RUBY)
+        example 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+        xit 'test', meta: true, focus: true do; end
+                                ^^^^^^^^^^^ Focused spec found.
+        describe 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        RSpec.describe 'test', meta: true, focus: true do; end
+                                           ^^^^^^^^^^^ Focused spec found.
+        it 'test', meta: true, focus: true do; end
+                               ^^^^^^^^^^^ Focused spec found.
+        xspecify 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        specify 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+        example_group 'test', meta: true, focus: true do; end
+                                          ^^^^^^^^^^^ Focused spec found.
+        scenario 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        xexample 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        xdescribe 'test', meta: true, focus: true do; end
+                                      ^^^^^^^^^^^ Focused spec found.
+        context 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+        xcontext 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        feature 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+        xfeature 'test', meta: true, focus: true do; end
+                                     ^^^^^^^^^^^ Focused spec found.
+        xscenario 'test', meta: true, focus: true do; end
+                                      ^^^^^^^^^^^ Focused spec found.
+        pending 'test', meta: true, focus: true do; end
+                                    ^^^^^^^^^^^ Focused spec found.
+      RUBY
 
-    expect_correction(<<-RUBY)
-      it "foo" do
-      end
-    RUBY
-  end
+      expect_no_corrections
+    end
 
-  it 'ignores non-rspec code with :focus blocks' do
-    expect_no_offenses(<<-RUBY)
-      some_method "foo", focus: true do
-      end
-    RUBY
-  end
+    it 'flags all rspec example blocks that include `:focus`' do
+      expect_offense(<<-RUBY)
+        example_group 'test', :focus do; end
+                              ^^^^^^ Focused spec found.
+        feature 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+        xexample 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        xdescribe 'test', :focus do; end
+                          ^^^^^^ Focused spec found.
+        xscenario 'test', :focus do; end
+                          ^^^^^^ Focused spec found.
+        specify 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+        example 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+        xfeature 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        xspecify 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        scenario 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        describe 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        RSpec.describe 'test', :focus do; end
+                               ^^^^^^ Focused spec found.
+        xit 'test', :focus do; end
+                    ^^^^^^ Focused spec found.
+        context 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+        xcontext 'test', :focus do; end
+                         ^^^^^^ Focused spec found.
+        it 'test', :focus do; end
+                   ^^^^^^ Focused spec found.
+        pending 'test', :focus do; end
+                        ^^^^^^ Focused spec found.
+      RUBY
 
-  it 'flags focused block types' do # rubocop:disable RSpec/ExampleLength
-    expect_offense(<<-RUBY)
-      fdescribe 'test' do; end
-      ^^^^^^^^^^^^^^^^ Focused spec found.
-      RSpec.fdescribe 'test' do; end
-      ^^^^^^^^^^^^^^^^^^^^^^ Focused spec found.
-      ffeature 'test' do; end
-      ^^^^^^^^^^^^^^^ Focused spec found.
-      fcontext 'test' do; end
-      ^^^^^^^^^^^^^^^ Focused spec found.
-      fit 'test' do; end
-      ^^^^^^^^^^ Focused spec found.
-      fscenario 'test' do; end
-      ^^^^^^^^^^^^^^^^ Focused spec found.
-      fexample 'test' do; end
-      ^^^^^^^^^^^^^^^ Focused spec found.
-      fspecify 'test' do; end
-      ^^^^^^^^^^^^^^^ Focused spec found.
-      focus 'test' do; end
-      ^^^^^^^^^^^^ Focused spec found.
-    RUBY
+      expect_no_corrections
+    end
 
-    expect_correction(<<-RUBY)
-      describe 'test' do; end
-      RSpec.describe 'test' do; end
-      feature 'test' do; end
-      context 'test' do; end
-      it 'test' do; end
-      scenario 'test' do; end
-      example 'test' do; end
-      specify 'test' do; end
-      focus 'test' do; end
-    RUBY
-  end
+    it 'does not flag unfocused specs' do
+      expect_no_offenses(<<-RUBY)
+        xcontext      'test' do; end
+        xscenario     'test' do; end
+        xspecify      'test' do; end
+        describe      'test' do; end
+        example       'test' do; end
+        xexample      'test' do; end
+        scenario      'test' do; end
+        specify       'test' do; end
+        xit           'test' do; end
+        feature       'test' do; end
+        xfeature      'test' do; end
+        context       'test' do; end
+        it            'test' do; end
+        example_group 'test' do; end
+        xdescribe     'test' do; end
+      RUBY
+    end
 
-  it 'flags rspec example blocks that include `:focus` preceding a hash' do
-    expect_offense(<<-RUBY)
-      describe 'test', :focus, js: true do; end
-                       ^^^^^^ Focused spec found.
-    RUBY
+    it 'flags a method that is focused twice' do
+      expect_offense(<<-RUBY)
+        fit "foo", :focus do
+        ^^^^^^^^^^^^^^^^^ Focused spec found.
+        end
+      RUBY
 
-    expect_correction(<<-RUBY)
-      describe 'test', js: true do; end
-    RUBY
+      expect_no_corrections
+    end
+
+    it 'ignores non-rspec code with :focus blocks' do
+      expect_no_offenses(<<-RUBY)
+        some_method "foo", focus: true do
+        end
+      RUBY
+    end
+
+    it 'flags focused block types' do # rubocop:disable RSpec/ExampleLength
+      expect_offense(<<-RUBY)
+        fdescribe 'test' do; end
+        ^^^^^^^^^^^^^^^^ Focused spec found.
+        RSpec.fdescribe 'test' do; end
+        ^^^^^^^^^^^^^^^^^^^^^^ Focused spec found.
+        ffeature 'test' do; end
+        ^^^^^^^^^^^^^^^ Focused spec found.
+        fcontext 'test' do; end
+        ^^^^^^^^^^^^^^^ Focused spec found.
+        fit 'test' do; end
+        ^^^^^^^^^^ Focused spec found.
+        fscenario 'test' do; end
+        ^^^^^^^^^^^^^^^^ Focused spec found.
+        fexample 'test' do; end
+        ^^^^^^^^^^^^^^^ Focused spec found.
+        fspecify 'test' do; end
+        ^^^^^^^^^^^^^^^ Focused spec found.
+        focus 'test' do; end
+        ^^^^^^^^^^^^ Focused spec found.
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'flags rspec example blocks that include `:focus` preceding a hash' do
+      expect_offense(<<-RUBY)
+        describe 'test', :focus, js: true do; end
+                         ^^^^^^ Focused spec found.
+      RUBY
+
+      expect_no_corrections
+    end
   end
 end


### PR DESCRIPTION
Background:
- The `RSpec/Focus` cop is very useful in preventing developers from accidentally committing focused specs, which skips all other specs in a suite.
- In certain editors, rubocop can be configured to run on save, with autocorrect enabled, which automatically applies corrections with cops considered "autocorrectable"
- In the case of the `RSpec/Focus` cop, if you are developing a test and want to focus it, and you have autocorrect configured in your editor, when you save the file it will remove any focused specs.

Therefore:
- This PR introduces AutoCorrect configurability to the `RSpec/Focus` cop
- Developers can choose whether they want the `RSpec/Focus` cop to automatically correct violations, or only notify.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [na] Added the new cop to `config/default.yml`.
* [na] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [na] The cop documents examples of good and bad code.
* [na] The tests assert both that bad code is reported and that good code is not reported.
* [na] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
