### PR TITLE
Exclude initializers from DescribeClass cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -195,6 +195,7 @@ RSpec/DescribeClass:
   Enabled: true
   Exclude:
     - "**/spec/features/**/*"
+    - "**/spec/initializers/**/*"
     - "**/spec/requests/**/*"
     - "**/spec/routing/**/*"
     - "**/spec/system/**/*"


### PR DESCRIPTION
Exclude `spec/initializers` from being enforced by RSpec/DescribeClass cop.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
