### PR TITLE
Untangle dependent shared_context

### DIFF
--- a/spec/shared/default_rspec_language_config_context.rb
+++ b/spec/shared/default_rspec_language_config_context.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-RSpec.shared_context 'with default RSpec/Language config', :config do
+RSpec.shared_context 'with default RSpec/Language config' do
+  include_context 'config'
+
   # Deep duplication is needed to prevent config leakage between examples
   let(:other_cops) do
     default_language = RuboCop::ConfigLoader


### PR DESCRIPTION
Previously I mistakenly assumed there's a problem with RSpec 4, as it includes the context that defines metadata first, and when we were removing `:config` from our `with default RSpec/Language`, we had to include `config` one first from `spec_helper.rb`.

In reality, if one shared context depends on another, it needs to explicitly include it.

Originated in #1322, follow-up to #1332. Also see https://github.com/rubocop/rubocop/commit/1e77a15f37f96c844c323c95ef6a99e4666e7a8e#diff-a328b4f030d5897fe22c01bb96a3bfbcc8bcc6a11f936d1e7a2db73a721d0eb8L52

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).