### PR TITLE
Mark RSpec/VerifiedDoubleReference as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed false offense detection in `FactoryBot/CreateList` when a n.times block is including method calls in the factory create arguments. ([@ngouy][])
 * Fix error in `RSpec/RSpec/FactoryBot/CreateList` cop for empty block. ([@tejasbubane][])
 * Update `RSpec/MultipleExpectations` cop documentation with examples of aggregate_failures use. ([@edgibbs][])
+* Declare autocorrect as unsafe for `RSpec/VerifiedDoubleReference`. ([@Drowze][])
 
 ## 2.11.1 (2022-05-18)
 
@@ -704,3 +705,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@johnny-miyake]: https://github.com/johnny-miyake
 [@ngouy]: https://github.com/ngouy
 [@edgibbs]: https://github.com/edgibbs
+[@Drowze]: https://github.com/Drowze

--- a/config/default.yml
+++ b/config/default.yml
@@ -783,11 +783,13 @@ RSpec/VariableName:
 RSpec/VerifiedDoubleReference:
   Description: Checks for consistent verified double reference style.
   Enabled: pending
+  SafeAutoCorrect: false
   EnforcedStyle: constant
   SupportedStyles:
     - constant
     - string
   VersionAdded: 2.10.0
+  VersionChanged: '2.12'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubleReference
 
 RSpec/VerifiedDoubles:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4429,9 +4429,9 @@ let(:userFood_2) { 'fettuccine' }
 
 | Pending
 | Yes
-| Yes
+| Yes (Unsafe)
 | 2.10.0
-| -
+| 2.12
 |===
 
 Checks for consistent verified double reference style.


### PR DESCRIPTION
It's unsafe as the constant might not exist, e.g.:

```ruby
# consider that Asdfasdf is not a defined constant
let(:object) { instance_double("Asdfasdf") }

it do
  expect(object).to receive(:hello)
  object.hello
end
```

If we ran RSpec/VerifiedDoubleReference's autocorrect on the above code, our previously passing test will fail with `NameError: uninitialized constant Asdfasdf`

Disclaimer: I understand this is a bad use of `instance_double` 🤷‍♂️ . Found this issue when trying to apply rubocop-rspec on a codebase I'm maintaining though.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
