### PR TITLE
[Doc] Clarify default enforced styles

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -699,7 +699,7 @@ directory.
 
 === Examples
 
-==== `EnforcedStyle: described_class`
+==== `EnforcedStyle: described_class` (default)
 
 [source,ruby]
 ----
@@ -1300,7 +1300,7 @@ This cop can be configured using the `EnforcedStyle` option
 
 === Examples
 
-==== `EnforcedStyle: always_allow`
+==== `EnforcedStyle: always_allow` (default)
 
 [source,ruby]
 ----
@@ -1539,7 +1539,7 @@ expect { run }.to change(Foo, :bar)
 expect { run }.to change { Foo.bar }
 ----
 
-==== `EnforcedStyle: method_call`
+==== `EnforcedStyle: method_call` (default)
 
 [source,ruby]
 ----
@@ -1800,7 +1800,7 @@ the same behavior.
 
 === Examples
 
-==== when configuration is `EnforcedStyle: implicit`
+==== `EnforcedStyle: implicit` (default)
 
 [source,ruby]
 ----
@@ -1820,7 +1820,7 @@ before do
 end
 ----
 
-==== when configuration is `EnforcedStyle: each`
+==== `EnforcedStyle: each`
 
 [source,ruby]
 ----
@@ -1840,7 +1840,7 @@ before(:each) do
 end
 ----
 
-==== when configuration is `EnforcedStyle: example`
+==== `EnforcedStyle: example`
 
 [source,ruby]
 ----
@@ -2000,7 +2000,7 @@ and supports the `--auto-gen-config` flag.
 
 === Examples
 
-==== `EnforcedStyle: is_expected`
+==== `EnforcedStyle: is_expected` (default)
 
 [source,ruby]
 ----
@@ -2244,7 +2244,7 @@ Checks that only one `it_behaves_like` style is used.
 
 === Examples
 
-==== when configuration is `EnforcedStyle: it_behaves_like`
+==== `EnforcedStyle: it_behaves_like` (default)
 
 [source,ruby]
 ----
@@ -2255,7 +2255,7 @@ it_should_behave_like 'a foo'
 it_behaves_like 'a foo'
 ----
 
-==== when configuration is `EnforcedStyle: it_should_behave_like`
+==== `EnforcedStyle: it_should_behave_like`
 
 [source,ruby]
 ----
@@ -2617,7 +2617,7 @@ This cop can be configured in your configuration using the
 
 === Examples
 
-==== `EnforcedStyle: allow`
+==== `EnforcedStyle: allow` (default)
 
 [source,ruby]
 ----
@@ -2672,7 +2672,7 @@ This cop can be configured in your configuration using the
 
 === Examples
 
-==== `EnforcedStyle: have_received`
+==== `EnforcedStyle: have_received` (default)
 
 [source,ruby]
 ----
@@ -3230,6 +3230,8 @@ Checks for consistent method usage for negating expectations.
 
 === Examples
 
+==== `EnforcedStyle: not_to` (default)
+
 [source,ruby]
 ----
 # bad
@@ -3240,6 +3242,21 @@ end
 # good
 it '...' do
   expect(false).not_to be_true
+end
+----
+
+==== `EnforcedStyle: to_not`
+
+[source,ruby]
+----
+# bad
+it '...' do
+  expect(false).not_to be_true
+end
+
+# good
+it '...' do
+  expect(false).to_not be_true
 end
 ----
 
@@ -3808,7 +3825,7 @@ expect(Foo).to receive(:bar) { "baz" }
 allow(Foo).to receive(:bar).and_return(bar.baz)
 ----
 
-==== `EnforcedStyle: and_return`
+==== `EnforcedStyle: and_return` (default)
 
 [source,ruby]
 ----

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -69,7 +69,7 @@ This cop can be configured using the `EnforcedStyle` option
 
 === Examples
 
-==== `EnforcedStyle: create_list`
+==== `EnforcedStyle: create_list` (default)
 
 [source,ruby]
 ----

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -11,7 +11,7 @@ module RuboCop
       # This cop can be configured using the `EnforcedStyle` and `SkipBlocks`
       # options.
       #
-      # @example `EnforcedStyle: described_class`
+      # @example `EnforcedStyle: described_class` (default)
       #   # bad
       #   describe MyClass do
       #     subject { MyClass.do_something }

--- a/lib/rubocop/cop/rspec/example_without_description.rb
+++ b/lib/rubocop/cop/rspec/example_without_description.rb
@@ -14,7 +14,7 @@ module RuboCop
       #
       # This cop can be configured using the `EnforcedStyle` option
       #
-      # @example `EnforcedStyle: always_allow`
+      # @example `EnforcedStyle: always_allow` (default)
       #   # bad
       #   it('') { is_expected.to be_good }
       #   it '' do

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   # good
       #   expect { run }.to change { Foo.bar }
       #
-      # @example `EnforcedStyle: method_call`
+      # @example `EnforcedStyle: method_call` (default)
       #   # bad
       #   expect { run }.to change { Foo.bar }
       #   expect { run }.to change { foo.baz }

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -8,7 +8,7 @@ module RuboCop
         #
         # This cop can be configured using the `EnforcedStyle` option
         #
-        # @example `EnforcedStyle: create_list`
+        # @example `EnforcedStyle: create_list` (default)
         #   # bad
         #   3.times { create :user }
         #

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -10,7 +10,7 @@ module RuboCop
       # styles: "implicit", "each", and "example." All styles have
       # the same behavior.
       #
-      # @example when configuration is `EnforcedStyle: implicit`
+      # @example `EnforcedStyle: implicit` (default)
       #   # bad
       #   before(:each) do
       #     # ...
@@ -26,7 +26,7 @@ module RuboCop
       #     # ...
       #   end
       #
-      # @example when configuration is `EnforcedStyle: each`
+      # @example `EnforcedStyle: each`
       #   # bad
       #   before(:example) do
       #     # ...
@@ -42,7 +42,7 @@ module RuboCop
       #     # ...
       #   end
       #
-      # @example when configuration is `EnforcedStyle: example`
+      # @example `EnforcedStyle: example`
       #   # bad
       #   before(:each) do
       #     # ...

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -8,7 +8,7 @@ module RuboCop
       # This cop can be configured using the `EnforcedStyle` option
       # and supports the `--auto-gen-config` flag.
       #
-      # @example `EnforcedStyle: is_expected`
+      # @example `EnforcedStyle: is_expected` (default)
       #
       #   # bad
       #   it { should be_truthy }

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -5,14 +5,14 @@ module RuboCop
     module RSpec
       # Checks that only one `it_behaves_like` style is used.
       #
-      # @example when configuration is `EnforcedStyle: it_behaves_like`
+      # @example `EnforcedStyle: it_behaves_like` (default)
       #   # bad
       #   it_should_behave_like 'a foo'
       #
       #   # good
       #   it_behaves_like 'a foo'
       #
-      # @example when configuration is `EnforcedStyle: it_should_behave_like`
+      # @example `EnforcedStyle: it_should_behave_like`
       #   # bad
       #   it_behaves_like 'a foo'
       #

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -8,7 +8,7 @@ module RuboCop
       # This cop can be configured in your configuration using the
       # `EnforcedStyle` option and supports `--auto-gen-config`.
       #
-      # @example `EnforcedStyle: allow`
+      # @example `EnforcedStyle: allow` (default)
       #
       #   # bad
       #   expect(foo).to receive(:bar)

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -8,7 +8,7 @@ module RuboCop
       # This cop can be configured in your configuration using the
       # `EnforcedStyle` option and supports `--auto-gen-config`.
       #
-      # @example `EnforcedStyle: have_received`
+      # @example `EnforcedStyle: have_received` (default)
       #
       #   # bad
       #   expect(foo).to receive(:bar)

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -5,7 +5,8 @@ module RuboCop
     module RSpec
       # Checks for consistent method usage for negating expectations.
       #
-      # @example
+      # @example `EnforcedStyle: not_to` (default)
+      #
       #   # bad
       #   it '...' do
       #     expect(false).to_not be_true
@@ -14,6 +15,18 @@ module RuboCop
       #   # good
       #   it '...' do
       #     expect(false).not_to be_true
+      #   end
+      #
+      # @example `EnforcedStyle: to_not`
+      #
+      #   # bad
+      #   it '...' do
+      #     expect(false).not_to be_true
+      #   end
+      #
+      #   # good
+      #   it '...' do
+      #     expect(false).to_not be_true
       #   end
       class NotToNot < Base
         extend AutoCorrector

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -22,7 +22,7 @@ module RuboCop
       #   # also good as the returned value is dynamic
       #   allow(Foo).to receive(:bar).and_return(bar.baz)
       #
-      # @example `EnforcedStyle: and_return`
+      # @example `EnforcedStyle: and_return` (default)
       #   # bad
       #   allow(Foo).to receive(:bar) { "baz" }
       #   expect(Foo).to receive(:bar) { "baz" }


### PR DESCRIPTION
This PR clarifies default enforced styles. It also supplements the missing `EnforcedStyle` examples for `RSpec/NotToNot`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
