### PR TITLE
Enable `Naming/InclusiveLanguage`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,17 @@ Naming/FileName:
   Exclude:
     - lib/rubocop-rspec.rb
 
+Naming/InclusiveLanguage:
+  Enabled: true
+  CheckStrings: true
+  FlaggedTerms:
+    behaviour:
+      Suggestions:
+        - behavior
+    offence:
+      Suggestions:
+        - offense
+
 RSpec/ExampleLength:
   CountAsOne:
     - heredoc

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1208,7 +1208,7 @@ let(:foo) { bar }
 Checks for long examples.
 
 A long example is usually more difficult to understand. Consider
-extracting out some behaviour, e.g. with a `let` block, or a helper
+extracting out some behavior, e.g. with a `let` block, or a helper
 method.
 
 You can set literals you want to fold with `CountAsOne`.
@@ -2380,7 +2380,7 @@ scope, are defined in global namespace, and leak between examples.
 
 If several examples may define a `DummyClass`, instead of being a
 blank slate class as it will be in the first example, subsequent
-examples will be reopening it and modifying its behaviour in
+examples will be reopening it and modifying its behavior in
 unpredictable ways.
 Even worse when a class that exists in the codebase is reopened.
 

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -52,17 +52,17 @@ module RuboCop
 
         def on_send(node)
           expect_change_with_arguments(node.parent) do
-            check_offence(node.parent)
+            check_offense(node.parent)
           end
 
           expect_change_with_block(node.parent.parent) do
-            check_offence(node.parent.parent)
+            check_offense(node.parent.parent)
           end
         end
 
         private
 
-        def check_offence(node)
+        def check_offense(node)
           expression = node.loc.expression
           if compound_expectations?(node)
             add_offense(expression, message: MSG_COMPOUND)

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks for long examples.
       #
       # A long example is usually more difficult to understand. Consider
-      # extracting out some behaviour, e.g. with a `let` block, or a helper
+      # extracting out some behavior, e.g. with a `let` block, or a helper
       # method.
       #
       # @example

--- a/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
+++ b/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
@@ -10,7 +10,7 @@ module RuboCop
       #
       # If several examples may define a `DummyClass`, instead of being a
       # blank slate class as it will be in the first example, subsequent
-      # examples will be reopening it and modifying its behaviour in
+      # examples will be reopening it and modifying its behavior in
       # unpredictable ways.
       # Even worse when a class that exists in the codebase is reopened.
       #

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
       end
 
       describe Foo do
-        skip 'undefined behaviour'
+        skip 'undefined behavior'
       end
 
       xdescribe Foo

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'does not register an offence for example groups '\
+  it 'does not register an offense for example groups '\
      'do not describe a class / method' do
     expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
       describe 'Test something' do; end
@@ -184,14 +184,14 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'does not register an offence for an arbitrary spec suffix' do
+  it 'does not register an offense for an arbitrary spec suffix' do
     filename = 'some/class/thing_predicate_spec.rb'
     expect_no_offenses(<<-RUBY, filename)
       describe Some::Class, '#thing?' do; end
     RUBY
   end
 
-  it 'does not register an offence for an arbitrary spec name '\
+  it 'does not register an offense for an arbitrary spec name '\
      'for an operator method' do
     filename = 'my_little_class/spaceship_operator_spec.rb'
     expect_no_offenses(<<-RUBY, filename)

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
   end
 
   context 'when not used with `have_received`' do
-    it 'does not add an offence' do
+    it 'does not add an offense' do
       expect_no_offenses(<<-RUBY)
         it do
           foo = instance_double(Foo).as_null_object

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     RUBY
   end
 
-  it 'does not register an offence for subject in arbitrary code' do
+  it 'does not register an offense for subject in arbitrary code' do
     expect_no_offenses(<<-RUBY)
       module Support
         subject do


### PR DESCRIPTION
This PR is unified word fluctuation.
- Use "offense" instead of "offence"
- Use "behavior" instead of "behaviour"

Refs: [rubocop/rubocop .rubocop.yml#L99-L108](https://github.com/rubocop/rubocop/blob/a258410e231e2c4a58c5162d617511887c317d5c/.rubocop.yml#L99-L108)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
~* [ ] Added tests.~
~* [ ] Updated documentation.~
~* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

~* [ ] Added the new cop to `config/default.yml`.~
~* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.~
~* [ ] The cop documents examples of good and bad code.~
~* [ ] The tests assert both that bad code is reported and that good code is not reported.~
~* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.~

If you have modified an existing cop's configuration options:

~* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.~
