### PR TITLE
Fix RSpec/LeadingSubject failure in non-spec code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add new `RSpec/FactoryBot/SyntaxMethods` cop. ([@leoarnold][])
 * Exclude `task` type specs from `RSpec/DescribeClass` cop. ([@harry-graham][])
 * Fix `RSpec/FactoryBot/SyntaxMethods` and `RSpec/Capybara/FeatureMethods` to inspect shared groups. ([@pirj][])
+* Fix `RSpec/LeadingSubject` failure in non-spec code. ([@pirj][])
 
 ## 2.6.0 (2021-11-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add new `RSpec/FactoryBot/SyntaxMethods` cop. ([@leoarnold][])
 * Exclude `task` type specs from `RSpec/DescribeClass` cop. ([@harry-graham][])
+* Fix `RSpec/FactoryBot/SyntaxMethods` and `RSpec/Capybara/FeatureMethods` to inspect shared groups. ([@pirj][])
 
 ## 2.6.0 (2021-11-08)
 

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -17,22 +17,16 @@ module RuboCop
       class EmptyLineAfterSubject < Base
         extend AutoCorrector
         include EmptyLineSeparation
+        include InsideExampleGroup
 
         MSG = 'Add an empty line after `%<subject>s`.'
 
         def on_block(node)
-          return unless subject?(node) && !in_spec_block?(node)
+          return unless subject?(node)
+          return unless inside_example_group?(node)
 
           missing_separating_line_offense(node) do |method|
             format(MSG, subject: method)
-          end
-        end
-
-        private
-
-        def in_spec_block?(node)
-          node.each_ancestor(:block).any? do |ancestor|
-            Examples.all(ancestor.method_name)
           end
         end
       end

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -33,11 +33,13 @@ module RuboCop
       #
       class LeadingSubject < Base
         extend AutoCorrector
+        include InsideExampleGroup
 
         MSG = 'Declare `subject` above any other `%<offending>s` declarations.'
 
         def on_block(node)
-          return unless subject?(node) && !in_spec_block?(node)
+          return unless subject?(node)
+          return unless inside_example_group?(node)
 
           check_previous_nodes(node)
         end
@@ -77,12 +79,6 @@ module RuboCop
             example?(node) ||
             spec_group?(node) ||
             include?(node)
-        end
-
-        def in_spec_block?(node)
-          node.each_ancestor(:block).any? do |ancestor|
-            example?(ancestor)
-          end
         end
       end
     end

--- a/lib/rubocop/cop/rspec/mixin/inside_example_group.rb
+++ b/lib/rubocop/cop/rspec/mixin/inside_example_group.rb
@@ -9,11 +9,11 @@ module RuboCop
         private
 
         def inside_example_group?(node)
-          return example_group?(node) if example_group_root?(node)
+          return spec_group?(node) if example_group_root?(node)
 
           root = node.ancestors.find { |parent| example_group_root?(parent) }
 
-          example_group?(root)
+          spec_group?(root)
         end
 
         def example_group_root?(node)

--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -87,6 +87,21 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     RUBY
   end
 
+  it 'flags violations inside shared groups' do
+    expect_offense(<<-RUBY)
+      RSpec.shared_examples_for 'common scenarios' do
+        feature 'Foo' do; end
+        ^^^^^^^ Use `describe` instead of `feature`.
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.shared_examples_for 'common scenarios' do
+        describe 'Foo' do; end
+      end
+    RUBY
+  end
+
   it 'ignores variables inside examples' do
     expect_no_offenses(<<-RUBY)
       it 'is valid code' do

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -57,19 +57,6 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     RUBY
   end
 
-  it 'does not register an offense for subjects in tests' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        # This shouldn't really ever happen in a sane codebase but I still
-        # want to avoid false positives
-        it "doesn't mind me calling a method called subject in the test" do
-          subject { bar }
-          let(foo)
-        end
-      end
-    RUBY
-  end
-
   it 'does not register an offense for multiline subject block' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/factory_bot/syntax_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/syntax_methods_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::SyntaxMethods, :config do
       RUBY
     end
 
+    it "registers an offense for `FactoryBot.#{method}` in a shared group" do
+      expect_offense(<<~RUBY)
+        shared_examples_for Foo do
+          let(:bar) { FactoryBot.#{method}(:bar) }
+                      ^^^^^^^^^^^#{'^' * method.length} Use `#{method}` from `FactoryBot::Syntax::Methods`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        shared_examples_for Foo do
+          let(:bar) { #{method}(:bar) }
+        end
+      RUBY
+    end
+
     it "registers an offense for `::FactoryBot.#{method}`" do
       expect_offense(<<~RUBY)
         RSpec.describe Foo do

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -279,4 +279,14 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
   end
+
+  it 'does not register an offence for subject in arbitrary code' do
+    expect_no_offenses(<<-RUBY)
+      module Support
+        subject do
+          test
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
fixes #1220

Along the way, fix RSpec/FactoryBot/SyntaxMethods and RSpec/Capybara/FeatureMethods cops to inspect in shared groups.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).