### PR TITLE
Update documentation after bugfix in RuboCop

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -349,7 +349,7 @@ end
 | Name | Default value | Configurable values
 
 | Exclude
-| `spec/spec_helper.rb`, `spec/rails_helper.rb`, `spec/support/**/*.rb`
+| `spec/spec_helper.rb`, `spec/rails_helper.rb`, `+spec/support/**/*.rb+`
 | Array
 |===
 
@@ -1431,7 +1431,7 @@ expect(name).to eq("John")
 | Name | Default value | Configurable values
 
 | Exclude
-| `spec/routing/**/*`
+| `+spec/routing/**/*+`
 | Array
 |===
 

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -43,7 +43,7 @@ count { 1 }
 | Name | Default value | Configurable values
 
 | Include
-| `spec/factories.rb`, `spec/factories/**/*.rb`, `features/support/factories/**/*.rb`
+| `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
 | Array
 |===
 
@@ -100,7 +100,7 @@ create_list :user, 3
 | Name | Default value | Configurable values
 
 | Include
-| `+**/*_spec.rb+`, `+**/spec/**/*+`, `spec/factories.rb`, `spec/factories/**/*.rb`, `features/support/factories/**/*.rb`
+| `+**/*_spec.rb+`, `+**/spec/**/*+`, `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
 | Array
 
 | EnforcedStyle
@@ -150,7 +150,7 @@ end
 | Name | Default value | Configurable values
 
 | Include
-| `spec/factories.rb`, `spec/factories/**/*.rb`, `features/support/factories/**/*.rb`
+| `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
 | Array
 |===
 


### PR DESCRIPTION
https://github.com/rubocop/rubocop/pull/10444 fixed a bug where e.g. the string `spec/support/**/*.rb` would be rendered in the documentation as the text `spec/support/*/.rb` with the last `/` being bold - because that is how `*/*` is interpreted.