### PR TITLE
Add new for AllowConsecutiveOneLiners option for Rspec/EmptyLineAfterHook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Add new `AllowConsecutiveOneLiners` (default true) option for `Rspec/EmptyLineAfterHook` cop. ([@ngouy][])
+
 ## 2.12.1 (2022-07-03)
 
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher`. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -315,8 +315,10 @@ RSpec/EmptyLineAfterHook:
   Description: Checks if there is an empty line after hook blocks.
   Enabled: true
   VersionAdded: '1.27'
+  VersionChanged: '2.13'
   StyleGuide: https://rspec.rubystyle.guide/#empty-line-after-let
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterHook
+  AllowConsecutiveOneLiners: true
 
 RSpec/EmptyLineAfterSubject:
   Description: Checks if there is an empty line after subject block.

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1123,10 +1123,13 @@ it { does_something }
 | Yes
 | Yes
 | 1.27
-| -
+| 2.13
 |===
 
 Checks if there is an empty line after hook blocks.
+
+`AllowConsecutiveOneLiners` configures whether adjacent
+one-line definitions are considered an offense.
 
 === Examples
 
@@ -1145,11 +1148,27 @@ around { |test| test.run }
 it { does_something }
 
 # good
-before { do_something }
+after { do_something }
 
 it { does_something }
 
-# good
+# fair - it's ok to have non-separated one-liners hooks
+around { |test| test.run }
+after { do_something }
+
+it { does_something }
+----
+
+==== with AllowConsecutiveOneLiners configuration
+
+[source,ruby]
+----
+# rubocop.yml
+# RSpec/EmptyLineAfterHook:
+#   AllowConsecutiveOneLiners: false
+
+# bad
+around { |test| test.run }
 after { do_something }
 
 it { does_something }
@@ -1157,8 +1176,20 @@ it { does_something }
 # good
 around { |test| test.run }
 
+after { do_something }
+
 it { does_something }
 ----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowConsecutiveOneLiners
+| `true`
+| Boolean
+|===
 
 === References
 

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -5,6 +5,9 @@ module RuboCop
     module RSpec
       # Checks if there is an empty line after hook blocks.
       #
+      # `AllowConsecutiveOneLiners` configures whether adjacent
+      # one-line definitions are considered an offense.
+      #
       # @example
       #   # bad
       #   before { do_something }
@@ -19,11 +22,23 @@ module RuboCop
       #   it { does_something }
       #
       #   # good
-      #   before { do_something }
+      #   after { do_something }
       #
       #   it { does_something }
       #
-      #   # good
+      #   # fair - it's ok to have non-separated one-liners hooks
+      #   around { |test| test.run }
+      #   after { do_something }
+      #
+      #   it { does_something }
+      #
+      # @example with AllowConsecutiveOneLiners configuration
+      #   # rubocop.yml
+      #   # RSpec/EmptyLineAfterHook:
+      #   #   AllowConsecutiveOneLiners: false
+      #
+      #   # bad
+      #   around { |test| test.run }
       #   after { do_something }
       #
       #   it { does_something }
@@ -31,20 +46,32 @@ module RuboCop
       #   # good
       #   around { |test| test.run }
       #
-      #   it { does_something }
+      #   after { do_something }
       #
+      #   it { does_something }
       class EmptyLineAfterHook < Base
         extend AutoCorrector
+        include ConfigurableEnforcedStyle
         include EmptyLineSeparation
 
         MSG = 'Add an empty line after `%<hook>s`.'
 
         def on_block(node)
           return unless hook?(node)
+          return if cop_config['AllowConsecutiveOneLiners'] &&
+            chained_single_line_hooks?(node)
 
           missing_separating_line_offense(node) do |method|
             format(MSG, hook: method)
           end
+        end
+
+        private
+
+        def chained_single_line_hooks?(node)
+          next_node = node.right_sibling
+
+          hook?(next_node) && node.single_line? && next_node.single_line?
         end
       end
     end

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -1,255 +1,455 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
-  it 'registers an offense for empty line after `before` hook' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
-        ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
-        it { does_something }
-      end
-    RUBY
-
-    expect_correction(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
-
-        it { does_something }
-      end
-    RUBY
-  end
-
-  it 'registers an offense for empty line after `after` hook' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        after { do_something }
-        ^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `after`.
-        it { does_something }
-      end
-    RUBY
-
-    expect_correction(<<-RUBY)
-      RSpec.describe User do
-        after { do_something }
-
-        it { does_something }
-      end
-    RUBY
-  end
-
-  it 'registers an offense for empty line after `around` hook' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        around { |test| test.run }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `around`.
-        it { does_something }
-      end
-    RUBY
-
-    expect_correction(<<-RUBY)
-      RSpec.describe User do
-        around { |test| test.run }
-
-        it { does_something }
-      end
-    RUBY
-  end
-
-  it 'does not register an offense for empty line after `before` hook' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
-
-        it { does_something }
-      end
-    RUBY
-  end
-
-  it 'does not register an offense for empty line after `after` hook' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        after { do_something }
-
-        it { does_something }
-      end
-    RUBY
-  end
-
-  it 'does not register an offense for empty line after `around` hook' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        around { |test| test.run }
-
-        it { does_something }
-      end
-    RUBY
-  end
-
-  it 'does not register an offense for multiline `before` block' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        before do
-          do_something
+  shared_examples_for 'always require empty line after hook groups' do
+    it 'registers an offense for multiline blocks without empty line before' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something_else }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          before do
+            do_something
+          end
+          ^^^ Add an empty line after `before`.
+          it { does_something }
         end
+      RUBY
 
-        it { does_something }
-      end
-    RUBY
-  end
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something_else }
 
-  it 'does not register an offense for multiline `after` block' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        after do
-          do_something
+          before do
+            do_something
+          end
+
+          it { does_something }
         end
+      RUBY
+    end
 
-        it { does_something }
-      end
-    RUBY
-  end
-
-  it 'does not register an offense for multiline `around` block' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        around do |test|
-          test.run
+    it 'registers an offense for empty line after `before` hook' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          it { does_something }
         end
+      RUBY
 
-        it { does_something }
-      end
-    RUBY
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'registers an offense for empty line after `after` hook' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          after { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `after`.
+          it { does_something }
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          after { do_something }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'registers an offense for empty line after `around` hook' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          around { |test| test.run }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `around`.
+          it { does_something }
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          around { |test| test.run }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for empty line after `before` hook' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for empty line after `after` hook' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          after { do_something }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for empty line after `around` hook' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          around { |test| test.run }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for multiline `before` block' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          before do
+            do_something
+          end
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for multiline `after` block' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          after do
+            do_something
+          end
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for multiline `around` block' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          around do |test|
+            test.run
+          end
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for `before` being the latest node' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for a comment followed by an empty line' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          # comment
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'flags a missing empty line before a comment' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          # comment
+          it { does_something }
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+
+          # comment
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'flags a missing empty line before a multiline comment' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          # multiline comment
+          # multiline comment
+          it { does_something }
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+
+          # multiline comment
+          # multiline comment
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'flags a missing empty line after a `rubocop:enable` directive' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          # rubocop:disable RSpec/Foo
+          before { do_something }
+          # rubocop:enable RSpec/Foo
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          it { does_something }
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          # rubocop:disable RSpec/Foo
+          before { do_something }
+          # rubocop:enable RSpec/Foo
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'flags a missing empty line before a `rubocop:disable` directive' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          # rubocop:disable RSpec/Foo
+          it { does_something }
+          # rubocop:enable RSpec/Foo
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+
+          # rubocop:disable RSpec/Foo
+          it { does_something }
+          # rubocop:enable RSpec/Foo
+        end
+      RUBY
+    end
+
+    it 'flags a missing empty line after a `rubocop:enable` directive '\
+        'when it is followed by a `rubocop:disable` directive' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          # rubocop:disable RSpec/Foo
+          before { do_something }
+          # rubocop:enable RSpec/Foo
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          # rubocop:disable RSpec/Foo
+          it { does_something }
+          # rubocop:enable RSpec/Foo
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          # rubocop:disable RSpec/Foo
+          before { do_something }
+          # rubocop:enable RSpec/Foo
+
+          # rubocop:disable RSpec/Foo
+          it { does_something }
+          # rubocop:enable RSpec/Foo
+        end
+      RUBY
+    end
   end
 
-  it 'does not register an offense for `before` being the latest node' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
-      end
-    RUBY
+  shared_examples_for 'never allows consecutive multiline blocks' do
+    it 'registers an offense for multiline blocks without empty line after' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before do
+            do_something
+          end
+          ^^^ Add an empty line after `before`.
+          before { do_something_else }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          it { does_something }
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before do
+            do_something
+          end
+
+          before { do_something_else }
+
+          it { does_something }
+        end
+      RUBY
+    end
   end
 
-  it 'does not register an offense for a comment followed by an empty line' do
-    expect_no_offenses(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
-        # comment
+  context 'when AllowConsecutiveOneLiners option has default value `true`' do
+    include_examples 'always require empty line after hook groups'
+    include_examples 'never allows consecutive multiline blocks'
 
-        it { does_something }
-      end
-    RUBY
+    it 'allows multiple one-liner blocks' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          before { do_something_else }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          it { does_something }
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          before { do_something_else }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'allows multiple one-liner blocks with comments' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          # this is a comment
+          before { do_something_else }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          it { does_something }
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          # this is a comment
+          before { do_something_else }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'does not register an offense for chained one-liner `before` hooks' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          before { do_something_else }
+
+          it { does_something }
+        end
+      RUBY
+    end
+
+    it 'allows chained one-liner with different hooks' do
+      expect_no_offenses(<<-RUBY)
+        RSpec.describe User do
+          before { do_something_else }
+          after { do_something_else }
+
+          it { does_something }
+        end
+      RUBY
+    end
   end
 
-  it 'flags a missing empty line before a comment' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
-        ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
-        # comment
-        it { does_something }
-      end
-    RUBY
+  context 'when AllowConsecutiveOneLiners option `false`' do
+    let(:cop_config) { { 'AllowConsecutiveOneLiners' => false } }
 
-    expect_correction(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
+    include_examples 'always require empty line after hook groups'
+    include_examples 'never allows consecutive multiline blocks'
 
-        # comment
-        it { does_something }
-      end
-    RUBY
-  end
+    it 'registers an offense for multiple one-liner same hook blocks' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          before { do_something_else }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          it { does_something }
+        end
+      RUBY
 
-  it 'flags a missing empty line before a multiline comment' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
-        ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
-        # multiline comment
-        # multiline comment
-        it { does_something }
-      end
-    RUBY
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
 
-    expect_correction(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
+          before { do_something_else }
 
-        # multiline comment
-        # multiline comment
-        it { does_something }
-      end
-    RUBY
-  end
+          it { does_something }
+        end
+      RUBY
+    end
 
-  it 'flags a missing empty line after a `rubocop:enable` directive' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        # rubocop:disable RSpec/Foo
-        before { do_something }
-        # rubocop:enable RSpec/Foo
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
-        it { does_something }
-      end
-    RUBY
+    it 'registers an offense for multiple one-liner blocks with comments' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          # this is a comment
+          before { do_something_else }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          it { does_something }
+        end
+      RUBY
 
-    expect_correction(<<-RUBY)
-      RSpec.describe User do
-        # rubocop:disable RSpec/Foo
-        before { do_something }
-        # rubocop:enable RSpec/Foo
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
 
-        it { does_something }
-      end
-    RUBY
-  end
+          # this is a comment
+          before { do_something_else }
 
-  it 'flags a missing empty line before a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
-        ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
-        # rubocop:disable RSpec/Foo
-        it { does_something }
-        # rubocop:enable RSpec/Foo
-      end
-    RUBY
+          it { does_something }
+        end
+      RUBY
+    end
 
-    expect_correction(<<-RUBY)
-      RSpec.describe User do
-        before { do_something }
+    it 'registers an offense for multiple one-liner different hook blocks' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
+          after { do_something_else }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `after`.
+          it { does_something }
+        end
+      RUBY
 
-        # rubocop:disable RSpec/Foo
-        it { does_something }
-        # rubocop:enable RSpec/Foo
-      end
-    RUBY
-  end
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          before { do_something }
 
-  it 'flags a missing empty line after a `rubocop:enable` directive '\
-      'when it is followed by a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
-      RSpec.describe User do
-        # rubocop:disable RSpec/Foo
-        before { do_something }
-        # rubocop:enable RSpec/Foo
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
-        # rubocop:disable RSpec/Foo
-        it { does_something }
-        # rubocop:enable RSpec/Foo
-      end
-    RUBY
+          after { do_something_else }
 
-    expect_correction(<<-RUBY)
-      RSpec.describe User do
-        # rubocop:disable RSpec/Foo
-        before { do_something }
-        # rubocop:enable RSpec/Foo
-
-        # rubocop:disable RSpec/Foo
-        it { does_something }
-        # rubocop:enable RSpec/Foo
-      end
-    RUBY
+          it { does_something }
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Add new `AllowAdjacentOneLineHooks` for `Rspec/EmptyLineAfterHook` so the cop allows to chain one-liner same kind hook blocks

https://github.com/rubocop/rubocop-rspec/issues/1314

Inspired from https://github.com/rubocop/rubocop/blob/00e7ac78fb83383ef537e9e08ecf2301a1427578/lib/rubocop/cop/layout/empty_line_between_defs.rb
https://github.com/ngouy/rubocop-rspec/blob/9f4d7faea265010bb643abe7fbc260db29563de8/lib/rubocop/cop/rspec/empty_line_after_example.rb#L68

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* no

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.

*edit* rename `AllowAdjacentOneLineHooks` to `AllowConsecutiveOneLiners` to follow already existing param in `EmptyLineAfterExample` example