### PR TITLE
Fix a typo for `RSpec/BeNil` cop

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -289,7 +289,7 @@ expect(foo).to be(nil)
 Check that `be_nil` is used instead of `be(nil)`.
 
 RSpec has a built-in `be_nil` matcher specifically for expecting `nil`.
-For consistent specs, we recommend using that instead of `be(nil).
+For consistent specs, we recommend using that instead of `be(nil)`.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/be_nil.rb
+++ b/lib/rubocop/cop/rspec/be_nil.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Check that `be_nil` is used instead of `be(nil)`.
       #
       # RSpec has a built-in `be_nil` matcher specifically for expecting `nil`.
-      # For consistent specs, we recommend using that instead of `be(nil).
+      # For consistent specs, we recommend using that instead of `be(nil)`.
       #
       # @example
       #


### PR DESCRIPTION
This PR fixes a typo for `RSpec/BeNil` cop.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
