### PR TITLE
Enable new cops

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@ If you have created a new cop:
 
 * [ ] Added the new cop to `config/default.yml`.
 * [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
+* [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
 * [ ] The cop documents examples of good and bad code.
 * [ ] The tests assert both that bad code is reported and that good code is not reported.
 * [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,3 +84,26 @@ RSpec/DescribeClass:
 Style/FormatStringToken:
   Exclude:
     - spec/rubocop/**/*.rb
+
+# Enable our own pending cops.
+
+RSpec/BeEq:
+  Enabled: true
+RSpec/BeNil:
+  Enabled: true
+RSpec/ChangeByZero:
+  Enabled: true
+RSpec/ExcessiveDocstringSpacing:
+  Enabled: true
+RSpec/IdenticalEqualityAssertion:
+  Enabled: true
+RSpec/SubjectDeclaration:
+  Enabled: true
+RSpec/VerifiedDoubleReference:
+  Enabled: true
+RSpec/Capybara/SpecificMatcher:
+  Enabled: true
+RSpec/FactoryBot/SyntaxMethods:
+  Enabled: true
+RSpec/Rails/AvoidSetupHook:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,9 +14,13 @@ AllCops:
     - 'tmp/**/*'
     - 'spec/smoke_tests/**/*.rb'
 
-# See https://github.com/rubocop/rubocop/issues/6410
 Layout/HashAlignment:
-  Enabled: false
+  EnforcedHashRocketStyle:
+    - key
+    - table
+  EnforcedColonStyle:
+    - key
+    - table
 
 Layout/LineLength:
   Max: 80 # default: 120
@@ -28,11 +32,6 @@ Layout/MultilineMethodCallIndentation:
 
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
-
-Lint/BooleanSymbol:
-  Exclude:
-    - lib/rubocop/cop/rspec/expect_actual.rb
-    - lib/rubocop/cop/rspec/focus.rb
 
 Lint/InterpolationCheck:
   Exclude:

--- a/lib/rubocop/cop/rspec/scattered_setup.rb
+++ b/lib/rubocop/cop/rspec/scattered_setup.rb
@@ -35,7 +35,7 @@ module RuboCop
             occurrences.each do |occurrence|
               lines_except_current = lines - [occurrence.first_line]
               message = format(MSG, hook_name: occurrences.first.method_name,
-                               lines: lines_msg(lines_except_current))
+                                    lines: lines_msg(lines_except_current))
               add_offense(occurrence, message: message)
             end
           end

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
-  it 'flags `let` after the first different node ' do
+  it 'flags `let` after the first different node' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         let(:a) { a }

--- a/spec/rubocop/rspec/config_formatter_spec.rb
+++ b/spec/rubocop/rspec/config_formatter_spec.rb
@@ -9,15 +9,15 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
         'Setting' => 'forty two'
       },
       'RSpec/Foo' => {
-        'Config'      => 2,
-        'Enabled'     => true
+        'Config' => 2,
+        'Enabled' => true
       },
       'RSpec/Bar' => {
-        'Enabled'     => true
+        'Enabled' => true
       },
       'RSpec/Baz' => {
-        'Enabled'     => true,
-        'StyleGuide'  => '#buzz'
+        'Enabled' => true,
+        'StyleGuide' => '#buzz'
       }
     }
   end

--- a/spec/rubocop/rspec/example_spec.rb
+++ b/spec/rubocop/rspec/example_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::RSpec::Example, :config do
   end
 
   it 'returns nil for examples without doc strings' do
-    expect(example('it { foo }').doc_string).to be(nil)
+    expect(example('it { foo }').doc_string).to be_nil
   end
 
   it 'extracts keywords' do
@@ -58,12 +58,14 @@ RSpec.describe RuboCop::RSpec::Example, :config do
   end
 
   describe 'value object semantics' do
+    # rubocop:disable RSpec/IdenticalEqualityAssertion
     it 'compares by value' do
       aggregate_failures 'equality semantics' do
         expect(example('it("foo")')).to eq(example('it("foo")'))
         expect(example('it("foo")')).not_to eq(example('it("bar")'))
       end
     end
+    # rubocop:enable RSpec/IdenticalEqualityAssertion
 
     it 'can be used as a key in a hash' do
       hash = {}


### PR DESCRIPTION
Our own pending `RSpec` cops should be enabled in our .rubocop.yml

I haven’t figured out a way to do it automatically, so here’s they are manually enabled

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
