### PR TITLE
Bump version to 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.12.0 (2022-07-02)
+
 * Fix incorrect path suggested by `RSpec/FilePath` cop when second argument contains spaces. ([@tejasbubane][])
 * Fix autocorrect for EmptyLineSeparation. ([@johnny-miyake][])
 * Add new `RSpec/Capybara/SpecificMatcher` cop. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -913,7 +913,7 @@ RSpec/Rails/HaveHttpStatus:
   Description: Checks that tests use `have_http_status` instead of equality matchers.
   Enabled: pending
   SafeAutoCorrect: false
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.12'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HaveHttpStatus
 
 RSpec/Rails/HttpStatus:

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -41,7 +41,7 @@ end
 | Pending
 | Yes
 | Yes (Unsafe)
-| <<next>>
+| 2.12
 | -
 |===
 

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.11.1'
+      STRING = '2.12.0'
     end
   end
 end


### PR DESCRIPTION
We have a few changes since the last release (v2.11.1), so I thought it might be time for a new release.

* Fix incorrect path suggested by `RSpec/FilePath` cop when second argument contains spaces.
* Fix autocorrect for EmptyLineSeparation.
* Add new `RSpec/Capybara/SpecificMatcher` cop.
* Fixed false offense detection in `FactoryBot/CreateList` when a n.times block is including method calls in the factory create arguments.
* Fix error in `RSpec/RSpec/FactoryBot/CreateList` cop for empty block.
* Update `RSpec/MultipleExpectations` cop documentation with examples of aggregate_failures use.
* Declare autocorrect as unsafe for `RSpec/VerifiedDoubleReference`.
* Add new `RSpec/Rails/HaveHttpStatus` cop.