### PR TITLE
Fix RedundantMethodDispatchNode offense

### DIFF
--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -161,7 +161,7 @@ module RuboCop
             def call_with_block_replacement(node)
               block = node.body
               arguments = build_arguments(block, node.receiver.source)
-              replacement = format_receiver(block.send_node.receiver)
+              replacement = format_receiver(block.receiver)
               replacement += format_method_call(block, 'create_list', arguments)
               replacement += format_block(block)
               replacement


### PR DESCRIPTION
InternalAffairs/RedundantMethodDispatchNode cop was added in https://github.com/rubocop/rubocop/pull/10312

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
