### PR TITLE
[Fix #1244] Fix a false positive for `RSpec/EmptyExampleGroup` when expectations in case statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix a false positive for `RSpec/EmptyExampleGroup` when expectations in case statement. ([@ydah][])
+
 ## 2.9.0 (2022-02-28)
 
 * Add new `RSpec/BeNil` cop. ([@bquorning][])
@@ -672,3 +674,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@leoarnold]: https://github.com/leoarnold
 [@harry-graham]: https://github.com/harry-graham
 [@oshiro3]: https://github.com/oshiro3
+[@ydah]: https://github.com/ydah

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -145,7 +145,7 @@ module RuboCop
           return true unless body
           return false if conditionals_with_examples?(body)
 
-          if body.if_type?
+          if body.if_type? || body.case_type?
             !examples_in_branches?(body)
           else
             !examples?(body)
@@ -153,15 +153,15 @@ module RuboCop
         end
 
         def conditionals_with_examples?(body)
-          return unless body.begin_type?
+          return unless body.begin_type? || body.case_type?
 
-          body.each_descendant(:if).any? do |if_node|
-            examples_in_branches?(if_node)
+          body.each_descendant(:if, :case).any? do |condition_node|
+            examples_in_branches?(condition_node)
           end
         end
 
-        def examples_in_branches?(if_node)
-          if_node.branches.any? { |branch| examples?(branch) }
+        def examples_in_branches?(condition_node)
+          condition_node.branches.any? { |branch| examples?(branch) }
         end
       end
     end

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -110,6 +110,69 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
     RUBY
   end
 
+  it 'ignores example group with examples defined in `case` branches' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        case bar
+        when baz
+          it { expect(result).to be(true) }
+        end
+      end
+
+      describe Foo do
+        case bar
+        when baz
+          it { expect(result).to be(true) }
+        else
+          warn 'Enforce appropriate warnings.'
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores example group with examples but no examples in `case` branches' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        case bar
+        when baz
+          warn 'Enforce appropriate warnings.'
+        end
+
+        it { expect(result).to have_ads }
+      end
+    RUBY
+  end
+
+  it 'flags an empty example group with no examples defined in `case`' \
+    'branches' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+      ^^^^^^^^^^^^ Empty example group detected.
+        case bar
+        when baz
+          warn 'Enforce appropriate warnings.'
+        else
+          warn 'Enforce appropriate warnings.'
+        end
+      end
+
+      describe Foo do
+      ^^^^^^^^^^^^ Empty example group detected.
+        case bar
+        when baz
+        else
+        end
+      end
+
+      describe Foo do
+      ^^^^^^^^^^^^ Empty example group detected.
+        case bar
+        when baz
+        end
+      end
+    RUBY
+  end
+
   it 'ignores example group with examples defined in iterator' do
     expect_no_offenses(<<~RUBY)
       describe 'RuboCop monthly' do


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rspec/issues/1244

This PR fixes a false positive for `RSpec/EmptyExampleGroup` when code like the following:

```ruby
describe Foo do
  case bar
  when baz
    it { expect(result).to be(true) }
  end
end
```

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] ~Updated documentation.~
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).