### PR TITLE
Add style guide references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix `RSpec/FactoryBot/SyntaxMethods` and `RSpec/Capybara/FeatureMethods` to inspect shared groups. ([@pirj][])
 * Fix `RSpec/LeadingSubject` failure in non-spec code. ([@pirj][])
 * Add bad example to `RSpec/SubjectStub` cop. ([@oshiro3][])
+* Replace non-styleguide cops `StyleGuide` attribute with `Reference`. ([@pirj][])
 
 ## 2.7.0 (2021-12-26)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,6 +1,7 @@
 ---
 RSpec:
   Enabled: true
+  StyleGuideBaseURL: https://rspec.rubystyle.guide
   Include: &1
     - "**/*_spec.rb"
     - "**/spec/**/*"
@@ -113,37 +114,39 @@ RSpec/AlignLeftLetBrace:
   Description: Checks that left braces for adjacent single line lets are aligned.
   Enabled: false
   VersionAdded: '1.16'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignLeftLetBrace
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignLeftLetBrace
 
 RSpec/AlignRightLetBrace:
   Description: Checks that right braces for adjacent single line lets are aligned.
   Enabled: false
   VersionAdded: '1.16'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignRightLetBrace
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignRightLetBrace
 
 RSpec/AnyInstance:
   Description: Check that instances are not being stubbed globally.
   Enabled: true
   VersionAdded: '1.4'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AnyInstance
+  StyleGuide: https://rspec.rubystyle.guide/#any_instance_of
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AnyInstance
 
 RSpec/AroundBlock:
   Description: Checks that around blocks actually run the test.
   Enabled: true
   VersionAdded: '1.11'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AroundBlock
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AroundBlock
 
 RSpec/Be:
   Description: Check for expectations where `be` is used without argument.
   Enabled: true
   VersionAdded: '1.25'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Be
+  StyleGuide: https://rspec.rubystyle.guide/#be-matcher
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Be
 
 RSpec/BeEql:
   Description: Check for expectations where `be(...)` can replace `eql(...)`.
   Enabled: true
   VersionAdded: '1.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEql
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEql
 
 RSpec/BeforeAfterAll:
   Description: Check that before/after(:all) isn't being used.
@@ -153,13 +156,15 @@ RSpec/BeforeAfterAll:
     - spec/rails_helper.rb
     - spec/support/**/*.rb
   VersionAdded: '1.12'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll
+  StyleGuide: https://rspec.rubystyle.guide/#avoid-hooks-with-context-scope
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll
 
 RSpec/ContextMethod:
   Description: "`context` should not be used for specifying methods."
   Enabled: true
   VersionAdded: '1.36'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextMethod
+  StyleGuide: https://rspec.rubystyle.guide/#example-group-naming
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextMethod
 
 RSpec/ContextWording:
   Description: Checks that `context` docstring starts with an allowed prefix.
@@ -170,7 +175,8 @@ RSpec/ContextWording:
     - without
   VersionAdded: '1.20'
   VersionChanged: 1.20.1
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
+  StyleGuide: https://rspec.rubystyle.guide/#context-descriptions
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
 
 RSpec/DescribeClass:
   Description: Check that the first argument to the top-level describe is a constant.
@@ -199,19 +205,19 @@ RSpec/DescribeClass:
       - task
   VersionAdded: '1.0'
   VersionChanged: '2.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
 
 RSpec/DescribeMethod:
   Description: Checks that the second argument to `describe` specifies a method.
   Enabled: true
   VersionAdded: '1.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeMethod
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeMethod
 
 RSpec/DescribeSymbol:
   Description: Avoid describing symbols.
   Enabled: true
   VersionAdded: '1.15'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeSymbol
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeSymbol
 
 RSpec/DescribedClass:
   Description: Checks that tests use `described_class`.
@@ -224,64 +230,69 @@ RSpec/DescribedClass:
   SafeAutoCorrect: false
   VersionAdded: '1.0'
   VersionChanged: '1.11'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass
 
 RSpec/DescribedClassModuleWrapping:
   Description: Avoid opening modules and defining specs within them.
   Enabled: false
   VersionAdded: '1.37'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClassModuleWrapping
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClassModuleWrapping
 
 RSpec/Dialect:
   Description: This cop enforces custom RSpec dialects.
   Enabled: false
   PreferredMethods: {}
   VersionAdded: '1.33'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Dialect
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Dialect
 
 RSpec/EmptyExampleGroup:
   Description: Checks if an example group does not include any tests.
   Enabled: true
   VersionAdded: '1.7'
   VersionChanged: '2.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
 
 RSpec/EmptyHook:
   Description: Checks for empty before and after hooks.
   Enabled: true
   VersionAdded: '1.39'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyHook
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyHook
 
 RSpec/EmptyLineAfterExample:
   Description: Checks if there is an empty line after example blocks.
   Enabled: true
   AllowConsecutiveOneLiners: true
   VersionAdded: '1.36'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExample
+  StyleGuide: https://rspec.rubystyle.guide/#empty-lines-around-examples
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExample
 
 RSpec/EmptyLineAfterExampleGroup:
   Description: Checks if there is an empty line after example group blocks.
   Enabled: true
   VersionAdded: '1.27'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExampleGroup
+  StyleGuide: https://rspec.rubystyle.guide/#empty-lines-between-describes
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExampleGroup
 
 RSpec/EmptyLineAfterFinalLet:
   Description: Checks if there is an empty line after the last let block.
   Enabled: true
   VersionAdded: '1.14'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterFinalLet
+  StyleGuide: https://rspec.rubystyle.guide/#empty-line-after-let
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterFinalLet
 
 RSpec/EmptyLineAfterHook:
   Description: Checks if there is an empty line after hook blocks.
   Enabled: true
   VersionAdded: '1.27'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterHook
+  StyleGuide: https://rspec.rubystyle.guide/#empty-line-after-let
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterHook
 
 RSpec/EmptyLineAfterSubject:
   Description: Checks if there is an empty line after subject block.
   Enabled: true
   VersionAdded: '1.14'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterSubject
+  StyleGuide: https://rspec.rubystyle.guide/#empty-line-after-let
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterSubject
 
 RSpec/ExampleLength:
   Description: Checks for long examples.
@@ -290,7 +301,7 @@ RSpec/ExampleLength:
   CountAsOne: []
   VersionAdded: '1.5'
   VersionChanged: '2.3'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength
 
 RSpec/ExampleWithoutDescription:
   Description: Checks for examples without a description.
@@ -301,13 +312,13 @@ RSpec/ExampleWithoutDescription:
     - single_line_only
     - disallow
   VersionAdded: '1.22'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWithoutDescription
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWithoutDescription
 
 RSpec/ExcessiveDocstringSpacing:
   Description: Checks for excessive whitespace in example descriptions.
   Enabled: pending
   VersionAdded: '2.5'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExcessiveDocstringSpacing
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExcessiveDocstringSpacing
 
 RSpec/ExampleWording:
   Description: Checks for common mistakes in example descriptions.
@@ -320,7 +331,8 @@ RSpec/ExampleWording:
   IgnoredWords: []
   VersionAdded: '1.0'
   VersionChanged: '1.2'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
+  StyleGuide: https://rspec.rubystyle.guide/#should-in-example-docstrings
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
 
 RSpec/ExpectActual:
   Description: Checks for `expect(...)` calls containing literal values.
@@ -328,7 +340,7 @@ RSpec/ExpectActual:
   Exclude:
     - spec/routing/**/*
   VersionAdded: '1.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectActual
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectActual
 
 RSpec/ExpectChange:
   Description: Checks for consistent style of change matcher.
@@ -340,19 +352,19 @@ RSpec/ExpectChange:
   SafeAutoCorrect: false
   VersionAdded: '1.22'
   VersionChanged: '2.5'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
 
 RSpec/ExpectInHook:
   Description: Do not use `expect` in hooks such as `before`.
   Enabled: true
   VersionAdded: '1.16'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook
 
 RSpec/ExpectOutput:
   Description: Checks for opportunities to use `expect { ... }.to output`.
   Enabled: true
   VersionAdded: '1.10'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectOutput
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectOutput
 
 RSpec/FilePath:
   Description: Checks that spec file paths are consistent and well-formed.
@@ -367,14 +379,14 @@ RSpec/FilePath:
   SpecSuffixOnly: false
   VersionAdded: '1.2'
   VersionChanged: '1.40'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FilePath
 
 RSpec/Focus:
   Description: Checks if examples are focused.
   Enabled: true
   VersionAdded: '1.5'
   VersionChanged: '2.1'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Focus
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Focus
 
 RSpec/HookArgument:
   Description: Checks the arguments passed to `before`, `around`, and `after`.
@@ -385,25 +397,27 @@ RSpec/HookArgument:
     - each
     - example
   VersionAdded: '1.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HookArgument
+  StyleGuide: https://rspec.rubystyle.guide/#redundant-beforeeach
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HookArgument
 
 RSpec/HooksBeforeExamples:
   Description: Checks for before/around/after hooks that come after an example.
   Enabled: true
   VersionAdded: '1.29'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HooksBeforeExamples
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HooksBeforeExamples
 
 RSpec/IdenticalEqualityAssertion:
   Description: Checks for equality assertions with identical expressions on both sides.
   Enabled: pending
   VersionAdded: '2.4'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IdenticalEqualityAssertion
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IdenticalEqualityAssertion
 
 RSpec/ImplicitBlockExpectation:
   Description: Check that implicit block expectation syntax is not used.
   Enabled: true
   VersionAdded: '1.35'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitBlockExpectation
+  StyleGuide: https://rspec.rubystyle.guide/#implicit-block-expectations
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitBlockExpectation
 
 RSpec/ImplicitExpect:
   Description: Check that a consistent implicit expectation style is used.
@@ -413,7 +427,8 @@ RSpec/ImplicitExpect:
     - is_expected
     - should
   VersionAdded: '1.8'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitExpect
+  StyleGuide: https://rspec.rubystyle.guide/#use-expect
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitExpect
 
 RSpec/ImplicitSubject:
   Description: Checks for usage of implicit subject (`is_expected` / `should`).
@@ -425,13 +440,13 @@ RSpec/ImplicitSubject:
     - disallow
   VersionAdded: '1.29'
   VersionChanged: '1.30'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitSubject
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitSubject
 
 RSpec/InstanceSpy:
   Description: Checks for `instance_double` used with `have_received`.
   Enabled: true
   VersionAdded: '1.12'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceSpy
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceSpy
 
 RSpec/InstanceVariable:
   Description: Checks for instance variable usage in specs.
@@ -439,7 +454,8 @@ RSpec/InstanceVariable:
   AssignmentOnly: false
   VersionAdded: '1.0'
   VersionChanged: '1.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceVariable
+  StyleGuide: https://rspec.rubystyle.guide/#instance-variables
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceVariable
 
 RSpec/ItBehavesLike:
   Description: Checks that only one `it_behaves_like` style is used.
@@ -449,45 +465,47 @@ RSpec/ItBehavesLike:
     - it_behaves_like
     - it_should_behave_like
   VersionAdded: '1.13'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ItBehavesLike
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ItBehavesLike
 
 RSpec/IteratedExpectation:
   Description: Check that `all` matcher is used instead of iterating over an array.
   Enabled: true
   VersionAdded: '1.14'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IteratedExpectation
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IteratedExpectation
 
 RSpec/LeadingSubject:
   Description: Enforce that subject is the first definition in the test.
   Enabled: true
   VersionAdded: '1.7'
   VersionChanged: '1.14'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeadingSubject
+  StyleGuide: https://rspec.rubystyle.guide/#leading-subject
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeadingSubject
 
 RSpec/LeakyConstantDeclaration:
   Description: Checks that no class, module, or constant is declared.
   Enabled: true
   VersionAdded: '1.35'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration
+  StyleGuide: https://rspec.rubystyle.guide/#declare-constants
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration
 
 RSpec/LetBeforeExamples:
   Description: Checks for `let` definitions that come after an example.
   Enabled: true
   VersionAdded: '1.16'
   VersionChanged: '1.22'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetBeforeExamples
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetBeforeExamples
 
 RSpec/LetSetup:
   Description: Checks unreferenced `let!` calls being used for test setup.
   Enabled: true
   VersionAdded: '1.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetSetup
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetSetup
 
 RSpec/MessageChain:
   Description: Check that chains of messages are not being stubbed.
   Enabled: true
   VersionAdded: '1.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageChain
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageChain
 
 RSpec/MessageExpectation:
   Description: Checks for consistent message expectation style.
@@ -498,7 +516,7 @@ RSpec/MessageExpectation:
     - expect
   VersionAdded: '1.7'
   VersionChanged: '1.8'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageExpectation
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageExpectation
 
 RSpec/MessageSpies:
   Description: Checks that message expectations are set using spies.
@@ -508,19 +526,19 @@ RSpec/MessageSpies:
     - have_received
     - receive
   VersionAdded: '1.9'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageSpies
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageSpies
 
 RSpec/MissingExampleGroupArgument:
   Description: Checks that the first argument to an example group is not empty.
   Enabled: true
   VersionAdded: '1.28'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExampleGroupArgument
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExampleGroupArgument
 
 RSpec/MultipleDescribes:
   Description: Checks for multiple top-level example groups.
   Enabled: true
   VersionAdded: '1.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleDescribes
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleDescribes
 
 RSpec/MultipleExpectations:
   Description: Checks if examples contain too many `expect` calls.
@@ -528,7 +546,8 @@ RSpec/MultipleExpectations:
   Max: 1
   VersionAdded: '1.7'
   VersionChanged: '1.21'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
+  StyleGuide: https://rspec.rubystyle.guide/#expectation-per-example
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 
 RSpec/MultipleMemoizedHelpers:
   Description: Checks if example groups contain too many `let` and `subject` calls.
@@ -536,20 +555,22 @@ RSpec/MultipleMemoizedHelpers:
   AllowSubject: true
   Max: 5
   VersionAdded: '1.43'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleMemoizedHelpers
+  StyleGuide: https://rspec.rubystyle.guide/#let-blocks
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleMemoizedHelpers
 
 RSpec/MultipleSubjects:
   Description: Checks if an example group defines `subject` multiple times.
   Enabled: true
   VersionAdded: '1.16'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleSubjects
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleSubjects
 
 RSpec/NamedSubject:
   Description: Checks for explicitly referenced test subjects.
   Enabled: true
   IgnoreSharedExamples: true
   VersionAdded: 1.5.3
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
+  StyleGuide: https://rspec.rubystyle.guide/#use-subject
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
 RSpec/NestedGroups:
   Description: Checks for nested example groups.
@@ -557,7 +578,7 @@ RSpec/NestedGroups:
   Max: 3
   VersionAdded: '1.7'
   VersionChanged: '1.10'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NestedGroups
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NestedGroups
 
 RSpec/NotToNot:
   Description: Checks for consistent method usage for negating expectations.
@@ -567,19 +588,19 @@ RSpec/NotToNot:
     - not_to
     - to_not
   VersionAdded: '1.4'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NotToNot
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NotToNot
 
 RSpec/OverwritingSetup:
   Description: Checks if there is a let/subject that overwrites an existing one.
   Enabled: true
   VersionAdded: '1.14'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/OverwritingSetup
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/OverwritingSetup
 
 RSpec/Pending:
   Description: Checks for any pending or skipped examples.
   Enabled: false
   VersionAdded: '1.25'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Pending
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Pending
 
 RSpec/PredicateMatcher:
   Description: Prefer using predicate matcher over using predicate method directly.
@@ -592,49 +613,50 @@ RSpec/PredicateMatcher:
     - explicit
   SafeAutoCorrect: false
   VersionAdded: '1.16'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
+  StyleGuide: https://rspec.rubystyle.guide/#predicate-matchers
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
 
 RSpec/ReceiveCounts:
   Description: Check for `once` and `twice` receive counts matchers usage.
   Enabled: true
   VersionAdded: '1.26'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveCounts
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveCounts
 
 RSpec/ReceiveNever:
   Description: Prefer `not_to receive(...)` over `receive(...).never`.
   Enabled: true
   VersionAdded: '1.28'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveNever
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveNever
 
 RSpec/RepeatedDescription:
   Description: Check for repeated description strings in example groups.
   Enabled: true
   VersionAdded: '1.9'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedDescription
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedDescription
 
 RSpec/RepeatedExample:
   Description: Check for repeated examples within example groups.
   Enabled: true
   VersionAdded: '1.10'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExample
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExample
 
 RSpec/RepeatedExampleGroupBody:
   Description: Check for repeated describe and context block body.
   Enabled: true
   VersionAdded: '1.38'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupBody
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupBody
 
 RSpec/RepeatedExampleGroupDescription:
   Description: Check for repeated example group descriptions.
   Enabled: true
   VersionAdded: '1.38'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupDescription
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupDescription
 
 RSpec/RepeatedIncludeExample:
   Description: Check for repeated include of shared examples.
   Enabled: true
   VersionAdded: '1.44'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedIncludeExample
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedIncludeExample
 
 RSpec/ReturnFromStub:
   Description: Checks for consistent style of stub's return setting.
@@ -645,63 +667,64 @@ RSpec/ReturnFromStub:
     - block
   VersionAdded: '1.16'
   VersionChanged: '1.22'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReturnFromStub
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReturnFromStub
 
 RSpec/ScatteredLet:
   Description: Checks for let scattered across the example group.
   Enabled: true
   VersionAdded: '1.14'
   VersionChanged: '1.39'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet
 
 RSpec/ScatteredSetup:
   Description: Checks for setup scattered across multiple hooks in an example group.
   Enabled: true
   VersionAdded: '1.10'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredSetup
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredSetup
 
 RSpec/SharedContext:
   Description: Checks for proper shared_context and shared_examples usage.
   Enabled: true
   VersionAdded: '1.13'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedContext
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedContext
 
 RSpec/SharedExamples:
   Description: Enforces use of string to titleize shared examples.
   Enabled: true
   VersionAdded: '1.25'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples
 
 RSpec/SingleArgumentMessageChain:
   Description: Checks that chains of messages contain more than one element.
   Enabled: true
   VersionAdded: '1.9'
   VersionChanged: '1.10'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SingleArgumentMessageChain
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SingleArgumentMessageChain
 
 RSpec/StubbedMock:
   Description: Checks that message expectations do not have a configured response.
   Enabled: true
   VersionAdded: '1.44'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/StubbedMock
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/StubbedMock
 
 RSpec/SubjectDeclaration:
   Description: Ensure that subject is defined using subject helper.
   Enabled: pending
   VersionAdded: '2.5'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectDeclaration
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectDeclaration
 
 RSpec/SubjectStub:
   Description: Checks for stubbed test subjects.
   Enabled: true
   VersionAdded: '1.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
+  StyleGuide: https://rspec.rubystyle.guide/#dont-stub-subject
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
 
 RSpec/UnspecifiedException:
   Description: Checks for a specified error in checking raised errors.
   Enabled: true
   VersionAdded: '1.30'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/UnspecifiedException
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/UnspecifiedException
 
 RSpec/VariableDefinition:
   Description: Checks that memoized helpers names are symbols or strings.
@@ -711,7 +734,7 @@ RSpec/VariableDefinition:
     - symbols
     - strings
   VersionAdded: '1.40'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableDefinition
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableDefinition
 
 RSpec/VariableName:
   Description: Checks that memoized helper names use the configured style.
@@ -723,7 +746,7 @@ RSpec/VariableName:
   IgnoredPatterns: []
   VersionAdded: '1.40'
   VersionChanged: '1.43'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableName
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableName
 
 RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.
@@ -732,19 +755,20 @@ RSpec/VerifiedDoubles:
   IgnoreSymbolicNames: false
   VersionAdded: 1.2.1
   VersionChanged: '1.5'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
+  StyleGuide: https://rspec.rubystyle.guide/#doubles
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
 
 RSpec/VoidExpect:
   Description: This cop checks void `expect()`.
   Enabled: true
   VersionAdded: '1.16'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VoidExpect
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VoidExpect
 
 RSpec/Yield:
   Description: This cop checks for calling a block within a stub.
   Enabled: true
   VersionAdded: '1.32'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Yield
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Yield
 
 RSpec/Capybara:
   Enabled: true
@@ -756,7 +780,7 @@ RSpec/Capybara/CurrentPathExpectation:
   Enabled: true
   VersionAdded: '1.18'
   VersionChanged: '2.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/CurrentPathExpectation
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/CurrentPathExpectation
 
 RSpec/Capybara/FeatureMethods:
   Description: Checks for consistent method usage in feature specs.
@@ -764,14 +788,14 @@ RSpec/Capybara/FeatureMethods:
   EnabledMethods: []
   VersionAdded: '1.17'
   VersionChanged: '2.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
 
 RSpec/Capybara/VisibilityMatcher:
   Description: Checks for boolean visibility in capybara finders.
   Enabled: true
   VersionAdded: '1.39'
   VersionChanged: '2.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/VisibilityMatcher
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/VisibilityMatcher
 
 RSpec/FactoryBot:
   Enabled: true
@@ -787,7 +811,7 @@ RSpec/FactoryBot/AttributeDefinedStatically:
     - features/support/factories/**/*.rb
   VersionAdded: '1.28'
   VersionChanged: '2.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/AttributeDefinedStatically
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/AttributeDefinedStatically
 
 RSpec/FactoryBot/CreateList:
   Description: Checks for create_list usage.
@@ -804,7 +828,7 @@ RSpec/FactoryBot/CreateList:
     - n_times
   VersionAdded: '1.25'
   VersionChanged: '2.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList
 
 RSpec/FactoryBot/FactoryClassName:
   Description: Use string value when setting the class attribute explicitly.
@@ -815,14 +839,14 @@ RSpec/FactoryBot/FactoryClassName:
     - features/support/factories/**/*.rb
   VersionAdded: '1.37'
   VersionChanged: '2.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName
 
 RSpec/FactoryBot/SyntaxMethods:
   Description: Use shorthands from `FactoryBot::Syntax::Methods` in your specs.
   Enabled: pending
   SafeAutoCorrect: false
   VersionAdded: '2.7'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/SyntaxMethods
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/SyntaxMethods
 
 RSpec/Rails:
   Enabled: true
@@ -833,7 +857,7 @@ RSpec/Rails/AvoidSetupHook:
   Description: Checks that tests use RSpec `before` hook over Rails `setup` method.
   Enabled: pending
   VersionAdded: '2.4'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/AvoidSetupHook
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/AvoidSetupHook
 
 RSpec/Rails/HttpStatus:
   Description: Enforces use of symbolic or numeric value to describe HTTP status.
@@ -844,4 +868,4 @@ RSpec/Rails/HttpStatus:
     - symbolic
   VersionAdded: '1.23'
   VersionChanged: '2.0'
-  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -104,6 +104,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#any_instance_of
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AnyInstance
 
 == RSpec/AroundBlock
@@ -182,6 +183,7 @@ expect(foo).to be(true)
 
 === References
 
+* https://rspec.rubystyle.guide/#be-matcher
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Be
 
 == RSpec/BeEql
@@ -284,6 +286,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#avoid-hooks-with-context-scope
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll
 
 == RSpec/ContextMethod
@@ -325,6 +328,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#example-group-naming
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextMethod
 
 == RSpec/ContextWording
@@ -388,6 +392,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#context-descriptions
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
 
 == RSpec/DescribeClass
@@ -888,6 +893,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#empty-lines-around-examples
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExample
 
 == RSpec/EmptyLineAfterExampleGroup
@@ -928,6 +934,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#empty-lines-between-describes
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExampleGroup
 
 == RSpec/EmptyLineAfterFinalLet
@@ -962,6 +969,7 @@ it { does_something }
 
 === References
 
+* https://rspec.rubystyle.guide/#empty-line-after-let
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterFinalLet
 
 == RSpec/EmptyLineAfterHook
@@ -1012,6 +1020,7 @@ it { does_something }
 
 === References
 
+* https://rspec.rubystyle.guide/#empty-line-after-let
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterHook
 
 == RSpec/EmptyLineAfterSubject
@@ -1044,6 +1053,7 @@ let(:foo) { bar }
 
 === References
 
+* https://rspec.rubystyle.guide/#empty-line-after-let
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterSubject
 
 == RSpec/ExampleLength
@@ -1272,6 +1282,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#should-in-example-docstrings
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
 
 == RSpec/ExcessiveDocstringSpacing
@@ -1724,6 +1735,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#redundant-beforeeach
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HookArgument
 
 == RSpec/HooksBeforeExamples
@@ -1829,6 +1841,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#implicit-block-expectations
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitBlockExpectation
 
 == RSpec/ImplicitExpect
@@ -1884,6 +1897,7 @@ it { should be_truthy }
 
 === References
 
+* https://rspec.rubystyle.guide/#use-expect
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitExpect
 
 == RSpec/ImplicitSubject
@@ -2074,6 +2088,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#instance-variables
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceVariable
 
 == RSpec/ItBehavesLike
@@ -2206,6 +2221,7 @@ Enforce that subject is the first definition in the test.
 
 === References
 
+* https://rspec.rubystyle.guide/#leading-subject
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeadingSubject
 
 == RSpec/LeakyConstantDeclaration
@@ -2321,6 +2337,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#declare-constants
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration
 
 == RSpec/LetBeforeExamples
@@ -2701,6 +2718,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#expectation-per-example
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 
 == RSpec/MultipleMemoizedHelpers
@@ -2821,6 +2839,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#let-blocks
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleMemoizedHelpers
 
 == RSpec/MultipleSubjects
@@ -2940,6 +2959,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#use-subject
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
 == RSpec/NestedGroups
@@ -3276,6 +3296,7 @@ expect(foo.something?).to be_truthy
 
 === References
 
+* https://rspec.rubystyle.guide/#predicate-matchers
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
 
 == RSpec/ReceiveCounts
@@ -4023,6 +4044,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#dont-stub-subject
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
 
 == RSpec/UnspecifiedException
@@ -4259,6 +4281,7 @@ end
 
 === References
 
+* https://rspec.rubystyle.guide/#doubles
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
 
 == RSpec/VoidExpect

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -8,7 +8,7 @@ module RuboCop
     class ConfigFormatter
       EXTENSION_ROOT_DEPARTMENT = %r{^(RSpec/)}.freeze
       SUBDEPARTMENTS = %(RSpec/Capybara RSpec/FactoryBot RSpec/Rails)
-      STYLE_GUIDE_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'
+      COP_DOC_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'
 
       def initialize(config, descriptions)
         @config       = config
@@ -27,9 +27,8 @@ module RuboCop
         cops.each_with_object(config.dup) do |cop, unified|
           next if SUBDEPARTMENTS.include?(cop)
 
-          unified[cop] = config.fetch(cop)
-            .merge(descriptions.fetch(cop))
-            .merge('StyleGuide' => STYLE_GUIDE_BASE_URL + cop.sub('RSpec/', ''))
+          unified[cop].merge!(descriptions.fetch(cop))
+          unified[cop]['Reference'] = COP_DOC_BASE_URL + cop.sub('RSpec/', '')
         end
       end
 

--- a/spec/rubocop/rspec/config_formatter_spec.rb
+++ b/spec/rubocop/rspec/config_formatter_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
       },
       'RSpec/Bar' => {
         'Enabled'     => true
+      },
+      'RSpec/Baz' => {
+        'Enabled'     => true,
+        'StyleGuide'  => '#buzz'
       }
     }
   end
@@ -25,6 +29,9 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
       },
       'RSpec/Bar' => {
         'Description' => 'Wow'
+      },
+      'RSpec/Baz' => {
+        'Description' => 'Woof'
       }
     }
   end
@@ -41,12 +48,18 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
       |  Config: 2
       |  Enabled: true
       |  Description: Blah
-      |  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Foo
+      |  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Foo
       |
       |RSpec/Bar:
       |  Enabled: true
       |  Description: Wow
-      |  StyleGuide: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Bar
+      |  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Bar
+      |
+      |RSpec/Baz:
+      |  Enabled: true
+      |  StyleGuide: "#buzz"
+      |  Description: Woof
+      |  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Baz
     YAML
   end
 end


### PR DESCRIPTION
~partially addresses~ fixes #1101. I believe #1101 raised the bar too high, and this PR is sufficient to a desired state.

☣️ ⚠️ This will affect the list of cops that RuboCop will run with `--only-guide-cops` option.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).