### PR TITLE
Add test case for `RSpec/Capybara/SpecificMatcher`

### DIFF
--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -60,6 +60,24 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
     RUBY
   end
 
+  it 'registers an offense when using abstract matcher with class selector' do
+    expect_offense(<<-RUBY)
+      expect(page).to have_css('a.cls')
+                      ^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+      expect(page).to have_css('a.cls', text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+    RUBY
+  end
+
+  it 'registers an offense when using abstract matcher with id selector' do
+    expect_offense(<<-RUBY)
+      expect(page).to have_css('a#id')
+                      ^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+      expect(page).to have_css('a#id', text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+    RUBY
+  end
+
   %i[above below left_of right_of near count minimum maximum between
      text id class style visible obscured exact exact_text normalize_ws
      match wait filter_set focused disabled name value


### PR DESCRIPTION
Added test cases for element and class selector and element and ID selector.

This is the case for the test corresponding to the following Issue:
- https://github.com/rubocop/rubocop-rspec/issues/1330

The problem itself has been solved with https://github.com/rubocop/rubocop-rspec/pull/1328

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
