### PR TITLE
Fix regression in ExpectChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix a regression in `RSpec/ExpectChange` flagging chained method calls. ([@pirj][])
+
 ## 2.11.0 (2022-05-18)
 
 * Drop Ruby 2.5 support. ([@ydah][])

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -47,7 +47,13 @@ module RuboCop
           (block
             (send nil? :change)
             (args)
-            (send $_ $_)
+            (send
+              ${
+                (send nil? _)  # change { user.name }
+                const          # change { User.count }
+              }
+              $_
+            )
           )
         PATTERN
 

--- a/spec/rubocop/cop/rspec/expect_change_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_change_spec.rb
@@ -86,11 +86,33 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
       RUBY
     end
 
-    it 'flags chained method calls' do
+    it 'flags a method call on an object' do
       expect_offense(<<-RUBY)
         it do
-          expect { file.upload! }.to change { user.uploads.count }.by(1)
-                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `change(user.uploads, :count)`.
+          expect { run }.to change { user.name }.to('Jack')
+                            ^^^^^^^^^^^^^^^^^^^^ Prefer `change(user, :name)`.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it do
+          expect { run }.to change(user, :name).to('Jack')
+        end
+      RUBY
+    end
+
+    it 'ignores multiple chained method calls' do
+      expect_no_offenses(<<-RUBY)
+        it do
+          expect { run }.to change { user.reload.name }
+        end
+      RUBY
+    end
+
+    it 'ignores a variable/method' do
+      expect_no_offenses(<<-RUBY)
+        it do
+          expect { run }.to change { results }.to([])
         end
       RUBY
     end


### PR DESCRIPTION
The cop was triggered by `change { user.reload.name }`

fixes #1276

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).