### PR TITLE
Remove the now-redundant include_context

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,6 @@ RSpec.configure do |config|
   config.include(ExpectOffense)
 
   config.include_context 'with default RSpec/Language config', :config
-  config.include_context 'config', :config
   config.include_context 'smoke test', type: :cop_spec
 end
 


### PR DESCRIPTION
Follow-up to #1322

Now, when this
https://github.com/rubocop/rubocop/commit/1e77a15f37f96c844c323c95ef6a99e4666e7a8e#diff-a328b4f030d5897fe22c01bb96a3bfbcc8bcc6a11f936d1e7a2db73a721d0eb8L52
has been merged, there's no race condition between included contexts.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).