### PR TITLE
Better explanation for MessageSpies

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2678,8 +2678,11 @@ This cop can be configured in your configuration using the
 ----
 # bad
 expect(foo).to receive(:bar)
+do_something
 
 # good
+allow(foo).to receive(:bar) # or use instance_spy
+do_something
 expect(foo).to have_received(:bar)
 ----
 
@@ -2688,10 +2691,13 @@ expect(foo).to have_received(:bar)
 [source,ruby]
 ----
 # bad
+allow(foo).to receive(:bar)
+do_something
 expect(foo).to have_received(:bar)
 
 # good
 expect(foo).to receive(:bar)
+do_something
 ----
 
 === Configurable attributes

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -12,22 +12,23 @@ module RuboCop
       #
       #   # bad
       #   expect(foo).to receive(:bar)
-      #   subject
+      #   do_something
       #
       #   # good
       #   allow(foo).to receive(:bar) # or use instance_spy
-      #   subject
+      #   do_something
       #   expect(foo).to have_received(:bar)
       #
       # @example `EnforcedStyle: receive`
       #
       #   # bad
-      #   subject
+      #   allow(foo).to receive(:bar)
+      #   do_something
       #   expect(foo).to have_received(:bar)
       #
       #   # good
       #   expect(foo).to receive(:bar)
-      #   subject
+      #   do_something
       #
       class MessageSpies < Base
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -12,17 +12,22 @@ module RuboCop
       #
       #   # bad
       #   expect(foo).to receive(:bar)
+      #   subject
       #
       #   # good
+      #   allow(foo).to receive(:bar) # or use instance_spy
+      #   subject
       #   expect(foo).to have_received(:bar)
       #
       # @example `EnforcedStyle: receive`
       #
       #   # bad
+      #   subject
       #   expect(foo).to have_received(:bar)
       #
       #   # good
       #   expect(foo).to receive(:bar)
+      #   subject
       #
       class MessageSpies < Base
         include ConfigurableEnforcedStyle


### PR DESCRIPTION
Current example simply switches `receive` and `have_received` but they are not same function.
