### PR TITLE
Enable pending cops – prepare for v3.0.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Enabled pending cops (`RSpec/BeEq`, `RSpec/BeNil`, `RSpec/ExcessiveDocstringSpacing`, `RSpec/IdenticalEqualityAssertion`, `RSpec/SubjectDeclaration`, `RSpec/FactoryBot/SyntaxMethods`, and `RSpec/Rails/AvoidSetupHook`). ([@bquorning][])
+
 ## 2.9.0 (2022-02-28)
 
 * Add new `RSpec/BeNil` cop. ([@bquorning][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -144,7 +144,7 @@ RSpec/Be:
 
 RSpec/BeEq:
   Description: Check for expectations where `be(...)` can replace `eq(...)`.
-  Enabled: pending
+  Enabled: true
   VersionAdded: 2.9.0
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEq
 
@@ -156,7 +156,7 @@ RSpec/BeEql:
 
 RSpec/BeNil:
   Description: Check that `be_nil` is used instead of `be(nil)`.
-  Enabled: pending
+  Enabled: true
   VersionAdded: 2.9.0
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeNil
 
@@ -328,7 +328,7 @@ RSpec/ExampleWithoutDescription:
 
 RSpec/ExcessiveDocstringSpacing:
   Description: Checks for excessive whitespace in example descriptions.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.5'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExcessiveDocstringSpacing
 
@@ -420,7 +420,7 @@ RSpec/HooksBeforeExamples:
 
 RSpec/IdenticalEqualityAssertion:
   Description: Checks for equality assertions with identical expressions on both sides.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.4'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IdenticalEqualityAssertion
 
@@ -721,7 +721,7 @@ RSpec/StubbedMock:
 
 RSpec/SubjectDeclaration:
   Description: Ensure that subject is defined using subject helper.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.5'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectDeclaration
 
@@ -856,7 +856,7 @@ RSpec/FactoryBot/FactoryClassName:
 
 RSpec/FactoryBot/SyntaxMethods:
   Description: Use shorthands from `FactoryBot::Syntax::Methods` in your specs.
-  Enabled: pending
+  Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '2.7'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/SyntaxMethods
@@ -868,7 +868,7 @@ RSpec/Rails:
 
 RSpec/Rails/AvoidSetupHook:
   Description: Checks that tests use RSpec `before` hook over Rails `setup` method.
-  Enabled: pending
+  Enabled: true
   VersionAdded: '2.4'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/AvoidSetupHook
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -191,7 +191,7 @@ expect(foo).to be(true)
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 2.9.0
@@ -279,7 +279,7 @@ expect(foo).to be(nil)
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 2.9.0
@@ -1359,7 +1359,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 2.5
@@ -1852,7 +1852,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | No
 | 2.4
@@ -4025,7 +4025,7 @@ expect(foo).to receive(:bar).with(42)
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | No
 | 2.5

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -163,7 +163,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Yes (Unsafe)
 | 2.7

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -5,7 +5,7 @@
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Pending
+| Enabled
 | Yes
 | Yes
 | 2.4

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
-  it 'flags `let` after the first different node ' do
+  it 'flags `let` after the first different node' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }

--- a/spec/rubocop/rspec/example_spec.rb
+++ b/spec/rubocop/rspec/example_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::RSpec::Example, :config do
   end
 
   it 'returns nil for examples without doc strings' do
-    expect(example('it { foo }').doc_string).to be(nil)
+    expect(example('it { foo }').doc_string).to be_nil
   end
 
   it 'extracts keywords' do
@@ -58,12 +58,14 @@ RSpec.describe RuboCop::RSpec::Example, :config do
   end
 
   describe 'value object semantics' do
+    # rubocop:disable RSpec/IdenticalEqualityAssertion
     it 'compares by value' do
       aggregate_failures 'equality semantics' do
         expect(example('it("foo")')).to eq(example('it("foo")'))
         expect(example('it("foo")')).not_to eq(example('it("bar")'))
       end
     end
+    # rubocop:enable RSpec/IdenticalEqualityAssertion
 
     it 'can be used as a key in a hash' do
       hash = {}


### PR DESCRIPTION
As [mentioned in the last release PR](https://github.com/rubocop/rubocop-rspec/pull/1242#issuecomment-1054001111), it’s over a year since we released v2.0.0. Let’s enable all the pending cops and make a v3.0.0 release soon 🎉 

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
