### PR TITLE
Fix doc formatting written in unescaped file path

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -349,7 +349,7 @@ end
 | Name | Default value | Configurable values
 
 | Exclude
-| `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/**/*.rb`
+| `spec/spec_helper.rb`, `spec/rails_helper.rb`, `+spec/support/**/*.rb+`
 | Array
 |===
 
@@ -1431,7 +1431,7 @@ expect(name).to eq("John")
 | Name | Default value | Configurable values
 
 | Exclude
-| `spec/routing/**/*`
+| `+spec/routing/**/*+`
 | Array
 |===
 

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -43,7 +43,7 @@ count { 1 }
 | Name | Default value | Configurable values
 
 | Include
-| `spec/factories.rb`, `spec/factories/**/*.rb`, `features/support/factories/**/*.rb`
+| `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
 | Array
 |===
 
@@ -100,7 +100,7 @@ create_list :user, 3
 | Name | Default value | Configurable values
 
 | Include
-| `+**/*_spec.rb+`, `+**/spec/**/*+`, `spec/factories.rb`, `spec/factories/**/*.rb`, `features/support/factories/**/*.rb`
+| `+**/*_spec.rb+`, `+**/spec/**/*+`, `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
 | Array
 
 | EnforcedStyle
@@ -150,7 +150,7 @@ end
 | Name | Default value | Configurable values
 
 | Include
-| `spec/factories.rb`, `spec/factories/**/*.rb`, `features/support/factories/**/*.rb`
+| `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
 | Array
 |===
 


### PR DESCRIPTION
This fixes an issue where file paths were not escaped and were displayed as follows:
![issue](https://user-images.githubusercontent.com/13041216/156981601-66c19453-75ed-4195-b19a-bbd3c368717e.png)


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
  * [-] Added tests.
* [x] Updated documentation.
  * [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
  * [-] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).