### PR TITLE
Add FactoryAssociation cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add bad example to `RSpec/SubjectStub` cop. ([@oshiro3][])
 * Replace non-styleguide cops `StyleGuide` attribute with `Reference`. ([@pirj][])
 * Fix `RSpec/SubjectStub` to disallow stubbing of subjects defined in parent example groups. ([@pirj][])
+* Add `RSpec/FactoryBot/FactoryAssociation` cop. ([@Benaaaaa][])
 
 ## 2.7.0 (2021-12-26)
 
@@ -667,3 +668,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@leoarnold]: https://github.com/leoarnold
 [@harry-graham]: https://github.com/harry-graham
 [@oshiro3]: https://github.com/oshiro3
+[@Benaaaaa]: https://github.com/Benaaaaa

--- a/config/default.yml
+++ b/config/default.yml
@@ -831,6 +831,11 @@ RSpec/FactoryBot/CreateList:
   VersionChanged: '2.0'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList
 
+RSpec/FactoryBot/FactoryAssociation:
+  Description: Checks for 'association' in factories that specify a ':factory' option. 
+  Enabled: pending
+  VersionAdded: '2.8.1'
+
 RSpec/FactoryBot/FactoryClassName:
   Description: Use string value when setting the class attribute explicitly.
   Enabled: true

--- a/lib/rubocop/cop/rspec/factory_bot/factory_association.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/factory_association.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+
+module RuboCop
+  module Cop
+    module RSpec
+      module FactoryBot
+        # This cop looks for 'association' in factories that specify a
+        # ':factory' option and tells you to use explicit build reference
+        # which improves the performance as cascading factories
+        # will not be saved unless needed to
+        #
+        # @example
+        #   #bad
+        #    FactoryBot.define do
+        #      factory :book do
+        #        title { 'Lord of the Rings' }
+        #        association :author
+        #      end
+        #    end
+        #
+        #    FactoryBoy.define do
+        #      factory :book do
+        #        title {'Lord of the Rings'}
+        #        author { association :author }
+        #      end
+        #    end
+        #
+        #    #good
+        #    FactoryBot.define do
+        #      factory :book do
+        #        title { 'Lord of the Rings' }
+        #        author { build(:author) }
+        #      end
+        #    end
+        #
+        #    FactoryBot.define do
+        #      factory :author do
+        #        name { 'J. R. R. Tolkien' }
+        #      end
+        #    end
+        class FactoryAssociation < ::RuboCop::Cop::Base
+          extend AutoCorrector
+
+          MSG = 'Use %<association>s { build(:%<factory>s) } instead'
+
+          # @!method association_definition(node)
+          def_node_matcher :association_definition, <<~PATTERN
+            (send nil? :association (:sym $_) (hash (pair (sym :factory) (:sym $_))) ?)
+          PATTERN
+
+          # @!method inline_association_definition(node)
+          def_node_matcher :inline_association_definition, <<~PATTERN
+            (block (send nil? $_) (args) (send nil? :association (sym $_)))
+          PATTERN
+
+          def on_block(node)
+            inline_association_definition(node) do |association, factory|
+              message = format(MSG, association: association.to_s,
+                                    factory: factory.to_s)
+
+              add_offense(node, message: message) do |corrector|
+                corrector.replace(node, replacement(association, factory))
+              end
+            end
+          end
+
+          def on_send(node)
+            return unless @current_corrector.empty?
+
+            association_definition(node) do |association, factory|
+              factory = [association] if factory.empty?
+
+              message = format(MSG, association: association.to_s,
+                                    factory: factory.first.to_s)
+
+              add_offense(node, message: message) do |corrector|
+                corrector.replace(node, replacement(association, factory.first))
+              end
+            end
+          end
+
+          private
+
+          def expression(node)
+            if node.block_type?
+              inline_association_definition(node)
+            else
+              association_definition(node).flatten
+            end
+          end
+
+          def replacement(association, factory)
+            "#{association} { build(:#{factory}) }"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -6,6 +6,7 @@ require_relative 'rspec/capybara/visibility_matcher'
 
 require_relative 'rspec/factory_bot/attribute_defined_statically'
 require_relative 'rspec/factory_bot/create_list'
+require_relative 'rspec/factory_bot/factory_association'
 require_relative 'rspec/factory_bot/factory_class_name'
 require_relative 'rspec/factory_bot/syntax_methods'
 

--- a/spec/rubocop/cop/rspec/factory_bot/factory_association_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/factory_association_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryAssociation,
+               :config do
+
+  let(:message) do
+    "Use #{association_name} { build(:#{factory_name}) } instead"
+  end
+
+  context 'when association name and factory name are the same' do
+    let(:association_name) { 'foo' }
+    let(:factory_name) { 'foo' }
+
+    it 'autocorrects method' do
+      expect_offense(<<~RUBY)
+        association :foo
+        ^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+
+    it 'autocorrects inline method' do
+      expect_offense(<<~RUBY)
+        foo { association :foo }
+        ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+
+    it 'autocorrects method with explicit factory' do
+      expect_offense(<<~RUBY)
+        association :foo, factory: :foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+
+    it 'autocorrects method in new line' do
+      expect_offense(<<~RUBY)
+        association :foo,
+        ^^^^^^^^^^^^^^^^^ #{message}
+                    factory: :foo
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+
+    it 'allows using build' do
+      expect_no_offenses(<<~RUBY)
+        foo { build(:foo) }
+      RUBY
+    end
+  end
+
+  context 'when association name and factory name differ' do
+    let(:association_name) { 'foo' }
+    let(:factory_name) { 'bar' }
+
+    it 'autocorrects inline method' do
+      expect_offense(<<~RUBY)
+        foo { association :bar }
+        ^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:bar) }
+      RUBY
+    end
+
+    it 'autocorrects method with explicit factory' do
+      expect_offense(<<~RUBY)
+        association :foo, factory: :bar
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{message}
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:bar) }
+      RUBY
+    end
+
+    it 'autocorrects method in new line' do
+      expect_offense(<<~RUBY)
+        association :foo,
+        ^^^^^^^^^^^^^^^^^ #{message}
+                    factory: :bar
+      RUBY
+
+      expect_correction(<<~RUBY)
+        foo { build(:bar) }
+      RUBY
+    end
+
+    it 'autocorrects using build' do
+      expect_no_offenses(<<~RUBY)
+        foo { build(:bar) }
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Add a FactoryAssociation cop which checks for 'associations' in factories that specify a ':factory' option and tells you to use explicit build reference which optimises performance as cascading factories are not saved unless needed to. 

Pics for cascading factory calls 
before:
![old_factory](https://user-images.githubusercontent.com/61794237/154726978-ea2d0f13-6d80-4ff2-afe5-5fd5e22fe396.png)
after:
![new_factory](https://user-images.githubusercontent.com/61794237/154727273-b1428823-c30a-4e99-93b3-ad8528b70890.png)

