### PR TITLE
Improved documentation for `RSpec/ExpectActual`

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1483,6 +1483,8 @@ end
 
 Checks for `expect(...)` calls containing literal values.
 
+Autocorrection is performed when the expected is not a literal.
+
 === Examples
 
 [source,ruby]

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -5,6 +5,8 @@ module RuboCop
     module RSpec
       # Checks for `expect(...)` calls containing literal values.
       #
+      # Autocorrection is performed when the expected is not a literal.
+      #
       # @example
       #   # bad
       #   expect(5).to eq(price)


### PR DESCRIPTION
This PR is improves documentation for `RSpec/ExpectActual`.

For example, if you create a gem by `$ bundle gem hoge`, the following rspec code will be created.

```ruby
it "does something useful" do
  expect(false).to eq(true)
end
```

At first glance, it seems to be autocorrected, but when both expected and actual values are literal, no autocorrection is performed.
We'll add this as an explanation for cop.


---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
