### PR TITLE
Fix latest internal affairs offences

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -262,7 +262,7 @@ RSpec/DescribedClassModuleWrapping:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClassModuleWrapping
 
 RSpec/Dialect:
-  Description: This cop enforces custom RSpec dialects.
+  Description: Enforces custom RSpec dialects.
   Enabled: false
   PreferredMethods: {}
   VersionAdded: '1.33'
@@ -793,13 +793,13 @@ RSpec/VerifiedDoubles:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
 
 RSpec/VoidExpect:
-  Description: This cop checks void `expect()`.
+  Description: Checks void `expect()`.
   Enabled: true
   VersionAdded: '1.16'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VoidExpect
 
 RSpec/Yield:
-  Description: This cop checks for calling a block within a stub.
+  Description: Checks for calling a block within a stub.
   Enabled: true
   VersionAdded: '1.32'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Yield

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -810,7 +810,7 @@ end
 | -
 |===
 
-This cop enforces custom RSpec dialects.
+Enforces custom RSpec dialects.
 
 A dialect can be based on the following RSpec methods:
 
@@ -4508,7 +4508,7 @@ end
 | -
 |===
 
-This cop checks void `expect()`.
+Checks void `expect()`.
 
 === Examples
 
@@ -4537,7 +4537,7 @@ expect(something).to be(1)
 | -
 |===
 
-This cop checks for calling a block within a stub.
+Checks for calling a block within a stub.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/dialect.rb
+++ b/lib/rubocop/cop/rspec/dialect.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      # This cop enforces custom RSpec dialects.
+      # Enforces custom RSpec dialects.
       #
       # A dialect can be based on the following RSpec methods:
       #

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      # This cop checks void `expect()`.
+      # Checks void `expect()`.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/rspec/yield.rb
+++ b/lib/rubocop/cop/rspec/yield.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      # This cop checks for calling a block within a stub.
+      # Checks for calling a block within a stub.
       #
       # @example
       #   # bad


### PR DESCRIPTION
See e.g. https://github.com/rubocop/rubocop-rspec/runs/6487019562?check_suite_focus=true

     lib/rubocop/cop/rspec/dialect.rb:6:9: C: [Correctable] InternalAffairs/CopDescription: Description should be started with Enforces instead of This cop ....
          # This cop enforces custom RSpec dialects. ...
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    lib/rubocop/cop/rspec/void_expect.rb:6:9: C: [Correctable] InternalAffairs/CopDescription: Description should be started with Checks instead of This cop ....
          # This cop checks void `expect()`. ...
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    lib/rubocop/cop/rspec/yield.rb:6:9: C: [Correctable] InternalAffairs/CopDescription: Description should be started with Checks instead of This cop ....
          # This cop checks for calling a block within a stub. ...
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).