### PR TITLE
Exclude all spec blocks from Metrics/BlockLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,7 +51,6 @@ Metrics/BlockLength:
     - rubocop-rspec.gemspec
     - Rakefile
     - '**/*.rake'
-    - spec/**/*.rb
 
 Naming/FileName:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Drop Ruby 2.5 support. ([@ydah][])
 * Add new `RSpec/ChangeByZero` cop. ([@ydah][])
 * Improve `RSpec/ExpectChange` to detect namespaced and top-level constants. ([@M-Yamashita01][])
+* Introduce an amendment to `Metrics/BlockLength` to exclude spec files. ([@luke-hill][])
 
 ## 2.10.0 (2022-04-19)
 
@@ -686,3 +687,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@ydah]: https://github.com/ydah
 [@t3h2mas]: https://github.com/t3h2mas
 [@M-Yamashita01]: https://github.com/M-Yamashita01
+[@luke-hill]: https://github.com/luke-hill

--- a/config/default.yml
+++ b/config/default.yml
@@ -110,6 +110,14 @@ RSpec:
       - subject
       - subject!
 
+Metrics/BlockLength:
+  inherit_mode:
+    merge:
+      - Exclude
+  Exclude:
+    - "**/*_spec.rb"
+    - "**/spec/**/*"
+
 RSpec/AlignLeftLetBrace:
   Description: Checks that left braces for adjacent single line lets are aligned.
   Enabled: false

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -8,6 +8,7 @@ module RuboCop
     class ConfigFormatter
       EXTENSION_ROOT_DEPARTMENT = %r{^(RSpec/)}.freeze
       SUBDEPARTMENTS = %(RSpec/Capybara RSpec/FactoryBot RSpec/Rails)
+      AMENDMENTS = %(Metrics/BlockLength)
       COP_DOC_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'
 
       def initialize(config, descriptions)
@@ -18,6 +19,7 @@ module RuboCop
       def dump
         YAML.dump(unified_config)
           .gsub(EXTENSION_ROOT_DEPARTMENT, "\n\\1")
+          .gsub(*AMENDMENTS, "\n\\0")
           .gsub(/^(\s+)- /, '\1  - ')
       end
 
@@ -26,6 +28,7 @@ module RuboCop
       def unified_config
         cops.each_with_object(config.dup) do |cop, unified|
           next if SUBDEPARTMENTS.include?(cop)
+          next if AMENDMENTS.include?(cop)
 
           unified[cop].merge!(descriptions.fetch(cop))
           unified[cop]['Reference'] = COP_DOC_BASE_URL + cop.sub('RSpec/', '')

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -42,8 +42,9 @@ RSpec.describe 'config/default.yml' do
     end
   end
 
-  it 'has configuration for all cops' do
-    expect(default_config.keys).to match_array(config_keys)
+  it 'has configuration for all cops and amendments' do
+    expect(default_config.keys)
+      .to match_array([*config_keys, 'Metrics/BlockLength'])
   end
 
   it 'sorts configuration keys alphabetically', :pending do


### PR DESCRIPTION
This was something that was originally discussed in https://github.com/rubocop/rubocop-rspec/issues/988

I'll probably need some more support from @pirj to just confirm I've done everything right (I think I may have missed some things)
It's likely some other maintainers may want to discuss this (As I couldn't spot any other examples of non-rspec cops in the default.yml

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).