### PR TITLE
Add a setting for "autocorrect" in `Naming/InclusiveLanguage`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,12 @@ Naming/InclusiveLanguage:
   Enabled: true
   CheckStrings: true
   FlaggedTerms:
+    auto-correct:
+      Suggestions:
+        - autocorrect
+    auto_correct:
+      Suggestions:
+        - autocorrect
     behaviour:
       Suggestions:
         - behavior

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -174,7 +174,7 @@ Use shorthands from `FactoryBot::Syntax::Methods` in your specs.
 
 === Safety
 
-The auto-correction is marked as unsafe because the cop
+The autocorrection is marked as unsafe because the cop
 cannot verify whether you already include
 `FactoryBot::Syntax::Methods` in your test suite.
 

--- a/lib/rubocop/cop/rspec/factory_bot/syntax_methods.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/syntax_methods.rb
@@ -7,7 +7,7 @@ module RuboCop
         # Use shorthands from `FactoryBot::Syntax::Methods` in your specs.
         #
         # @safety
-        #   The auto-correction is marked as unsafe because the cop
+        #   The autocorrection is marked as unsafe because the cop
         #   cannot verify whether you already include
         #   `FactoryBot::Syntax::Methods` in your test suite.
         #


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop/pull/10714

In this PR, we have made the following word's suggestions
- auto-correct -> autocorrect
- auto_correct -> autocorrect

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).