### PR TITLE
Add new `RSpec/Capybara/SpecificMatcher` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix incorrect path suggested by `RSpec/FilePath` cop when second argument contains spaces. ([@tejasbubane][])
 * Fix autocorrect for EmptyLineSeparation. ([@johnny-miyake][])
+* Add new `RSpec/Capybara/SpecificMatcher` cop. ([@ydah][])
 
 ## 2.11.1 (2022-05-18)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -832,6 +832,12 @@ RSpec/Capybara/FeatureMethods:
   VersionChanged: '2.0'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
 
+RSpec/Capybara/SpecificMatcher:
+  Description: Checks for there is a more specific matcher offered by Capybara.
+  Enabled: pending
+  VersionAdded: '2.12'
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/SpecificMatcher
+
 RSpec/Capybara/VisibilityMatcher:
   Description: Checks for boolean visibility in Capybara finders.
   Enabled: true

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -93,6 +93,7 @@
 
 * xref:cops_rspec_capybara.adoc#rspeccapybara/currentpathexpectation[RSpec/Capybara/CurrentPathExpectation]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/featuremethods[RSpec/Capybara/FeatureMethods]
+* xref:cops_rspec_capybara.adoc#rspeccapybara/specificmatcher[RSpec/Capybara/SpecificMatcher]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/visibilitymatcher[RSpec/Capybara/VisibilityMatcher]
 
 === Department xref:cops_rspec_factorybot.adoc[RSpec/FactoryBot]

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -106,6 +106,45 @@ end
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
 
+== RSpec/Capybara/SpecificMatcher
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| No
+| 2.12
+| -
+|===
+
+Checks for there is a more specific matcher offered by Capybara.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+expect(page).to have_selector('button')
+expect(page).to have_no_selector('button.cls')
+expect(page).to have_css('button')
+expect(page).to have_no_css('a.cls', exact_text: 'foo')
+expect(page).to have_css('table.cls')
+expect(page).to have_css('select')
+
+# good
+expect(page).to have_button
+expect(page).to have_no_button(class: 'cls')
+expect(page).to have_button
+expect(page).to have_no_link('foo', class: 'cls')
+expect(page).to have_table(class: 'cls')
+expect(page).to have_select
+----
+
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/SpecificMatcher
+
 == RSpec/Capybara/VisibilityMatcher
 
 |===

--- a/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module Capybara
+        # Checks for there is a more specific matcher offered by Capybara.
+        #
+        # @example
+        #
+        #   # bad
+        #   expect(page).to have_selector('button')
+        #   expect(page).to have_no_selector('button.cls')
+        #   expect(page).to have_css('button')
+        #   expect(page).to have_no_css('a.cls', exact_text: 'foo')
+        #   expect(page).to have_css('table.cls')
+        #   expect(page).to have_css('select')
+        #
+        #   # good
+        #   expect(page).to have_button
+        #   expect(page).to have_no_button(class: 'cls')
+        #   expect(page).to have_button
+        #   expect(page).to have_no_link('foo', class: 'cls')
+        #   expect(page).to have_table(class: 'cls')
+        #   expect(page).to have_select
+        #
+        class SpecificMatcher < Base
+          MSG = 'Prefer `%<good_matcher>s` over `%<bad_matcher>s`.'
+          RESTRICT_ON_SEND = %i[have_selector have_no_selector have_css
+                                have_no_css].freeze
+          SPECIFIC_MATCHER = {
+            'button' => 'button',
+            'a' => 'link',
+            'table' => 'table',
+            'select' => 'select'
+          }.freeze
+
+          # @!method first_argument(node)
+          def_node_matcher :first_argument, <<-PATTERN
+            (send nil? _ (str $_) ... )
+          PATTERN
+
+          def on_send(node)
+            return unless (arg = first_argument(node))
+            return unless (matcher = specific_matcher(arg))
+            return if acceptable_pattern?(arg)
+
+            add_offense(node, message: message(node, matcher))
+          end
+
+          private
+
+          def specific_matcher(arg)
+            splitted_arg = arg[/^\w+/, 0]
+            SPECIFIC_MATCHER[splitted_arg]
+          end
+
+          def acceptable_pattern?(arg)
+            arg.match?(/\[.+=\w+\]/)
+          end
+
+          def message(node, matcher)
+            format(MSG,
+                   good_matcher: good_matcher(node, matcher),
+                   bad_matcher: node.method_name)
+          end
+
+          def good_matcher(node, matcher)
+            node.method_name
+              .to_s
+              .gsub(/selector|css/, matcher.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -2,6 +2,7 @@
 
 require_relative 'rspec/capybara/current_path_expectation'
 require_relative 'rspec/capybara/feature_methods'
+require_relative 'rspec/capybara/specific_matcher'
 require_relative 'rspec/capybara/visibility_matcher'
 
 require_relative 'rspec/factory_bot/attribute_defined_statically'

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
+  it 'does not register an offense for abstract matcher when ' \
+    'first argument is not a replaceable element' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_selector('article')
+      expect(page).to have_no_selector('body')
+      expect(page).to have_css('tbody')
+    RUBY
+  end
+
+  it 'does not register an offense for abstract matcher when ' \
+    'first argument is not an element' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_no_css('.a')
+      expect(page).to have_selector('#button')
+      expect(page).to have_no_selector('[table]')
+    RUBY
+  end
+
+  it 'registers an offense when using `have_selector`' do
+    expect_offense(<<-RUBY)
+    expect(page).to have_selector('button')
+                    ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_selector`.
+    expect(page).to have_selector('a')
+                    ^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_selector`.
+    expect(page).to have_selector('table')
+                    ^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_table` over `have_selector`.
+    expect(page).to have_selector('select')
+                    ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_select` over `have_selector`.
+    RUBY
+  end
+
+  it 'registers an offense when using `have_no_selector`' do
+    expect_offense(<<-RUBY)
+    expect(page).to have_no_selector('button')
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_no_button` over `have_no_selector`.
+    RUBY
+  end
+
+  it 'registers an offense when using `have_css`' do
+    expect_offense(<<-RUBY)
+    expect(page).to have_css('button')
+                    ^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+    RUBY
+  end
+
+  it 'registers an offense when using `have_no_css`' do
+    expect_offense(<<-RUBY)
+    expect(page).to have_no_css('button')
+                    ^^^^^^^^^^^^^^^^^^^^^ Prefer `have_no_button` over `have_no_css`.
+    RUBY
+  end
+
+  it 'registers an offense when using abstract matcher and other args' do
+    expect_offense(<<-RUBY)
+    expect(page).to have_css('button', exact_text: 'foo')
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+    RUBY
+  end
+
+  it 'registers an offense when using abstract matcher with state' do
+    expect_offense(<<-RUBY)
+    expect(page).to have_css('button[disabled]', exact_text: 'foo')
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+    expect(page).to have_css('button:not([disabled])', exact_text: 'bar')
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+    RUBY
+  end
+
+  it 'does not register an offense for abstract matcher when ' \
+    'first argument is element with nonreplaceable attributes' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('button[foo=bar]')
+      expect(page).to have_css('button[foo-bar=baz]', exact_text: 'foo')
+    RUBY
+  end
+
+  it 'does not register an offense for abstract matcher when ' \
+    'first argument is dstr' do
+    expect_no_offenses(<<-'RUBY')
+      expect(page).to have_css(%{a[href="#{foo}"]}, text: "bar")
+    RUBY
+  end
+end


### PR DESCRIPTION
Resolves: https://github.com/rubocop/rubocop-rspec/issues/1248

This cop checks for there is a more specific matcher offered by Capybara.

### @example
```ruby
# bad
expect(page).to have_css('button')
expect(page).to have_css('button', exact_text: 'foo')
expect(page).to have_css('button[disabled]', exact_text: 'foo')
expect(page).to have_css('a')
expect(page).to have_css('a.cls', exact_text: 'foo')
expect(page).to have_css('table')
expect(page).to have_css('table.cls')

# good
expect(page).to have_button
expect(page).to have_button('foo')
expect(page).to have_button('foo', disabled: true)
expect(page).to have_link
expect(page).to have_link('foo', class: 'cls')
expect(page).to have_table
expect(page).to have_table(class: 'cls')
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
* [x] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
