### PR TITLE
[Fix #1237] Fix `Capybara/CurrentPathExpectation` autocorrect incompatible with `Style/TrailingCommaInArguments` autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix a false positive for `RSpec/EmptyExampleGroup` when expectations in case statement. ([@ydah][])
 * Add `RSpec/VerifiedDoubleReference` cop. ([@t3h2mas][])
 * Make `RSpec/BeNil` cop configurable with a `be_nil` style and a `be` style. ([@bquorning][])
+* Fix `Capybara/CurrentPathExpectation` autocorrect incompatible with `Style/TrailingCommaInArguments` autocorrect. ([@ydah][])
 
 ## 2.9.0 (2022-02-28)
 

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -37,16 +37,21 @@ require_relative 'rubocop/cop/rspec_cops'
 # We have to register our autocorrect incompatibilities in RuboCop's cops
 # as well so we do not hit infinite loops
 
-module RuboCop
-  module Cop
-    module Layout
-      class ExtraSpacing # rubocop:disable Style/Documentation
-        def self.autocorrect_incompatible_with
-          [RSpec::AlignLeftLetBrace, RSpec::AlignRightLetBrace]
-        end
-      end
+RuboCop::Cop::Layout::ExtraSpacing.singleton_class.prepend(
+  Module.new do
+    def autocorrect_incompatible_with
+      super.push(RuboCop::Cop::RSpec::AlignLeftLetBrace)
+      .push(RuboCop::Cop::RSpec::AlignRightLetBrace)
     end
   end
-end
+)
+
+RuboCop::Cop::Style::TrailingCommaInArguments.singleton_class.prepend(
+  Module.new do
+    def autocorrect_incompatible_with
+      super.push(RuboCop::Cop::RSpec::Capybara::CurrentPathExpectation)
+    end
+  end
+)
 
 RuboCop::AST::Node.include(RuboCop::RSpec::Node)

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -52,6 +52,10 @@ module RuboCop
               $(send nil? :match (str $_)))
           PATTERN
 
+          def self.autocorrect_incompatible_with
+            [Style::TrailingCommaInArguments]
+          end
+
           def on_send(node)
             expectation_set_on_current_path(node) do
               add_offense(node.loc.selector) do |corrector|

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+  subject(:cli) { RuboCop::CLI.new }
+
+  include_context 'when cli spec behavior'
+
+  context 'when corrects `RSpec/Capybara/CurrentPathExpectation` with ' \
+    '`Style/TrailingCommaInArguments`' do
+    before do
+      RuboCop::ConfigLoader
+        .default_configuration
+        .for_all_cops['SuggestExtensions'] = false
+
+      create_file('.rubocop.yml', <<~YAML)
+        Style/TrailingCommaInArguments:
+          EnforcedStyleForMultiline: 'comma'
+      YAML
+
+      create_file('spec/example.rb', <<-RUBY)
+        expect(page.current_path).to eq(
+          some_path(
+            id: id
+          )
+        )
+      RUBY
+    end
+
+    it 'rubocop terminates with a succsess' do
+      expect(cli.run(['-A', '--only',
+                      'RSpec/Capybara/CurrentPathExpectation,' \
+                      'Style/TrailingCommaInArguments'])).to eq(0)
+    end
+
+    it 'autocorrects be compatible with each other' do
+      cli.run(['-A', '--only',
+               'RSpec/Capybara/CurrentPathExpectation,' \
+               'Style/TrailingCommaInArguments'])
+
+      expect(File.read('spec/example.rb')).to eq(<<-RUBY)
+        expect(page).to have_current_path(
+          some_path(
+            id: id,
+          ), ignore_query: true
+        )
+      RUBY
+    end
+  end
+end

--- a/spec/support/cli_spec_behavior.rb
+++ b/spec/support/cli_spec_behavior.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'when cli spec behavior' do
+  include_context 'mock console output'
+
+  include FileHelper
+
+  before do
+    RuboCop::ConfigLoader.debug = false
+
+    # OPTIMIZE: Makes these specs faster. Work directory (the parent of
+    # .rubocop_cache) is removed afterwards anyway.
+    RuboCop::ResultCache.inhibit_cleanup = true
+  end
+
+  # Wrap all cli specs in `aggregate_failures` so that the expected and
+  # actual results of every expectation per example are shown. This is
+  # helpful because it shows information like expected and actual
+  # $stdout messages while not using `aggregate_failures` will only
+  # show information about expected and actual exit code
+  around { |example| aggregate_failures(&example) }
+
+  after { RuboCop::ResultCache.inhibit_cleanup = false }
+end

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module FileHelper
+  def create_file(file_path, content)
+    file_path = File.expand_path(file_path)
+    create_dir file_path
+
+    File.open(file_path, 'w') do |file|
+      case content
+      when String
+        file.puts content
+      when Array
+        file.puts content.join("\n")
+      end
+    end
+  end
+
+  def create_dir(file_path)
+    dir_path = File.dirname(file_path)
+    FileUtils.makedirs dir_path unless File.exist?(dir_path)
+  end
+end


### PR DESCRIPTION
I accidentally Close: https://github.com/rubocop/rubocop-rspec/pull/1252 Sorry.

Fixes https://github.com/rubocop/rubocop-rspec/issues/1237

This PR fixes `Capybara/CurrentPathExpectation` autocorrect incompatible with `Style/TrailingCommaInArguments` autocorrect when code like the following:

```ruby
expect(current_path).to eq(
  some_path(
    record_id: record.id
  )
)
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).