### PR TITLE
Improved documentation for `RSpec/ChangeByZero`

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -404,6 +404,8 @@ Prefer negated matchers over `to change.by(0)`.
 # bad
 expect { run }.to change(Foo, :bar).by(0)
 expect { run }.to change { Foo.bar }.by(0)
+
+# bad - compound expectations
 expect { run }
   .to change(Foo, :bar).by(0)
   .and change(Foo, :baz).by(0)
@@ -414,6 +416,9 @@ expect { run }
 # good
 expect { run }.not_to change(Foo, :bar)
 expect { run }.not_to change { Foo.bar }
+
+# good - compound expectations
+define_negated_matcher :not_change, :change
 expect { run }
   .to not_change(Foo, :bar)
   .and not_change(Foo, :baz)

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -9,6 +9,8 @@ module RuboCop
       #   # bad
       #   expect { run }.to change(Foo, :bar).by(0)
       #   expect { run }.to change { Foo.bar }.by(0)
+      #
+      #   # bad - compound expectations
       #   expect { run }
       #     .to change(Foo, :bar).by(0)
       #     .and change(Foo, :baz).by(0)
@@ -19,6 +21,9 @@ module RuboCop
       #   # good
       #   expect { run }.not_to change(Foo, :bar)
       #   expect { run }.not_to change { Foo.bar }
+      #
+      #   # good - compound expectations
+      #   define_negated_matcher :not_change, :change
       #   expect { run }
       #     .to not_change(Foo, :bar)
       #     .and not_change(Foo, :baz)


### PR DESCRIPTION
This PR is improves documentation for `RSpec/ChangeByZero`.

Since it isn’t mentioned that define our own negation matcher for `not_change` for the compound expectations case, I felt it would be a bit confusing, so I'll explicitly mention that we define a negation matcher for the good case.

```ruby
define_negated_matcher :not_change, :change
expect { run }.to not_change(Foo, :x).and not_change(Foo, :y)
expect { run }.to not_change { Foo.x }.and not_change { Foo.y }
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).