### PR TITLE
Deprecate `IgnoredPatterns` option in favor of the `AllowedPatterns` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add support for numblocks to `RSpec/AroundBlock`, `RSpec/EmptyLineAfterHook`, `RSpec/ExpectInHook`, `RSpec/HookArgument`, `RSpec/HooksBeforeExamples`, `RSpec/IteratedExpectation`, and `RSpec/NoExpectationExample`. ([@ydah][])
 * Fix incorrect documentation URLs when using `rubocop --show-docs-url`. ([@r7kamura][])
 * Add `AllowedGroups` configuration option to `RSpec/NestedGroups`. ([@ydah][])
+* Deprecate `IgnoredPatterns` option in favor of the `AllowedPatterns` options. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 
@@ -666,7 +667,6 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@hosamaly]: https://github.com/hosamaly
 [@jaredbeck]: https://github.com/jaredbeck
 [@jaredmoody]: https://github.com/jaredmoody
-[@jawshooah]: https://github.com/jawshooah
 [@jeffreyc]: https://github.com/jeffreyc
 [@jfragoulis]: https://github.com/jfragoulis
 [@johnny-miyake]: https://github.com/johnny-miyake

--- a/config/default.yml
+++ b/config/default.yml
@@ -794,9 +794,10 @@ RSpec/VariableName:
   SupportedStyles:
     - snake_case
     - camelCase
+  AllowedPatterns: []
   IgnoredPatterns: []
   VersionAdded: '1.40'
-  VersionChanged: '1.43'
+  VersionChanged: '2.13'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableName
 
 RSpec/VerifiedDoubleReference:

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -1,0 +1,14 @@
+#
+# Configuration of obsolete/deprecated cops used by `ConfigObsoletion`.
+#
+# See: https://docs.rubocop.org/rubocop/extensions.html#config-obsoletions
+#
+
+# Cop parameters that have been changed
+# Can be treated as a warning instead of a failure with `severity: warning`
+changed_parameters:
+  - cops:
+      - RSpec/VariableName
+    parameters: IgnoredPatterns
+    alternative: AllowedPatterns
+    severity: warning

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4527,12 +4527,12 @@ let('user_name') { 'Adam' }
 | Yes
 | No
 | 1.40
-| 1.43
+| 2.13
 |===
 
 Checks that memoized helper names use the configured style.
 
-Variables can be excluded from checking using the `IgnoredPatterns`
+Variables can be excluded from checking using the `AllowedPatterns`
 option.
 
 === Examples
@@ -4563,20 +4563,20 @@ subject(:userName1) { 'Adam' }
 let(:userName2) { 'Adam' }
 ----
 
-==== IgnoredPatterns configuration
+==== AllowedPatterns configuration
 
 [source,ruby]
 ----
 # rubocop.yml
 # RSpec/VariableName:
 #   EnforcedStyle: snake_case
-#   IgnoredPatterns:
+#   AllowedPatterns:
 #     - ^userFood
 ----
 
 [source,ruby]
 ----
-# okay because it matches the `^userFood` regex in `IgnoredPatterns`
+# okay because it matches the `^userFood` regex in `AllowedPatterns`
 subject(:userFood_1) { 'spaghetti' }
 let(:userFood_2) { 'fettuccine' }
 ----
@@ -4589,6 +4589,10 @@ let(:userFood_2) { 'fettuccine' }
 | EnforcedStyle
 | `snake_case`
 | `snake_case`, `camelCase`
+
+| AllowedPatterns
+| `[]`
+| Array
 
 | IgnoredPatterns
 | `[]`

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -5,6 +5,7 @@ require 'yaml'
 
 require 'rubocop'
 
+require_relative 'rubocop/rspec'
 require_relative 'rubocop/rspec/version'
 require_relative 'rubocop/rspec/inject'
 require_relative 'rubocop/rspec/node'

--- a/lib/rubocop/cop/rspec/variable_name.rb
+++ b/lib/rubocop/cop/rspec/variable_name.rb
@@ -5,7 +5,7 @@ module RuboCop
     module RSpec
       # Checks that memoized helper names use the configured style.
       #
-      # Variables can be excluded from checking using the `IgnoredPatterns`
+      # Variables can be excluded from checking using the `AllowedPatterns`
       # option.
       #
       # @example EnforcedStyle: snake_case (default)
@@ -26,21 +26,21 @@ module RuboCop
       #   subject(:userName1) { 'Adam' }
       #   let(:userName2) { 'Adam' }
       #
-      # @example IgnoredPatterns configuration
+      # @example AllowedPatterns configuration
       #   # rubocop.yml
       #   # RSpec/VariableName:
       #   #   EnforcedStyle: snake_case
-      #   #   IgnoredPatterns:
+      #   #   AllowedPatterns:
       #   #     - ^userFood
       #
       # @example
-      #   # okay because it matches the `^userFood` regex in `IgnoredPatterns`
+      #   # okay because it matches the `^userFood` regex in `AllowedPatterns`
       #   subject(:userFood_1) { 'spaghetti' }
       #   let(:userFood_2) { 'fettuccine' }
       #
       class VariableName < Base
         include ConfigurableNaming
-        include IgnoredPattern
+        include AllowedPattern
         include Variable
 
         MSG = 'Use %<style>s for variable names.'
@@ -48,7 +48,7 @@ module RuboCop
         def on_send(node)
           variable_definition?(node) do |variable|
             return if variable.dstr_type? || variable.dsym_type?
-            return if matches_ignored_pattern?(variable.value)
+            return if matches_allowed_pattern?(variable.value)
 
             check_name(node, variable.value, variable.loc.expression)
           end

--- a/lib/rubocop/rspec.rb
+++ b/lib/rubocop/rspec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # RuboCop RSpec project namespace
+  module RSpec
+    PROJECT_ROOT   = Pathname.new(__dir__).parent.parent.expand_path.freeze
+    CONFIG_DEFAULT = PROJECT_ROOT.join('config', 'default.yml').freeze
+
+    private_constant(:CONFIG_DEFAULT, :PROJECT_ROOT)
+
+    ::RuboCop::ConfigObsoletion.files << PROJECT_ROOT.join('config',
+                                                           'obsoletion.yml')
+  end
+end

--- a/lib/rubocop/rspec/inject.rb
+++ b/lib/rubocop/rspec/inject.rb
@@ -6,9 +6,7 @@ module RuboCop
     # bit of our configuration.
     module Inject
       def self.defaults!
-        project_root = Pathname.new(__dir__).parent.parent.parent.expand_path
-        config_default = project_root.join('config', 'default.yml')
-        path = config_default.to_s
+        path = CONFIG_DEFAULT.to_s
         hash = ConfigLoader.send(:load_yaml_configuration, path)
         config = RuboCop::Config.new(hash, path)
         puts "configuration from #{path}" if ConfigLoader.debug?

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.31'
+  spec.add_runtime_dependency 'rubocop', '~> 1.33'
 end

--- a/spec/rubocop/cop/rspec/variable_name_spec.rb
+++ b/spec/rubocop/cop/rspec/variable_name_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe RuboCop::Cop::RSpec::VariableName do
     end
   end
 
-  context 'when configured to ignore certain patterns' do
+  context 'when configured to ignore certain patterns (deprecated key)' do
     let(:cop_config) do
       { 'EnforcedStyle' => 'snake_case',
         'IgnoredPatterns' => ['^userFood$', '^userPet$'] }
@@ -203,6 +203,26 @@ RSpec.describe RuboCop::Cop::RSpec::VariableName do
     end
 
     it 'does not register an offense when matching any ignored pattern' do
+      expect_no_offenses(<<~RUBY)
+        let(:userFood) { 'Adam' }
+      RUBY
+    end
+  end
+
+  context 'when configured to allow certain patterns' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'snake_case',
+        'AllowedPatterns' => ['^userFood$', '^userPet$'] }
+    end
+
+    it 'registers an offense when not matching any allowed patterns' do
+      expect_offense(<<~RUBY)
+        let(:userName) { 'Adam' }
+            ^^^^^^^^^ Use snake_case for variable names.
+      RUBY
+    end
+
+    it 'does not register an offense when matching any allowed pattern' do
       expect_no_offenses(<<~RUBY)
         let(:userFood) { 'Adam' }
       RUBY


### PR DESCRIPTION
Follow up https://github.com/rubocop/rubocop/pull/10555

This PR obsoletes the `IgnoredPatterns` option and replaces it with the `AllowedPatterns` option.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
