### PR TITLE
Fix a warning for "bin/build_config"

### DIFF
--- a/bin/build_config
+++ b/bin/build_config
@@ -17,6 +17,7 @@ glob = File.join('lib', 'rubocop', 'cop', 'rspec',
 # are detected as RuboCop::Cop::Base, and that complicates the detection
 # of their relation with RuboCop RSpec.
 rspec_cop_path = File.join('lib', 'rubocop', 'cop', 'rspec', 'base.rb')
+YARD::Tags::Library.define_tag('Cop Safety Information', :safety)
 YARD.parse(Dir[glob].prepend(rspec_cop_path), [])
 
 descriptions = RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all).to_h


### PR DESCRIPTION
Fixed a warning when executing `bundle exec rake default`.

The following warning was generated when executing the command:

```
bundle exec rake default
bin/build_config
[warn]: Unknown tag @safety in file `lib/rubocop/cop/rspec/factory_bot/syntax_methods.rb` near line 49
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
~* [ ] Added tests.~
~* [ ] Updated documentation.~
~* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).