### PR TITLE
Set `rubygems_mfa_required` in gemspec

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -33,7 +33,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     'changelog_uri' => 'https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md',
-    'documentation_uri' => 'https://docs.rubocop.org/rubocop-rspec/'
+    'documentation_uri' => 'https://docs.rubocop.org/rubocop-rspec/',
+    'rubygems_mfa_required' => 'true'
   }
 
   spec.add_runtime_dependency 'rubocop', '~> 1.19'


### PR DESCRIPTION
Ruby gems now allows MFA to be required for pushes: https://guides.rubygems.org/mfa-requirement-opt-in/
This allows users to have confidence that the actual authors were responsible for updates (obviously that doesn't mean that it can't be a malicious update, but at least it's not from someone who got access to a pusher's account).

Follows rubocop/rubocop#10239. Update gemspec to require MFA for privileged operations.