### PR TITLE
Make `RSpec/FilePath` support ActiveSupport inflections, if defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Drop Ruby 2.5 support. ([@ydah][])
 * Add new `RSpec/ChangeByZero` cop. ([@ydah][])
+* Make `RSpec/FilePath` support ActiveSupport inflections, if defined. ([@jeromedalbert][])
 
 ## 2.10.0 (2022-04-19)
 
@@ -684,3 +685,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@oshiro3]: https://github.com/oshiro3
 [@ydah]: https://github.com/ydah
 [@t3h2mas]: https://github.com/t3h2mas
+[@jeromedalbert]: https://github.com/jeromedalbert

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -130,6 +130,13 @@ module RuboCop
         end
 
         def camel_to_snake_case(string)
+          if defined?(ActiveSupport::Inflector)
+            if File.exist?('./config/initializers/inflections.rb')
+              require './config/initializers/inflections'
+            end
+            return ActiveSupport::Inflector.underscore(string)
+          end
+
           string
             .gsub(/([^A-Z])([A-Z]+)/, '\1_\2')
             .gsub(/([A-Z])([A-Z][^A-Z\d]+)/, '\1_\2')

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rubocop', '~> 1.19'
 
+  spec.add_development_dependency 'activesupport'
   spec.add_development_dependency 'rack'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.4'

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -246,6 +246,27 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     end
   end
 
+  context 'when ActiveSupport Inflector is defined', order: :defined do
+    before { require 'active_support/inflector' }
+
+    it 'registers an offense for a bad path when there is no custom acronym' do
+      expect_offense(<<-RUBY, 'pvp_class_foo_spec.rb')
+        describe PvPClass, 'foo' do; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `pv_p_class*foo*_spec.rb`.
+      RUBY
+    end
+
+    it 'does not register an offense when class name contains custom acronym' do
+      ActiveSupport::Inflector.inflections do |inflect|
+        inflect.acronym('PvP')
+      end
+
+      expect_no_offenses(<<-RUBY, 'pvp_class_foo_spec.rb')
+        describe PvPClass, 'foo' do; end
+      RUBY
+    end
+  end
+
   context 'when configured with IgnoreMethods' do
     let(:cop_config) { { 'IgnoreMethods' => true } }
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rspec/issues/740. Implementation is based on the suggestion in this comment: https://github.com/rubocop/rubocop-rspec/issues/740#issuecomment-462932812.

This is especially useful for Rails applications (or any application using ActiveSupport inflections) that define mixed-case custom acronyms, for example:

```ruby
# config/initializers/inflections.rb
ActiveSupport::Inflector.inflections do |inflect|
  inflect.acronym('PvP')
end

# app/models/pvp_class.rb instead of app/models/pv_p_class.rb, thanks to the custom acronym
class PvPClass
  ...
end
```

It is also great to be re-using ActiveSupport's inflection configuration instead of having to repeat it in Rubocop as mentioned in https://github.com/rubocop/rubocop-rspec/issues/740.

Other common custom mixed-case acronyms could be StatsD, OAuth, RESTful, etc.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
* [x] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
