### PR TITLE
[Fix #1310] Fix a false positive for `RSpec/Capybara/SpecificMatcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix a false positive for `RSpec/Capybara/SpecificMatcher`. ([@ydah][])
+
 ## 2.12.0 (2022-07-02)
 
 * Fix incorrect path suggested by `RSpec/FilePath` cop when second argument contains spaces. ([@tejasbubane][])

--- a/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
@@ -56,7 +56,7 @@ module RuboCop
           end
 
           def acceptable_pattern?(arg)
-            arg.match?(/\[.+=\w+\]/)
+            arg.match?(/\[.+=\w+\]/) || arg.match?(/[ >,+]/)
           end
 
           def message(node, matcher)

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -78,6 +78,16 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   end
 
   it 'does not register an offense for abstract matcher when ' \
+  'first argument is element with sub matcher' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('button body')
+      expect(page).to have_css('a,h1')
+      expect(page).to have_css('table>tr')
+      expect(page).to have_css('select+option')
+    RUBY
+  end
+
+  it 'does not register an offense for abstract matcher when ' \
     'first argument is dstr' do
     expect_no_offenses(<<-'RUBY')
       expect(page).to have_css(%{a[href="#{foo}"]}, text: "bar")


### PR DESCRIPTION
Fix: #1310

Updated to not offense in the case of non-replaceable css selectors.

```ruby
expect(page).to have_css('button body')
expect(page).to have_css('a,h1')
expect(page).to have_css('table>tr')
expect(page).to have_css('select+option')
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
