### PR TITLE
Fix RSpec/ChangeByZero with compound operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix `RSpec/FilePath` cop missing mismatched expanded namespace. ([@sl4vr][])
 * Add new `AllowConsecutiveOneLiners` (default true) option for `Rspec/EmptyLineAfterHook` cop. ([@ngouy][])
 * Add autocorrect support for `RSpec/EmptyExampleGroup`. ([@r7kamura][])
+* Fix `RSpec/ChangeByZero` with compound expressions using `&` or `|` operators. ([@BrianHawley][])
 
 ## 2.12.1 (2022-07-03)
 
@@ -718,3 +719,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@edgibbs]: https://github.com/edgibbs
 [@Drowze]: https://github.com/Drowze
 [@akiomik]: https://github.com/akiomik
+[@BrianHawley]: https://github.com/BrianHawley

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -79,7 +79,7 @@ module RuboCop
         end
 
         def compound_expectations?(node)
-          %i[and or].include?(node.parent.method_name)
+          %i[and or & |].include?(node.parent.method_name)
         end
 
         def autocorrect(corrector, node)

--- a/spec/rubocop/cop/rspec/change_by_zero_spec.rb
+++ b/spec/rubocop/cop/rspec/change_by_zero_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
           .and change { Foo.baz }.by(0)
                ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
         expect { foo }
+          .to change(Foo, :bar).by(0) &
+              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+              change(Foo, :baz).by(0)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+        expect { foo }
+          .to change { Foo.bar }.by(0) &
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+              change { Foo.baz }.by(0)
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+        expect { foo }
           .to change(Foo, :bar).by(0)
               ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
           .or change(Foo, :baz).by(0)
@@ -49,8 +59,20 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
               ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
           .or change { Foo.baz }.by(0)
               ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+        expect { foo }
+          .to change(Foo, :bar).by(0) |
+              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+              change(Foo, :baz).by(0)
+              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+        expect { foo }
+          .to change { Foo.bar }.by(0) |
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+              change { Foo.baz }.by(0)
+              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'does not register an offense when the argument to `by` is not zero' do


### PR DESCRIPTION
Previously, it didn't recognize compound expressions using `&` or `|`.
This led it to correct part of the expressions as regular code, but the
generated code was malformed.

Now it recognizes compound expressions using the operators.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
