### PR TITLE
Fix a bit of asciidoc formatting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,8 @@ Layout/HashAlignment:
 
 Layout/LineLength:
   Max: 80 # default: 120
+  IgnoredPatterns:
+    - '^\s*# .*https?:\/\/.+\[.+\]\.?$' # Allow long asciidoc links
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/config/default.yml
+++ b/config/default.yml
@@ -791,7 +791,7 @@ RSpec/Capybara/FeatureMethods:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
 
 RSpec/Capybara/VisibilityMatcher:
-  Description: Checks for boolean visibility in capybara finders.
+  Description: Checks for boolean visibility in Capybara finders.
   Enabled: true
   VersionAdded: '1.39'
   VersionChanged: '2.0'

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -14,13 +14,13 @@
 
 Checks that no expectations are set on Capybara's `current_path`.
 
-The `have_current_path` matcher (https://www.rubydoc.info/github/
-teamcapybara/capybara/master/Capybara/RSpecMatchers#have_current_path-
-instance_method) should be used on `page` to set expectations on
-Capybara's current path, since it uses Capybara's waiting
-functionality (https://github.com/teamcapybara/capybara/blob/master/
-README.md#asynchronous-javascript-ajax-and-friends) which ensures that
-preceding actions (like `click_link`) have completed.
+The
+https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/RSpecMatchers#have_current_path-instance_method[`have_current_path` matcher]
+should be used on `page` to set expectations on Capybara's
+current path, since it uses
+https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends[Capybara's waiting functionality]
+which ensures that preceding actions (like `click_link`) have
+completed.
 
 === Examples
 
@@ -118,7 +118,7 @@ end
 | 2.0
 |===
 
-Checks for boolean visibility in capybara finders.
+Checks for boolean visibility in Capybara finders.
 
 Capybara lets you find elements that match a certain visibility using
 the `:visible` option. `:visible` accepts both boolean and symbols as
@@ -126,7 +126,8 @@ values, however using booleans can have unwanted effects. `visible:
 false` does not find just invisible elements, but both visible and
 invisible elements. For expressiveness and clarity, use one of the
 symbol values, `:all`, `:hidden` or `:visible`.
-(https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all)
+Read more in
+https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all[the documentation].
 
 === Examples
 

--- a/docs/modules/ROOT/pages/third_party_rspec_syntax_extensions.adoc
+++ b/docs/modules/ROOT/pages/third_party_rspec_syntax_extensions.adoc
@@ -8,7 +8,7 @@ RuboCop https://docs.rubocop.org/rubocop/configuration.html#inheriting-configura
 
 == Packaging configuration for RuboCop RSpec
 
-NOTE: Due to a [bug](https://github.com/rubocop/rubocop-rspec/issues/1126), this feature doesn't work properly for `rubocop-rspec` 2.5.0 and earlier versions.
+NOTE: Due to https://github.com/rubocop/rubocop-rspec/issues/1126[a bug], this feature doesn't work properly for `rubocop-rspec` 2.5.0 and earlier versions.
 
 For a third-party gem, it's sufficient to follow three steps:
 

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -6,13 +6,13 @@ module RuboCop
       module Capybara
         # Checks that no expectations are set on Capybara's `current_path`.
         #
-        # The `have_current_path` matcher (https://www.rubydoc.info/github/
-        # teamcapybara/capybara/master/Capybara/RSpecMatchers#have_current_path-
-        # instance_method) should be used on `page` to set expectations on
-        # Capybara's current path, since it uses Capybara's waiting
-        # functionality (https://github.com/teamcapybara/capybara/blob/master/
-        # README.md#asynchronous-javascript-ajax-and-friends) which ensures that
-        # preceding actions (like `click_link`) have completed.
+        # The
+        # https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/RSpecMatchers#have_current_path-instance_method[`have_current_path` matcher]
+        # should be used on `page` to set expectations on Capybara's
+        # current path, since it uses
+        # https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends[Capybara's waiting functionality]
+        # which ensures that preceding actions (like `click_link`) have
+        # completed.
         #
         # @example
         #   # bad

--- a/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module RSpec
       module Capybara
-        # Checks for boolean visibility in capybara finders.
+        # Checks for boolean visibility in Capybara finders.
         #
         # Capybara lets you find elements that match a certain visibility using
         # the `:visible` option. `:visible` accepts both boolean and symbols as
@@ -12,7 +12,8 @@ module RuboCop
         # false` does not find just invisible elements, but both visible and
         # invisible elements. For expressiveness and clarity, use one of the
         # symbol values, `:all`, `:hidden` or `:visible`.
-        # (https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all)
+        # Read more in
+        # https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all[the documentation].
         #
         # @example
         #


### PR DESCRIPTION
I noticed a couple of minor layout issues on https://docs.rubocop.org/rubocop-rspec/2.7/third_party_rspec_syntax_extensions.html and https://docs.rubocop.org/rubocop-rspec/2.7/cops_rspec_capybara.html

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
