### PR TITLE
Make RSpec/SubjectStub stricter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix `RSpec/LeadingSubject` failure in non-spec code. ([@pirj][])
 * Add bad example to `RSpec/SubjectStub` cop. ([@oshiro3][])
 * Replace non-styleguide cops `StyleGuide` attribute with `Reference`. ([@pirj][])
+* Fix `RSpec/SubjectStub` to disallow stubbing of subjects defined in parent example groups. ([@pirj][])
 
 ## 2.7.0 (2021-12-26)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -717,6 +717,7 @@ RSpec/SubjectStub:
   Description: Checks for stubbed test subjects.
   Enabled: true
   VersionAdded: '1.7'
+  VersionChanged: '2.8'
   StyleGuide: https://rspec.rubystyle.guide/#dont-stub-subject
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3996,7 +3996,7 @@ subject(:test_subject) { foo }
 | Yes
 | No
 | 1.7
-| -
+| 2.8
 |===
 
 Checks for stubbed test subjects.


### PR DESCRIPTION
fixes #1230

Make the cop stricter by also considering stubbing of subjects defined in parent example groups:
```ruby
RSpec.describe Foo do
  subject(:foo) { ... }
  
  describe '#bar' do
    subject(:bar) { foo.bar }

    specify do
      allow(foo).to receive(:baz).and_return(:baz) # <= this wasn't previously considered as an offence
    end
  end
end
```

### Comparison

Running it against [`real-world-rspec`](https://github.com/pirj/real-world-rspec):

Before:
```
55577 files inspected, 1686 offenses detected
rubocop --only RSpec/SubjectStub ~/source/real-world-rspec  1537.45s user 139.80s system 167% cpu 16:42.65 total
```

After:
```
55577 files inspected, 1752 offenses detected
rubocop --only RSpec/SubjectStub ../real-world-rspec  1521.27s user 129.19s system 191% cpu 14:20.72 total
```

~🎉 due to minor optimizations, the cop is now 2x faster.~ - no changes

Less than 100 new offences, details below.

### Newly Discovered Real-World Offences

Basically all in the same category - `subject` is redefined in a child example group, and the subject from parent example group is stubbed (cases 1-5).

Only the last case 6 takes care of redefining the previously defined `subject` with `let`. ✅ - we ignore this.

1.
```ruby
RSpec.describe API::Helpers::Caching, :use_clean_rails_redis_caching do
  subject(:instance) { Class.new.include(described_class, Grape::DSL::Headers).new }

  describe "#cache_action_if" do
    subject do
      instance.cache_action_if(conditional, cache_key, **kwargs) do
        return_value
      end
    end

    it "caches the block" do
      expect(instance).to receive(:cache_action).with(cache_key, **kwargs)

      subject
    end
```

2.
```ruby
RSpec.describe Banzai::ReferenceParser::MergeRequestParser do
  subject(:parser) { described_class.new(Banzai::RenderContext.new(merge_request.target_project, user)) }


  describe '#can_read_reference?' do
    subject { parser.can_read_reference?(user, merge_request) }

    it 'calls #can? only once' do
      expect(parser).to receive(:can?).once

      2.times { parser.can_read_reference?(user, merge_request) }
    end
```

3.
```ruby
RSpec.describe Gitlab::AlertManagement::Payload::Base do
  subject(:parsed_payload) { payload_class.new(project: project, payload: raw_payload) }

  describe '#alert_params' do
    subject { parsed_payload.alert_params }
      before do
        allow(parsed_payload).to receive_messages(stubs)
      end
```

4.
```ruby
RSpec.describe ::Gitlab::Ci::Pipeline::Logger do
  subject(:logger) { described_class.new(project: project) }

  describe '#commit' do
    subject(:commit) { logger.commit(pipeline: pipeline, caller: 'source') }

    before do
      allow(logger).to receive(:current_monotonic_time) { Time.current.to_i }
    end
```

5.
```ruby
RSpec.describe RuboCop::Formatter::JSONFormatter do
  subject(:formatter) { described_class.new(output) }

  describe '#hash_for_file' do
    subject(:hash) { formatter.hash_for_file(file, offenses) }

    before do
      count = 0
      allow(formatter).to receive(:hash_for_offense) do
        count += 1
      end
    end
```

6. ⚠️ ~`return_item` is redefined from `subject` to `let` - seems to be a false positive~ ✅ fixed, we ignore this now
```ruby
RSpec.describe Spree::ReturnItem, type: :model do
  describe "reception_status state_machine" do
    subject(:return_item) { create(:return_item) }

    context 'when transitioning to :received' do
      let(:return_item) { create(:return_item) }
      subject { return_item.receive! }

      # StateMachines has some "smart" code for guessing how many arguments to
      # send to the callback methods that interferes with rspec-mocks.
      around { |e| without_partial_double_verification { e.call } }

      it 'calls #attempt_accept, #check_unexchange, and #process_inventory_unit!' do
        expect(return_item).to receive(:attempt_accept)
        expect(return_item).to receive(:check_unexchange)
        expect(return_item).to receive(:process_inventory_unit!)

        subject
      end
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).