### PR TITLE
[Fix #1282] Fix autocorrect for EmptyLineSeparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Master (Unreleased)
+
 * Fix incorrect path suggested by `RSpec/FilePath` cop when second argument contains spaces. ([@tejasbubane][])
+* Fix autocorrect for EmptyLineSeparation. ([@johnny-miyake][])
 
 ## 2.11.1 (2022-05-18)
 
@@ -695,3 +697,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@t3h2mas]: https://github.com/t3h2mas
 [@M-Yamashita01]: https://github.com/M-Yamashita01
 [@luke-hill]: https://github.com/luke-hill
+[@johnny-miyake]: https://github.com/johnny-miyake

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -116,4 +116,150 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
   end
+
+  it 'does not register an offense for a comment followed by an empty line' do
+    expect_no_offenses(<<-RUBY)
+      RSpec.describe Foo do
+        describe 'bar' do
+        end
+        # comment
+
+        describe 'baz' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        describe 'bar' do
+        end
+        ^^^ Add an empty line after `describe`.
+        # comment
+        describe 'baz' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        describe 'bar' do
+        end
+
+        # comment
+        describe 'baz' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a multiline comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        describe 'bar' do
+        end
+        ^^^ Add an empty line after `describe`.
+        # multiline comment
+        # multiline comment
+        describe 'baz' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        describe 'bar' do
+        end
+
+        # multiline comment
+        # multiline comment
+        describe 'baz' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        # rubocop:disable RSpec/Foo
+        describe 'bar' do
+        end
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `describe`.
+        describe 'baz' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        # rubocop:disable RSpec/Foo
+        describe 'bar' do
+        end
+        # rubocop:enable RSpec/Foo
+
+        describe 'baz' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        describe 'bar' do
+        end
+        ^^^ Add an empty line after `describe`.
+        # rubocop:disable RSpec/Foo
+        describe 'baz' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        describe 'bar' do
+        end
+
+        # rubocop:disable RSpec/Foo
+        describe 'baz' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive '\
+      'when it is followed by a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        # rubocop:disable RSpec/Foo
+        describe 'bar' do
+        end
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `describe`.
+        # rubocop:disable RSpec/Foo
+        describe 'baz' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        # rubocop:disable RSpec/Foo
+        describe 'bar' do
+        end
+        # rubocop:enable RSpec/Foo
+
+        # rubocop:disable RSpec/Foo
+        describe 'baz' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
@@ -101,6 +101,152 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
     RUBY
   end
 
+  it 'does not register an offense for a comment followed by an empty line' do
+    expect_no_offenses(<<-RUBY)
+      RSpec.describe Foo do
+        it 'does this' do
+        end
+        # comment
+
+        it 'does that' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        it 'does this' do
+        end
+        ^^^ Add an empty line after `it`.
+        # comment
+        it 'does that' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        it 'does this' do
+        end
+
+        # comment
+        it 'does that' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a multiline comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        it 'does this' do
+        end
+        ^^^ Add an empty line after `it`.
+        # multiline comment
+        # multiline comment
+        it 'does that' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        it 'does this' do
+        end
+
+        # multiline comment
+        # multiline comment
+        it 'does that' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        # rubocop:disable RSpec/Foo
+        it 'does this' do
+        end
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `it`.
+        it 'does that' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        # rubocop:disable RSpec/Foo
+        it 'does this' do
+        end
+        # rubocop:enable RSpec/Foo
+
+        it 'does that' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        it 'does this' do
+        end
+        ^^^ Add an empty line after `it`.
+        # rubocop:disable RSpec/Foo
+        it 'does that' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        it 'does this' do
+        end
+
+        # rubocop:disable RSpec/Foo
+        it 'does that' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive '\
+      'when it is followed by a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        # rubocop:disable RSpec/Foo
+        it 'does this' do
+        end
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `it`.
+        # rubocop:disable RSpec/Foo
+        it 'does that' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        # rubocop:disable RSpec/Foo
+        it 'does this' do
+        end
+        # rubocop:enable RSpec/Foo
+
+        # rubocop:disable RSpec/Foo
+        it 'does that' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
+
   context 'when AllowConsecutiveOneLiners is false' do
     let(:cop_config) { { 'AllowConsecutiveOneLiners' => false } }
 

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -89,14 +89,13 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'registers an offense for missing empty line after the comment '\
-     'that comes after last let' do
+  it 'flags a missing empty line before a comment' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
-        # end of setup
-        ^^^^^^^^^^^^^^ Add an empty line after the last `let`.
+        ^^^^^^^^^^^^^ Add an empty line after the last `let`.
+        # comment
         it { expect(a).to eq(b) }
       end
     RUBY
@@ -105,23 +104,70 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
-        # end of setup
+
+        # comment
+        it { expect(a).to eq(b) }
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a multiline comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
+        ^^^^^^^^^^^^^ Add an empty line after the last `let`.
+        # multiline comment
+        # multiline comment
+        it { expect(a).to eq(b) }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        let(:a) { a }
+        let(:b) { b }
+
+        # multiline comment
+        # multiline comment
+        it { expect(a).to eq(b) }
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        let(:a) { a }
+        let(:b) { b }
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after the last `let`.
+        it { expect(a).to eq(b) }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        let(:a) { a }
+        let(:b) { b }
+        # rubocop:enable RSpec/Foo
 
         it { expect(a).to eq(b) }
       end
     RUBY
   end
 
-  it 'registers an offense for missing empty line after a multiline comment '\
-     'after last let' do
+  it 'flags a missing empty line before a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
-        # a multiline comment marking
-        # the end of setup
-        ^^^^^^^^^^^^^^^^^^ Add an empty line after the last `let`.
+        ^^^^^^^^^^^^^ Add an empty line after the last `let`.
+        # rubocop:disable RSpec/Foo
         it { expect(a).to eq(b) }
+        # rubocop:enable RSpec/Foo
       end
     RUBY
 
@@ -129,10 +175,39 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
-        # a multiline comment marking
-        # the end of setup
 
+        # rubocop:disable RSpec/Foo
         it { expect(a).to eq(b) }
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive '\
+      'when it is followed by a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        let(:a) { a }
+        let(:b) { b }
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after the last `let`.
+        # rubocop:disable RSpec/Foo
+        it { expect(a).to eq(b) }
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        let(:a) { a }
+        let(:b) { b }
+        # rubocop:enable RSpec/Foo
+
+        # rubocop:disable RSpec/Foo
+        it { expect(a).to eq(b) }
+        # rubocop:enable RSpec/Foo
       end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -128,4 +128,128 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
       end
     RUBY
   end
+
+  it 'does not register an offense for a comment followed by an empty line' do
+    expect_no_offenses(<<-RUBY)
+      RSpec.describe User do
+        before { do_something }
+        # comment
+
+        it { does_something }
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        before { do_something }
+        ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+        # comment
+        it { does_something }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        before { do_something }
+
+        # comment
+        it { does_something }
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a multiline comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        before { do_something }
+        ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+        # multiline comment
+        # multiline comment
+        it { does_something }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        before { do_something }
+
+        # multiline comment
+        # multiline comment
+        it { does_something }
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        before { do_something }
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+        it { does_something }
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        before { do_something }
+        # rubocop:enable RSpec/Foo
+
+        it { does_something }
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        before { do_something }
+        ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+        # rubocop:disable RSpec/Foo
+        it { does_something }
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        before { do_something }
+
+        # rubocop:disable RSpec/Foo
+        it { does_something }
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive '\
+      'when it is followed by a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        before { do_something }
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+        # rubocop:disable RSpec/Foo
+        it { does_something }
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        before { do_something }
+        # rubocop:enable RSpec/Foo
+
+        # rubocop:disable RSpec/Foo
+        it { does_something }
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -76,4 +76,139 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
   end
+
+  it 'does not register an offense for a comment followed by an empty line' do
+    expect_no_offenses(<<-RUBY)
+      RSpec.describe Foo do
+        subject { described_user }
+        # comment
+
+        describe 'bar' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        subject { described_user }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
+        # comment
+        describe 'bar' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        subject { described_user }
+
+        # comment
+        describe 'bar' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a multiline comment' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        subject { described_user }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
+        # multiline comment
+        # multiline comment
+        describe 'bar' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        subject { described_user }
+
+        # multiline comment
+        # multiline comment
+        describe 'bar' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        subject { described_user }
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
+        describe 'bar' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        subject { described_user }
+        # rubocop:enable RSpec/Foo
+
+        describe 'bar' do
+        end
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line before a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe Foo do
+        subject { described_user }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
+        # rubocop:disable RSpec/Foo
+        describe 'bar' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe Foo do
+        subject { described_user }
+
+        # rubocop:disable RSpec/Foo
+        describe 'bar' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
+
+  it 'flags a missing empty line after a `rubocop:enable` directive '\
+      'when it is followed by a `rubocop:disable` directive' do
+    expect_offense(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        subject { described_user }
+        # rubocop:enable RSpec/Foo
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
+        # rubocop:disable RSpec/Foo
+        describe 'bar' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.describe User do
+        # rubocop:disable RSpec/Foo
+        subject { described_user }
+        # rubocop:enable RSpec/Foo
+
+        # rubocop:disable RSpec/Foo
+        describe 'bar' do
+        end
+        # rubocop:enable RSpec/Foo
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #1282

Current behavior
- Insert an empty line _after_ a comment

New behavior

- Insert an empty line _before_ a comment
  - except `rubocop:enable` directive, because it is for its above line in most cases.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
