### PR TITLE
Refactor specs to use offence substitution

### DIFF
--- a/spec/rubocop/cop/rspec/factory_bot/syntax_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/syntax_methods_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::SyntaxMethods, :config do
     end
 
     it "registers an offense for `FactoryBot.#{method}`" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, method: method)
         describe Foo do
-          let(:bar) { FactoryBot.#{method}(:bar) }
-                      ^^^^^^^^^^^#{'^' * method.length} Use `#{method}` from `FactoryBot::Syntax::Methods`.
+          let(:bar) { FactoryBot.%{method}(:bar) }
+                      ^^^^^^^^^^^^{method} Use `%{method}` from `FactoryBot::Syntax::Methods`.
         end
       RUBY
 
@@ -32,10 +32,10 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::SyntaxMethods, :config do
     end
 
     it "registers an offense for `FactoryBot.#{method}` in a shared group" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, method: method)
         shared_examples_for Foo do
-          let(:bar) { FactoryBot.#{method}(:bar) }
-                      ^^^^^^^^^^^#{'^' * method.length} Use `#{method}` from `FactoryBot::Syntax::Methods`.
+          let(:bar) { FactoryBot.%{method}(:bar) }
+                      ^^^^^^^^^^^^{method} Use `%{method}` from `FactoryBot::Syntax::Methods`.
         end
       RUBY
 
@@ -47,10 +47,10 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::SyntaxMethods, :config do
     end
 
     it "registers an offense for `::FactoryBot.#{method}`" do
-      expect_offense(<<~RUBY)
+      expect_offense(<<~RUBY, method: method)
         RSpec.describe Foo do
-          let(:bar) { ::FactoryBot.#{method}(:bar) }
-                      ^^^^^^^^^^^^^#{'^' * method.length} Use `#{method}` from `FactoryBot::Syntax::Methods`.
+          let(:bar) { ::FactoryBot.%{method}(:bar) }
+                      ^^^^^^^^^^^^^^{method} Use `%{method}` from `FactoryBot::Syntax::Methods`.
         end
       RUBY
 


### PR DESCRIPTION
It's a convenient way to declare variable multi-column offence marks.
Spotted in https://github.com/rubocop/rubocop/blob/3b49d8558177cded154a5d51decdca918b01ad4c/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb#L194

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).