### PR TITLE
Exclude task type specs from RSpec/DescribeClass cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * [#1215](https://github.com/rubocop/rubocop-rails/pull/1215): Add new `RSpec/FactoryBot/SyntaxMethods` cop. ([@leoarnold][])
+* Exclude `task` type specs from `RSpec/DescribeClass` cop. ([@harry-graham][])
 
 ## 2.6.0 (2021-11-08)
 
@@ -654,3 +655,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@francois-ferrandis]: https://github.com/francois-ferrandis
 [@r7kamura]: https://github.com/r7kamura
 [@leoarnold]: https://github.com/leoarnold
+[@harry-graham]: https://github.com/harry-graham

--- a/config/default.yml
+++ b/config/default.yml
@@ -196,8 +196,9 @@ RSpec/DescribeClass:
       - system
       - mailbox
       - aruba
+      - task
   VersionAdded: '1.0'
-  VersionChanged: '2.5'
+  VersionChanged: '2.7'
   StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
 
 RSpec/DescribeMethod:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -399,7 +399,7 @@ end
 | Yes
 | No
 | 1.0
-| 2.5
+| 2.7
 |===
 
 Check that the first argument to the top-level describe is a constant.
@@ -451,7 +451,7 @@ end
 | Array
 
 | IgnoredMetadata
-| `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox", "aruba"]}`
+| `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox", "aruba", "task"]}`
 | 
 |===
 


### PR DESCRIPTION
Exclude `task` type specs from `RSpec/DescribeClass` cop.

This gives an option for rake task specs to be excluded from this cop, which would otherwise always be flagged.

fixes #1218 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
