### PR TITLE
Add bad example to `RSpec/SubjectStub` cop for nested subject stub 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix `RSpec/FactoryBot/SyntaxMethods` and `RSpec/Capybara/FeatureMethods` to inspect shared groups. ([@pirj][])
 * Fix `RSpec/LeadingSubject` failure in non-spec code. ([@pirj][])
+* Add bad example to `RSpec/SubjectStub` cop. ([@oshiro3][])
 
 ## 2.7.0 (2021-12-26)
 
@@ -661,3 +662,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@r7kamura]: https://github.com/r7kamura
 [@leoarnold]: https://github.com/leoarnold
 [@harry-graham]: https://github.com/harry-graham
+[@oshiro3]: https://github.com/oshiro3

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3980,6 +3980,9 @@ subject(:test_subject) { foo }
 
 Checks for stubbed test subjects.
 
+Checks nested subject stubs for innermost subject definition
+when subject is also defined in parent example groups.
+
 === Examples
 
 [source,ruby]
@@ -3991,6 +3994,20 @@ describe Article do
   it 'indicates that the author is unknown' do
     allow(article).to receive(:author).and_return(nil)
     expect(article.description).to include('by an unknown author')
+  end
+end
+
+# bad
+describe Article do
+  subject(:foo) { Article.new }
+
+  context 'nested subject' do
+    subject(:article) { Article.new }
+
+    it 'indicates that the author is unknown' do
+      allow(article).to receive(:author).and_return(nil)
+      expect(article.description).to include('by an unknown author')
+    end
   end
 end
 

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -7,6 +7,9 @@ module RuboCop
     module RSpec
       # Checks for stubbed test subjects.
       #
+      # Checks nested subject stubs for innermost subject definition
+      # when subject is also defined in parent example groups.
+      #
       # @see https://robots.thoughtbot.com/don-t-stub-the-system-under-test
       # @see https://samphippen.com/introducing-rspec-smells-and-where-to-find-them#smell-1-stubject
       # @see https://github.com/rubocop-hq/rspec-style-guide#dont-stub-subject
@@ -19,6 +22,20 @@ module RuboCop
       #     it 'indicates that the author is unknown' do
       #       allow(article).to receive(:author).and_return(nil)
       #       expect(article.description).to include('by an unknown author')
+      #     end
+      #   end
+      #
+      #   # bad
+      #   describe Article do
+      #     subject(:foo) { Article.new }
+      #
+      #     context 'nested subject' do
+      #       subject(:article) { Article.new }
+      #
+      #       it 'indicates that the author is unknown' do
+      #         allow(article).to receive(:author).and_return(nil)
+      #         expect(article.description).to include('by an unknown author')
+      #       end
       #     end
       #   end
       #


### PR DESCRIPTION
For the SubjectStub rule, I added an explanation as a bad example, because it is not clear from the description that nested subject stubs are not arrowed.

The spec for the nested subject in `SubjectStub` already exists.

https://github.com/rubocop/rubocop-rspec/blob/a8101aeb8607d9265414502aed16b459a077feef/spec/rubocop/cop/rspec/subject_stub_spec.rb#L191-L211

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
