### PR TITLE
[Fix #1327] Fix a false positive for `RSpec/Capybara/SpecificMatcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix `RSpec/ChangeByZero` with compound expressions using `&` or `|` operators. ([@BrianHawley][])
 * Add `RSpec/NoExpectationExample`. ([@r7kamura][])
 * Add some expectation methods to default configuration. ([@r7kamura][])
+* Fix a false positive for `RSpec/Capybara/SpecificMatcher`. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -21,59 +21,145 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
 
   it 'registers an offense when using `have_selector`' do
     expect_offense(<<-RUBY)
-    expect(page).to have_selector('button')
-                    ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_selector`.
-    expect(page).to have_selector('a')
-                    ^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_selector`.
-    expect(page).to have_selector('table')
-                    ^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_table` over `have_selector`.
-    expect(page).to have_selector('select')
-                    ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_select` over `have_selector`.
+      expect(page).to have_selector('button')
+                      ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_selector`.
+      expect(page).to have_selector('a')
+                      ^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_selector`.
+      expect(page).to have_selector('table')
+                      ^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_table` over `have_selector`.
+      expect(page).to have_selector('select')
+                      ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_select` over `have_selector`.
     RUBY
   end
 
   it 'registers an offense when using `have_no_selector`' do
     expect_offense(<<-RUBY)
-    expect(page).to have_no_selector('button')
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_no_button` over `have_no_selector`.
+      expect(page).to have_no_selector('button')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_no_button` over `have_no_selector`.
     RUBY
   end
 
   it 'registers an offense when using `have_css`' do
     expect_offense(<<-RUBY)
-    expect(page).to have_css('button')
-                    ^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button')
+                      ^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using `have_no_css`' do
     expect_offense(<<-RUBY)
-    expect(page).to have_no_css('button')
-                    ^^^^^^^^^^^^^^^^^^^^^ Prefer `have_no_button` over `have_no_css`.
+      expect(page).to have_no_css('button')
+                      ^^^^^^^^^^^^^^^^^^^^^ Prefer `have_no_button` over `have_no_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher and other args' do
     expect_offense(<<-RUBY)
-    expect(page).to have_css('button', exact_text: 'foo')
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button', exact_text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+    RUBY
+  end
+
+  %i[above below left_of right_of near count minimum maximum between
+     text id class style visible obscured exact exact_text normalize_ws
+     match wait filter_set focused disabled name value
+     title type].each do |attr|
+    it 'registers an offense for abstract matcher when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `have_button`' do
+      expect_offense(<<-RUBY, attr: attr)
+        expect(page).to have_css("button[#{attr}=foo]")
+                        ^^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_button` over `have_css`.
+        expect(page).to have_css("button[#{attr}]")
+                        ^^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_button` over `have_css`.
+      RUBY
+    end
+  end
+
+  %i[above below left_of right_of near count minimum maximum between text id
+     class style visible obscured exact exact_text normalize_ws match wait
+     filter_set focused href alt title download].each do |attr|
+    it 'registers an offense for abstract matcher when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `have_link`' do
+      expect_offense(<<-RUBY, attr: attr)
+        expect(page).to have_css("a[#{attr}=foo]")
+                        ^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_link` over `have_css`.
+        expect(page).to have_css("a[#{attr}]")
+                        ^^^^^^^^^^^^^{attr}^^^ Prefer `have_link` over `have_css`.
+      RUBY
+    end
+  end
+
+  %i[above below left_of right_of near count minimum maximum between
+     text id class style visible obscured exact exact_text normalize_ws
+     match wait filter_set focused caption with_cols cols with_rows
+     rows].each do |attr|
+    it 'registers an offense for abstract matcher when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `have_table`' do
+      expect_offense(<<-RUBY, attr: attr)
+        expect(page).to have_css("table[#{attr}=foo]")
+                        ^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_table` over `have_css`.
+        expect(page).to have_css("table[#{attr}]")
+                        ^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_table` over `have_css`.
+      RUBY
+    end
+  end
+
+  %i[above below left_of right_of near count minimum maximum between
+     text id class style visible obscured exact exact_text normalize_ws
+     match wait filter_set focused disabled name placeholder options
+     enabled_options disabled_options selected with_selected
+     multiple with_options].each do |attr|
+    it 'registers an offense for abstract matcher when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `have_select`' do
+      expect_offense(<<-RUBY, attr: attr)
+        expect(page).to have_css("select[#{attr}=foo]")
+                        ^^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_select` over `have_css`.
+        expect(page).to have_css("select[#{attr}]")
+                        ^^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_select` over `have_css`.
+      RUBY
+    end
+  end
+
+  it 'registers an offense when using abstract matcher with ' \
+     'first argument is element with multiple replaceable attributes' do
+    expect_offense(<<-RUBY)
+      expect(page).to have_css('button[disabled][name="foo"]', exact_text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([name="foo"][disabled])', exact_text: 'bar')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher with state' do
     expect_offense(<<-RUBY)
-    expect(page).to have_css('button[disabled]', exact_text: 'foo')
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
-    expect(page).to have_css('button:not([disabled])', exact_text: 'bar')
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button[disabled]', exact_text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([disabled])', exact_text: 'bar')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'does not register an offense for abstract matcher when ' \
     'first argument is element with nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('button[data-disabled]')
       expect(page).to have_css('button[foo=bar]')
       expect(page).to have_css('button[foo-bar=baz]', exact_text: 'foo')
+    RUBY
+  end
+
+  it 'does not register an offense for abstract matcher when ' \
+    'first argument is element with multiple nonreplaceable attributes' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('button[disabled][foo]')
+      expect(page).to have_css('button[foo][disabled]')
+      expect(page).to have_css('button[foo][disabled][bar]')
+      expect(page).to have_css('button[disabled][foo=bar]')
+      expect(page).to have_css('button[disabled=foo][bar]', exact_text: 'foo')
     RUBY
   end
 


### PR DESCRIPTION
Fix: #1327

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
