### PR TITLE
Bump version to 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.8.0 (2022-01-24)
+
 * Fix `RSpec/FactoryBot/SyntaxMethods` and `RSpec/Capybara/FeatureMethods` to inspect shared groups. ([@pirj][])
 * Fix `RSpec/LeadingSubject` failure in non-spec code. ([@pirj][])
 * Add bad example to `RSpec/SubjectStub` cop. ([@oshiro3][])

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: master
+version: '2.8'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.7.0'
+      STRING = '2.8.0'
     end
   end
 end


### PR DESCRIPTION
It's been about a month since our last release. It's mostly minor fixes, but the recent change to `RSpec/SubjectStub` (disallow stubbing of subjects defined in parent example groups) warrants a minor release.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).