### PR TITLE
Add an RSpec 4 pre-release CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,3 +61,24 @@ jobs:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
       - run: bundle exec rake ${{ matrix.task }}
+
+  rspec4:
+    runs-on: ubuntu-latest
+    name: RSpec 4
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use latest RSpec 4 from `4-0-dev` branch
+        run: |
+          sed -e '/rspec/d' -i Gemfile
+          cat << EOF > Gemfile.local
+            gem 'rspec', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec-core', github: 'rspec/rspec-core', branch: '4-0-dev'
+            gem 'rspec-expectations', github: 'rspec/rspec-expectations', branch: '4-0-dev'
+            gem 'rspec-mocks', github: 'rspec/rspec-mocks', branch: '4-0-dev'
+            gem 'rspec-support', github: 'rspec/rspec-support', branch: '4-0-dev'
+          EOF
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle exec rake spec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,22 +32,30 @@ jobs:
         task:
           - internal_investigation
           - spec
-        rubocop_version:
-          - gem
-        include:
-          - rubocop_version: edge
-            ruby: 2.7
-            task: internal_investigation
-          - rubocop_version: edge
-            ruby: 2.7
-            task: spec
-    name: ${{ matrix.task }}, Ruby ${{ matrix.ruby }} (${{ matrix.rubocop_version }})
+    name: ${{ matrix.task }}, Ruby ${{ matrix.ruby }} (gem)
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "${{ matrix.ruby }}"
+          bundler-cache: true
+      - run: bundle exec rake ${{ matrix.task }}
+
+  edge-rubocop:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - 2.7
+        task:
+          - internal_investigation
+          - spec
+    name: ${{ matrix.task }} Ruby ${{ matrix.ruby }} (edge)
     steps:
       - uses: actions/checkout@v2
       - name: Use latest RuboCop from `master`
         run: |
           echo "gem 'rubocop', github: 'rubocop-hq/rubocop'" > Gemfile.local
-        if: matrix.rubocop_version == 'edge'
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby }}"

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --require spec_helper
---color
 --format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem 'rack'
 gem 'rake'
-gem 'rspec', '>= 3.4'
+gem 'rspec', '~> 3.11'
 gem 'rubocop-performance', '~> 1.7'
 gem 'rubocop-rake', '~> 0.6'
 gem 'yard'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,13 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'rack'
+gem 'rake'
+gem 'rspec', '>= 3.4'
+gem 'rubocop-performance', '~> 1.7'
+gem 'rubocop-rake', '~> 0.6'
+gem 'yard'
+
 local_gemfile = 'Gemfile.local'
 
 if File.exist?(local_gemfile)

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -38,11 +38,4 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency 'rubocop', '~> 1.31'
-
-  spec.add_development_dependency 'rack'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '>= 3.4'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.7'
-  spec.add_development_dependency 'rubocop-rake', '~> 0.6'
-  spec.add_development_dependency 'yard'
 end

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe 'RuboCop::CLI --autocorrect', :isolated_environment do # rubocop:disable RSpec/DescribeClass
+RSpec.describe 'RuboCop::CLI --autocorrect' do # rubocop:disable RSpec/DescribeClass
   subject(:cli) { RuboCop::CLI.new }
+
+  include_context 'isolated environment'
 
   include_context 'when cli spec behavior'
 

--- a/spec/smoke_tests/weird_rspec_spec.rb
+++ b/spec/smoke_tests/weird_rspec_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Weirdness' do
   end
 
   it_behaves_like :something
-  it_should_behave_like :something
+  it_should_behave_like :something if RSpec::Core::Version::STRING < '4.0'
 
   it_behaves_like :something do
     let(:foo) { 'bar' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,11 +24,7 @@ RSpec.configure do |config|
   config.order = :random
 
   # Run focused tests with `fdescribe`, `fit`, `:focus` etc.
-  config.filter_run focus: true
-  config.run_all_when_everything_filtered = true
-
-  # Forbid RSpec from monkey patching any of our objects
-  config.disable_monkey_patching!
+  config.filter_run_when_matching :focus
 
   # We should address configuration warnings when we upgrade
   config.raise_errors_for_deprecations!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,10 @@ RSpec.configure do |config|
   config.raise_on_warning = true
 
   config.include(ExpectOffense)
+
+  config.include_context 'with default RSpec/Language config', :config
+  config.include_context 'config', :config
+  config.include_context 'smoke test', type: :cop_spec
 end
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))


### PR DESCRIPTION
RSpec 4 will eventually be released. Since we're checking RSpec style, why don't we use RSpec 4 at least in an optional job to help test it out?

Below what had to be done.

### Move dev dependencies to Gemfile

A similar (unmerged) `rspec-support` PR https://github.com/rspec/rspec-support/pull/517

Reasoning (https://bundler.io/v2.2/man/gemfile.5.html#GEMSPEC):

> The .gemspec file is ... where you specify the dependencies your gem needs *to run*.

Even though it contradicts the very existence of add_development_dependency.

Discussions on this topic:
- https://github.com/rubygems/rubygems/discussions/5065
- https://github.com/rubygems/rubygems/issues/1104

### Refactored our CI workflow

Extracted `edge` RuboCop in separate job(s).

### RSpec 4

It's complicated and not an obvious situation with shared contexts.
Previously, they were auto-included using matching metadata. Now, only explicitly (see changes to the `spec/spec_helper.rb`). This revealed two issues:

1. Those shared examples that define metadata themselves, e.g. `shared_examples 'config', :config do` would be included first. Since we're overriding the one defined in `rubocop` with ours, to set `other_cops` with a proper RSpec DSL configuration, there is only one way of doing that in a non-Yoda order as we have to do now:
```ruby
  config.include_context 'with default RSpec/Language config', :config # Intuituvely, this should go below
  config.include_context 'config', :config
```
is to remove `:config` from the definition in `rubocop`.
But this makes it complicated, since well-known extensions depend on this metadata, and custom cops' specs, too.
This needs to be somehow fixed on RSpec 4 side.

2. There is no straightforward way now to define a satellite example group for specs, like e.g. 'smoke test' one. There is no such thing as `config.include_examples`. However, `config.include_context` exists, and it's an alias that has different semantics but identical behaviour.