### PR TITLE
Fix FilePath cop missing expanded namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Fix `RSpec/FilePath` cop missing mismatched expanded namespace. ([@sl4vr][])
 * Add new `AllowConsecutiveOneLiners` (default true) option for `Rspec/EmptyLineAfterHook` cop. ([@ngouy][])
 * Add autocorrect support for `RSpec/EmptyExampleGroup`. ([@r7kamura][])
 

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -20,6 +20,7 @@ require_relative 'rubocop/cop/rspec/mixin/final_end_location'
 require_relative 'rubocop/cop/rspec/mixin/comments_help'
 require_relative 'rubocop/cop/rspec/mixin/empty_line_separation'
 require_relative 'rubocop/cop/rspec/mixin/inside_example_group'
+require_relative 'rubocop/cop/rspec/mixin/namespace'
 
 require_relative 'rubocop/rspec/concept'
 require_relative 'rubocop/rspec/example_group'

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -57,6 +57,7 @@ module RuboCop
       class DescribedClass < Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle
+        include Namespace
 
         DESCRIBED_CLASS = 'described_class'
         MSG             = 'Use `%<replacement>s` instead of `%<src>s`.'
@@ -160,7 +161,8 @@ module RuboCop
         end
 
         def full_const_name(node)
-          collapse_namespace(namespace(node), const_name(node))
+          symbolized_namespace = namespace(node).map(&:to_sym)
+          collapse_namespace(symbolized_namespace, const_name(node))
         end
 
         # @param namespace [Array<Symbol>]
@@ -199,18 +201,6 @@ module RuboCop
           elsif %i[lvar cbase send].include?(namespace.type)
             [nil, name]
           end
-        end
-
-        # @param node [RuboCop::AST::Node]
-        # @return [Array<Symbol>]
-        # @example
-        #   namespace(node) # => [:A, :B, :C]
-        def namespace(node)
-          node
-            .each_ancestor(:class, :module)
-            .reverse_each
-            .flat_map { |ancestor| ancestor.defined_module_name.split('::') }
-            .map(&:to_sym)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -58,6 +58,7 @@ module RuboCop
       #
       class FilePath < Base
         include TopLevelGroup
+        include Namespace
 
         MSG = 'Spec path should end with `%<suffix>s`.'
 
@@ -101,7 +102,7 @@ module RuboCop
 
         def pattern_for(example_group, method_name)
           if spec_suffix_only? || !example_group.const_type?
-            return pattern_for_spec_suffix_only?
+            return pattern_for_spec_suffix_only
           end
 
           [
@@ -111,7 +112,7 @@ module RuboCop
           ].join
         end
 
-        def pattern_for_spec_suffix_only?
+        def pattern_for_spec_suffix_only
           '.*_spec\.rb'
         end
 
@@ -123,8 +124,10 @@ module RuboCop
         end
 
         def expected_path(constant)
+          constants = namespace(constant) + constant.const_name.split('::')
+
           File.join(
-            constant.const_name.split('::').map do |name|
+            constants.map do |name|
               custom_transform.fetch(name) { camel_to_snake_case(name) }
             end
           )

--- a/lib/rubocop/cop/rspec/mixin/namespace.rb
+++ b/lib/rubocop/cop/rspec/mixin/namespace.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Helps to find namespace of the node.
+      module Namespace
+        private
+
+        # @param node [RuboCop::AST::Node]
+        # @return [Array<String>]
+        # @example
+        #   namespace(node) # => ['A', 'B', 'C']
+        def namespace(node)
+          node
+            .each_ancestor(:class, :module)
+            .reverse_each
+            .flat_map { |ancestor| ancestor.defined_module_name.split('::') }
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -213,10 +213,21 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'registers an offense for path based on a class name with long module' do
+  it 'registers an offense for path with incorrect collapsed namespace' do
     expect_offense(<<-RUBY, '/home/foo/spec/very/my_class_spec.rb')
       describe Very::Long::Namespace::MyClass do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `very/long/namespace/my_class*_spec.rb`.
+    RUBY
+  end
+
+  it 'registers an offense for path with incorrect expanded namespace' do
+    expect_offense(<<-RUBY, '/home/foo/spec/very/long/my_class_spec.rb')
+      module Very
+        module Medium
+          describe MyClass do; end
+          ^^^^^^^^^^^^^^^^ Spec path should end with `very/medium/my_class*_spec.rb`.
+        end
+      end
     RUBY
   end
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rspec/issues/1107.
Tests taken from https://github.com/rubocop/rubocop-rspec/pull/1287.

In order to handle expanded namespaces, `namespace` helper method from `RSpec/DescribedClass` cop is used and moved into standalone mixin.

I haven't dug into it, but at first glance it seems that [parent_module_name from rubocop-ast](https://github.com/rubocop-hq/rubocop-ast/blob/e2df776f6aa4133413e2de0e20b4a3295b12988f/lib/rubocop/ast/node.rb#L333) returns namespace of concrete node while `namespace` helper method just looks or all ancestor nodes.
AFAIU `parent_module_name` works fine with class definitions, but to get proper namespace for `describe MyClass` we have to call it on `s(:block, s(:send, nil, :describe, s(:const, nil, :MyClass)), s(:args), nil)` node and not on `s(:const, nil, :MyClass)` node. Which is doable, but it's way more easier to use `namespace` helper method from `RSpec/DescribedClass` cop. Which in turn raises the question: is https://github.com/rubocop/rubocop-rspec/issues/984 really actual?

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
