### PR TITLE
Make `RSpec/BeNil` cop configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 ## Master (Unreleased)
-* Add `RSpec/VerifiedDoubleReference` cop. ([@t3h2mas][])
 
 * Fix a false positive for `RSpec/EmptyExampleGroup` when expectations in case statement. ([@ydah][])
+* Add `RSpec/VerifiedDoubleReference` cop. ([@t3h2mas][])
+* Make `RSpec/BeNil` cop configurable with a `be_nil` style and a `be` style. ([@bquorning][])
 
 ## 2.9.0 (2022-02-28)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -155,9 +155,14 @@ RSpec/BeEql:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEql
 
 RSpec/BeNil:
-  Description: Check that `be_nil` is used instead of `be(nil)`.
+  Description: Ensures a consistent style is used when matching `nil`.
   Enabled: pending
+  EnforcedStyle: be_nil
+  SupportedStyles:
+    - be
+    - be_nil
   VersionAdded: 2.9.0
+  VersionChanged: 2.10.0
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeNil
 
 RSpec/BeforeAfterAll:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -283,15 +283,19 @@ expect(foo).to be(nil)
 | Yes
 | Yes
 | 2.9.0
-| -
+| 2.10.0
 |===
 
-Check that `be_nil` is used instead of `be(nil)`.
+Ensures a consistent style is used when matching `nil`.
 
-RSpec has a built-in `be_nil` matcher specifically for expecting `nil`.
-For consistent specs, we recommend using that instead of `be(nil)`.
+You can either use the more specific `be_nil` matcher, or the more
+generic `be` matcher with a `nil` argument.
+
+This cop can be configured using the `EnforcedStyle` option
 
 === Examples
+
+==== `EnforcedStyle: be_nil` (default)
 
 [source,ruby]
 ----
@@ -301,6 +305,27 @@ expect(foo).to be(nil)
 # good
 expect(foo).to be_nil
 ----
+
+==== `EnforcedStyle: be`
+
+[source,ruby]
+----
+# bad
+expect(foo).to be_nil
+
+# good
+expect(foo).to be(nil)
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| EnforcedStyle
+| `be_nil`
+| `be`, `be_nil`
+|===
 
 === References
 

--- a/lib/rubocop/cop/rspec/be_nil.rb
+++ b/lib/rubocop/cop/rspec/be_nil.rb
@@ -3,24 +3,39 @@
 module RuboCop
   module Cop
     module RSpec
-      # Check that `be_nil` is used instead of `be(nil)`.
+      # Ensures a consistent style is used when matching `nil`.
       #
-      # RSpec has a built-in `be_nil` matcher specifically for expecting `nil`.
-      # For consistent specs, we recommend using that instead of `be(nil)`.
+      # You can either use the more specific `be_nil` matcher, or the more
+      # generic `be` matcher with a `nil` argument.
       #
-      # @example
+      # This cop can be configured using the `EnforcedStyle` option
       #
+      # @example `EnforcedStyle: be_nil` (default)
       #   # bad
       #   expect(foo).to be(nil)
       #
       #   # good
       #   expect(foo).to be_nil
       #
+      # @example `EnforcedStyle: be`
+      #   # bad
+      #   expect(foo).to be_nil
+      #
+      #   # good
+      #   expect(foo).to be(nil)
+      #
       class BeNil < Base
         extend AutoCorrector
+        include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `be_nil` over `be(nil)`.'
-        RESTRICT_ON_SEND = %i[be].freeze
+        BE_MSG = 'Prefer `be(nil)` over `be_nil`.'
+        BE_NIL_MSG = 'Prefer `be_nil` over `be(nil)`.'
+        RESTRICT_ON_SEND = %i[be be_nil].freeze
+
+        # @!method be_nil_matcher?(node)
+        def_node_matcher :be_nil_matcher?, <<-PATTERN
+          (send nil? :be_nil)
+        PATTERN
 
         # @!method nil_value_expectation?(node)
         def_node_matcher :nil_value_expectation?, <<-PATTERN
@@ -28,9 +43,28 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          case style
+          when :be
+            check_be_style(node)
+          when :be_nil
+            check_be_nil_style(node)
+          end
+        end
+
+        private
+
+        def check_be_style(node)
+          return unless be_nil_matcher?(node)
+
+          add_offense(node, message: BE_MSG) do |corrector|
+            corrector.replace(node.loc.expression, 'be(nil)')
+          end
+        end
+
+        def check_be_nil_style(node)
           return unless nil_value_expectation?(node)
 
-          add_offense(node) do |corrector|
+          add_offense(node, message: BE_NIL_MSG) do |corrector|
             corrector.replace(node.loc.expression, 'be_nil')
           end
         end

--- a/spec/rubocop/cop/rspec/be_nil_spec.rb
+++ b/spec/rubocop/cop/rspec/be_nil_spec.rb
@@ -1,30 +1,67 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::BeNil do
-  it 'registers an offense when using `#be` for `nil` value' do
-    expect_offense(<<~RUBY)
-      expect(foo).to be(nil)
-                     ^^^^^^^ Prefer `be_nil` over `be(nil)`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      expect(foo).to be_nil
-    RUBY
+  let(:cop_config) do
+    { 'EnforcedStyle' => enforced_style }
   end
 
-  it 'does not register an offense when using `#be_nil`' do
-    expect_no_offenses(<<~RUBY)
-      expect(foo).to be_nil
-    RUBY
+  context 'with EnforcedStyle `be_nil`' do
+    let(:enforced_style) { 'be_nil' }
+
+    it 'registers an offense when using `#be` for `nil` value' do
+      expect_offense(<<~RUBY)
+        expect(foo).to be(nil)
+                       ^^^^^^^ Prefer `be_nil` over `be(nil)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(foo).to be_nil
+      RUBY
+    end
+
+    it 'does not register an offense when using `#be_nil`' do
+      expect_no_offenses(<<~RUBY)
+        expect(foo).to be_nil
+      RUBY
+    end
+
+    it 'does not register an offense when using `#be` with other values' do
+      expect_no_offenses(<<~RUBY)
+        expect(foo).to be(true)
+        expect(foo).to be(false)
+        expect(foo).to be(1)
+        expect(foo).to be("yes")
+        expect(foo).to be(Class.new)
+      RUBY
+    end
   end
 
-  it 'does not register an offense when using `#be` with other values' do
-    expect_no_offenses(<<~RUBY)
-      expect(foo).to be(true)
-      expect(foo).to be(false)
-      expect(foo).to be(1)
-      expect(foo).to be("yes")
-      expect(foo).to be(Class.new)
-    RUBY
+  context 'with EnforcedStyle `be`' do
+    let(:enforced_style) { 'be' }
+
+    it 'does not register an offense when using `#be` for `nil` value' do
+      expect_no_offenses(<<~RUBY)
+        expect(foo).to be(nil)
+      RUBY
+    end
+
+    it 'registers an offense when using `#be_nil`' do
+      expect_offense(<<~RUBY)
+        expect(foo).to be_nil
+                       ^^^^^^ Prefer `be(nil)` over `be_nil`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(foo).to be(nil)
+      RUBY
+    end
+
+    it 'does not register an offense when using other `#be_*` methods' do
+      expect_no_offenses(<<~RUBY)
+        expect(foo).to be_truthy
+        expect(foo).to be_falsey
+        expect(foo).to be_fooish
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Make `RSpec/BeNil` cop configurable with a :be_nil and a :be style.

Inspired by @marcandre's comment at https://github.com/rubocop/rubocop-rspec/pull/1239#issuecomment-1067532133

> I see absolutely no reason to prefer `be_nil` to `be nil`. The latter is stricter, simpler and requires less knowledge of rspec.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
