### PR TITLE
Fix a warning for obsolete parameter `IgnoredPatterns` (for `Layout/LineLength`) found in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Layout/HashAlignment:
 
 Layout/LineLength:
   Max: 80 # default: 120
-  IgnoredPatterns:
+  AllowedPatterns:
     - '^\s*# .*https?:\/\/.+\[.+\]\.?$' # Allow long asciidoc links
 
 Layout/MultilineMethodCallIndentation:


### PR DESCRIPTION
Reference: https://github.com/rubocop/rubocop/pull/10555

The following warning was issued. This PR changed to use `AllowedPatterns`.

```
$ bundle exec rubocop                                         
Warning: obsolete parameter `IgnoredPatterns` (for `Layout/LineLength`) found in .rubocop.yml
`IgnoredPatterns` has been renamed to `AllowedPatterns`.
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
~* [ ] Added tests.~
~* [ ] Updated documentation.~
~* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

~* [ ] Added the new cop to `config/default.yml`.~
~* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.~
~* [ ] The cop documents examples of good and bad code.~
~* [ ] The tests assert both that bad code is reported and that good code is not reported.~
~* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.~

If you have modified an existing cop's configuration options:

~* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.~
