### PR TITLE
Move enforced styles to top in docs

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1528,17 +1528,6 @@ This cop can be configured using the `EnforcedStyle` option.
 
 === Examples
 
-==== `EnforcedStyle: block`
-
-[source,ruby]
-----
-# bad
-expect { run }.to change(Foo, :bar)
-
-# good
-expect { run }.to change { Foo.bar }
-----
-
 ==== `EnforcedStyle: method_call` (default)
 
 [source,ruby]
@@ -1553,6 +1542,17 @@ expect { run }.to change(foo, :baz)
 # also good when there are arguments or chained method calls
 expect { run }.to change { Foo.bar(:count) }
 expect { run }.to change { user.reload.name }
+----
+
+==== `EnforcedStyle: block`
+
+[source,ruby]
+----
+# bad
+expect { run }.to change(Foo, :bar)
+
+# good
+expect { run }.to change { Foo.bar }
 ----
 
 === Configurable attributes
@@ -3810,21 +3810,6 @@ This cop can be configured using the `EnforcedStyle` option
 
 === Examples
 
-==== `EnforcedStyle: block`
-
-[source,ruby]
-----
-# bad
-allow(Foo).to receive(:bar).and_return("baz")
-expect(Foo).to receive(:bar).and_return("baz")
-
-# good
-allow(Foo).to receive(:bar) { "baz" }
-expect(Foo).to receive(:bar) { "baz" }
-# also good as the returned value is dynamic
-allow(Foo).to receive(:bar).and_return(bar.baz)
-----
-
 ==== `EnforcedStyle: and_return` (default)
 
 [source,ruby]
@@ -3838,6 +3823,21 @@ allow(Foo).to receive(:bar).and_return("baz")
 expect(Foo).to receive(:bar).and_return("baz")
 # also good as the returned value is dynamic
 allow(Foo).to receive(:bar) { bar.baz }
+----
+
+==== `EnforcedStyle: block`
+
+[source,ruby]
+----
+# bad
+allow(Foo).to receive(:bar).and_return("baz")
+expect(Foo).to receive(:bar).and_return("baz")
+
+# good
+allow(Foo).to receive(:bar) { "baz" }
+expect(Foo).to receive(:bar) { "baz" }
+# also good as the returned value is dynamic
+allow(Foo).to receive(:bar).and_return(bar.baz)
 ----
 
 === Configurable attributes

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -10,13 +10,6 @@ module RuboCop
       #
       # This cop can be configured using the `EnforcedStyle` option.
       #
-      # @example `EnforcedStyle: block`
-      #   # bad
-      #   expect { run }.to change(Foo, :bar)
-      #
-      #   # good
-      #   expect { run }.to change { Foo.bar }
-      #
       # @example `EnforcedStyle: method_call` (default)
       #   # bad
       #   expect { run }.to change { Foo.bar }
@@ -28,6 +21,13 @@ module RuboCop
       #   # also good when there are arguments or chained method calls
       #   expect { run }.to change { Foo.bar(:count) }
       #   expect { run }.to change { user.reload.name }
+      #
+      # @example `EnforcedStyle: block`
+      #   # bad
+      #   expect { run }.to change(Foo, :bar)
+      #
+      #   # good
+      #   expect { run }.to change { Foo.bar }
       #
       class ExpectChange < Base
         extend AutoCorrector

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -11,17 +11,6 @@ module RuboCop
       #
       # This cop can be configured using the `EnforcedStyle` option
       #
-      # @example `EnforcedStyle: block`
-      #   # bad
-      #   allow(Foo).to receive(:bar).and_return("baz")
-      #   expect(Foo).to receive(:bar).and_return("baz")
-      #
-      #   # good
-      #   allow(Foo).to receive(:bar) { "baz" }
-      #   expect(Foo).to receive(:bar) { "baz" }
-      #   # also good as the returned value is dynamic
-      #   allow(Foo).to receive(:bar).and_return(bar.baz)
-      #
       # @example `EnforcedStyle: and_return` (default)
       #   # bad
       #   allow(Foo).to receive(:bar) { "baz" }
@@ -32,6 +21,17 @@ module RuboCop
       #   expect(Foo).to receive(:bar).and_return("baz")
       #   # also good as the returned value is dynamic
       #   allow(Foo).to receive(:bar) { bar.baz }
+      #
+      # @example `EnforcedStyle: block`
+      #   # bad
+      #   allow(Foo).to receive(:bar).and_return("baz")
+      #   expect(Foo).to receive(:bar).and_return("baz")
+      #
+      #   # good
+      #   allow(Foo).to receive(:bar) { "baz" }
+      #   expect(Foo).to receive(:bar) { "baz" }
+      #   # also good as the returned value is dynamic
+      #   allow(Foo).to receive(:bar).and_return(bar.baz)
       #
       class ReturnFromStub < Base
         extend AutoCorrector


### PR DESCRIPTION
Coming from https://github.com/rubocop/rubocop-rspec/pull/1279#discussion_r884678237

> but should we always have the default on top, or should we have them alphabeticall? 

This PR suggests default on top.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).