### PR TITLE
Simplify siblings code

### DIFF
--- a/lib/rubocop/cop/rspec/empty_line_after_example.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example.rb
@@ -65,19 +65,15 @@ module RuboCop
         end
 
         def consecutive_one_liner?(node)
-          node.line_count == 1 && next_one_line_example?(node)
+          node.single_line? && next_one_line_example?(node)
         end
 
         def next_one_line_example?(node)
-          next_sibling = next_sibling(node)
+          next_sibling = node.right_sibling
           return unless next_sibling
           return unless example?(next_sibling)
 
-          next_sibling.line_count == 1
-        end
-
-        def next_sibling(node)
-          node.parent.children[node.sibling_index + 1]
+          next_sibling.single_line?
         end
       end
     end

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -52,13 +52,12 @@ module RuboCop
           first_example = find_first_example(node)
           return unless first_example
 
-          node.each_child_node do |child|
-            next if child.sibling_index < first_example.sibling_index
-            next unless hook?(child)
+          first_example.right_siblings.each do |sibling|
+            next unless hook?(sibling)
 
-            msg = format(MSG, hook: child.method_name)
-            add_offense(child, message: msg) do |corrector|
-              autocorrect(corrector, child, first_example)
+            msg = format(MSG, hook: sibling.method_name)
+            add_offense(sibling, message: msg) do |corrector|
+              autocorrect(corrector, sibling, first_example)
             end
           end
         end

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -59,12 +59,11 @@ module RuboCop
           first_example = find_first_example(node)
           return unless first_example
 
-          node.each_child_node do |child|
-            next if child.sibling_index < first_example.sibling_index
-            next unless let?(child)
+          first_example.right_siblings.each do |sibling|
+            next unless let?(sibling)
 
-            add_offense(child) do |corrector|
-              autocorrect(corrector, child, first_example)
+            add_offense(sibling) do |corrector|
+              autocorrect(corrector, sibling, first_example)
             end
           end
         end

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -53,10 +53,6 @@ module RuboCop
             end
           end
         end
-
-        def find_first_let(node)
-          node.children.find { |child| let?(child) }
-        end
       end
     end
   end


### PR DESCRIPTION
Previously we would iterate all siblings and skip as necessary to get only the ones on the right. But rubocop-ast provides methods to get the left/right sibling(s).
So this takes advantage of those and removes some custom code. It also removes an unused method

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Updated documentation.~
* [x] ~Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

