### PR TITLE
Add Ruby 3.1 release to the matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
           - 2.7
           - "3.0"
           - "3.1"
+          - ruby-head
           - jruby
         task:
           - internal_investigation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           - 2.6
           - 2.7
           - "3.0"
-          - ruby-head
+          - "3.1"
           - jruby
         task:
           - internal_investigation


### PR DESCRIPTION
3.1.0 was released https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

Follow-up to #1211, but to avoid occidental failures with `ruby-head` that supposedly tracks the ongoing development of a potentially breaking Ruby 3.2.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).