### PR TITLE
Add autocorrect support for `RSpec/EmptyExampleGroup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add new `AllowConsecutiveOneLiners` (default true) option for `Rspec/EmptyLineAfterHook` cop. ([@ngouy][])
+* Add autocorrect support for `RSpec/EmptyExampleGroup`. ([@r7kamura][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -279,8 +279,9 @@ RSpec/Dialect:
 RSpec/EmptyExampleGroup:
   Description: Checks if an example group does not include any tests.
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '1.7'
-  VersionChanged: '2.0'
+  VersionChanged: '2.13'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
 
 RSpec/EmptyHook:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -879,9 +879,9 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes (Unsafe)
 | 1.7
-| 2.0
+| 2.13
 |===
 
 Checks if an example group does not include any tests.

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -36,6 +36,10 @@ module RuboCop
       #     pending 'will add tests later'
       #   end
       class EmptyExampleGroup < Base
+        extend AutoCorrector
+
+        include RangeHelp
+
         MSG = 'Empty example group detected.'
 
         # @!method example_group_body(node)
@@ -135,7 +139,11 @@ module RuboCop
           return if node.each_ancestor(:block).any? { |block| example?(block) }
 
           example_group_body(node) do |body|
-            add_offense(node.send_node) if offensive?(body)
+            next unless offensive?(body)
+
+            add_offense(node.send_node) do |corrector|
+              corrector.remove(removed_range(node))
+            end
           end
         end
 
@@ -162,6 +170,13 @@ module RuboCop
 
         def examples_in_branches?(condition_node)
           condition_node.branches.any? { |branch| examples?(branch) }
+        end
+
+        def removed_range(node)
+          range_by_whole_lines(
+            node.location.expression,
+            include_final_newline: true
+          )
         end
       end
     end

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
         it { should be_true }
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+
+        describe '#thingy?' do
+          specify do
+            expect(whatever.thingy?).to be(true)
+          end
+        end
+
+        it { should be_true }
+      end
+    RUBY
   end
 
   it 'flags an empty top level describe' do
@@ -26,6 +39,9 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
       describe Foo do
       ^^^^^^^^^^^^ Empty example group detected.
       end
+    RUBY
+
+    expect_correction(<<~RUBY)
     RUBY
   end
 


### PR DESCRIPTION
This is an unsafe cop, but I think it could be useful when we wany to automatically remove unnecessary test code.

I have used this feature in our own application and found it so useful that I decided to submit this pull request.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
