### PR TITLE
Add new `RSpec/Capybara/SpecificFinders` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,6 +114,8 @@ RSpec/SubjectDeclaration:
   Enabled: true
 RSpec/VerifiedDoubleReference:
   Enabled: true
+RSpec/Capybara/SpecificFinders:
+  Enabled: true
 RSpec/Capybara/SpecificMatcher:
   Enabled: true
 RSpec/FactoryBot/SyntaxMethods:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fix a false negative for `RSpec/Capybara/SpecificMatcher` for `have_field`. ([@ydah][])
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher` when may not have a `href` by `have_link`. ([@ydah][])
 * Add `NegatedMatcher` configuration option to `RSpec/ChangeByZero`. ([@ydah][])
+* Add new `RSpec/Capybara/SpecificFinders` cop. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -851,6 +851,12 @@ RSpec/Capybara/FeatureMethods:
   VersionChanged: '2.0'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
 
+RSpec/Capybara/SpecificFinders:
+  Description: Checks if there is a more specific finder offered by Capybara.
+  Enabled: pending
+  VersionAdded: '2.13'
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/SpecificFinders
+
 RSpec/Capybara/SpecificMatcher:
   Description: Checks for there is a more specific matcher offered by Capybara.
   Enabled: pending

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -94,6 +94,7 @@
 
 * xref:cops_rspec_capybara.adoc#rspeccapybara/currentpathexpectation[RSpec/Capybara/CurrentPathExpectation]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/featuremethods[RSpec/Capybara/FeatureMethods]
+* xref:cops_rspec_capybara.adoc#rspeccapybara/specificfinders[RSpec/Capybara/SpecificFinders]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/specificmatcher[RSpec/Capybara/SpecificMatcher]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/visibilitymatcher[RSpec/Capybara/VisibilityMatcher]
 

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -112,6 +112,37 @@ end
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/FeatureMethods
 
+== RSpec/Capybara/SpecificFinders
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| Yes
+| 2.13
+| -
+|===
+
+Checks if there is a more specific finder offered by Capybara.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+find('#some-id')
+find('[visible][id=some-id]')
+
+# good
+find_by_id('some-id')
+find_by_id('some-id', visible: true)
+----
+
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/SpecificFinders
+
 == RSpec/Capybara/SpecificMatcher
 
 |===

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -21,6 +21,7 @@ require_relative 'rubocop/cop/rspec/mixin/comments_help'
 require_relative 'rubocop/cop/rspec/mixin/empty_line_separation'
 require_relative 'rubocop/cop/rspec/mixin/inside_example_group'
 require_relative 'rubocop/cop/rspec/mixin/namespace'
+require_relative 'rubocop/cop/rspec/mixin/css_selector'
 
 require_relative 'rubocop/rspec/concept'
 require_relative 'rubocop/rspec/example_group'

--- a/lib/rubocop/cop/rspec/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_finders.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module Capybara
+        # Checks if there is a more specific finder offered by Capybara.
+        #
+        # @example
+        #   # bad
+        #   find('#some-id')
+        #   find('[visible][id=some-id]')
+        #
+        #   # good
+        #   find_by_id('some-id')
+        #   find_by_id('some-id', visible: true)
+        #
+        class SpecificFinders < Base
+          extend AutoCorrector
+
+          include RangeHelp
+
+          MSG = 'Prefer `find_by` over `find`.'
+          RESTRICT_ON_SEND = %i[find].freeze
+
+          # @!method find_argument(node)
+          def_node_matcher :find_argument, <<~PATTERN
+            (send _ :find (str $_) ...)
+          PATTERN
+
+          def on_send(node)
+            find_argument(node) do |arg|
+              next if CssSelector.multiple_selectors?(arg)
+
+              on_attr(node, arg) if attribute?(arg)
+              on_id(node, arg) if CssSelector.id?(arg)
+            end
+          end
+
+          private
+
+          def on_attr(node, arg)
+            return unless (id = CssSelector.attributes(arg)['id'])
+
+            register_offense(node, replaced_argments(arg, id))
+          end
+
+          def on_id(node, arg)
+            register_offense(node, "'#{arg.to_s.delete('#')}'")
+          end
+
+          def attribute?(arg)
+            CssSelector.attribute?(arg) &&
+              CssSelector.common_attributes?(arg)
+          end
+
+          def register_offense(node, arg_replacemenet)
+            add_offense(offense_range(node)) do |corrector|
+              corrector.replace(node.loc.selector, 'find_by_id')
+              corrector.replace(node.first_argument.loc.expression,
+                                arg_replacemenet)
+            end
+          end
+
+          def replaced_argments(arg, id)
+            options = to_options(CssSelector.attributes(arg))
+            options.empty? ? id : "#{id}, #{options}"
+          end
+
+          def to_options(attrs)
+            attrs.each.map do |key, value|
+              next if key == 'id'
+
+              "#{key}: #{value}"
+            end.compact.join(', ')
+          end
+
+          def offense_range(node)
+            range_between(node.loc.selector.begin_pos,
+                          node.loc.end.end_pos)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec/mixin/css_selector.rb
+++ b/lib/rubocop/cop/rspec/mixin/css_selector.rb
@@ -14,6 +14,24 @@ module RuboCop
         module_function
 
         # @param selector [String]
+        # @return [Boolean]
+        # @example
+        #   id?('#some-id') # => true
+        #   id?('.some-class') # => false
+        def id?(selector)
+          selector.start_with?('#')
+        end
+
+        # @param selector [String]
+        # @return [Boolean]
+        # @example
+        #   attribute?('[attribute]') # => true
+        #   attribute?('attribute') # => false
+        def attribute?(selector)
+          selector.start_with?('[')
+        end
+
+        # @param selector [String]
         # @return [Array<String>]
         # @example
         #   attributes('a[foo-bar_baz]') # => {"foo-bar_baz=>true}
@@ -24,6 +42,17 @@ module RuboCop
             key, value = attr.split('=')
             [key, normalize_value(value)]
           end
+        end
+
+        # @param selector [String]
+        # @return [Boolean]
+        # @example
+        #   common_attributes?('a[focused]') # => true
+        #   common_attributes?('button[focused][visible]') # => true
+        #   common_attributes?('table[id=some-id]') # => true
+        #   common_attributes?('h1[invalid]') # => false
+        def common_attributes?(selector)
+          attributes(selector).keys.difference(COMMON_OPTIONS).none?
         end
 
         # @param selector [String]

--- a/lib/rubocop/cop/rspec/mixin/css_selector.rb
+++ b/lib/rubocop/cop/rspec/mixin/css_selector.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Helps parsing css selector.
+      module CssSelector
+        COMMON_OPTIONS = %w[
+          above below left_of right_of near count minimum maximum between text
+          id class style visible obscured exact exact_text normalize_ws match
+          wait filter_set focused
+        ].freeze
+
+        module_function
+
+        # @param selector [String]
+        # @return [Array<String>]
+        # @example
+        #   attributes('a[foo-bar_baz]') # => {"foo-bar_baz=>true}
+        #   attributes('button[foo][bar]') # => {"foo"=>true, "bar"=>true}
+        #   attributes('table[foo=bar]') # => {"foo"=>"'bar'"}
+        def attributes(selector)
+          selector.scan(/\[(.*?)\]/).flatten.to_h do |attr|
+            key, value = attr.split('=')
+            [key, normalize_value(value)]
+          end
+        end
+
+        # @param selector [String]
+        # @return [Boolean]
+        # @example
+        #   multiple_selectors?('a.cls b#id') # => true
+        #   multiple_selectors?('a.cls') # => false
+        def multiple_selectors?(selector)
+          selector.match?(/[ >,+]/)
+        end
+
+        # @param selector [String]
+        # @return [Boolean, String]
+        # @example
+        #   normalize_value('true') # => true
+        #   normalize_value('false') # => false
+        #   normalize_value(nil) # => false
+        #   normalize_value("foo") # => "'foo'"
+        def normalize_value(value)
+          case value
+          when 'true' then true
+          when 'false' then false
+          when nil then true
+          else "'#{value}'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -2,6 +2,7 @@
 
 require_relative 'rspec/capybara/current_path_expectation'
 require_relative 'rspec/capybara/feature_methods'
+require_relative 'rspec/capybara/specific_finders'
 require_relative 'rspec/capybara/specific_matcher'
 require_relative 'rspec/capybara/visibility_matcher'
 

--- a/spec/rubocop/cop/rspec/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_finders_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
+  it 'registers an offense when using `find`' do
+    expect_offense(<<~RUBY)
+      find('#some-id')
+      ^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` and other args' do
+    expect_offense(<<~RUBY)
+      find('#some-id', exact_text: 'foo')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', exact_text: 'foo')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with method chain' do
+    expect_offense(<<~RUBY)
+      find('#some-id').find('#other-id').find('#another-id')
+      ^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+                       ^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+                                         ^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id').find_by_id('other-id').find_by_id('another-id')
+    RUBY
+  end
+
+  it 'registers an offense when using `find ' \
+    'with argument is attribute specified id' do
+    expect_offense(<<~RUBY)
+      find('[id=some-id]')
+      ^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('[visible][id=some-id]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('[id=some-id][class=some-cls][focused]')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id')
+      find_by_id('some-id', visible: true)
+      find_by_id('some-id', class: 'some-cls', focused: true)
+    RUBY
+  end
+
+  it 'does not register an offense when using `find ' \
+    'with argument is attribute not specified id' do
+    expect_no_offenses(<<~RUBY)
+      find('[visible]')
+      find('[class=some-cls][visible]')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find ' \
+    'with argument is element with id' do
+    expect_no_offenses(<<~RUBY)
+      find('h1#some-id')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find ' \
+    'with argument is element with attribute specified id' do
+    expect_no_offenses(<<~RUBY)
+      find('h1[id=some-id]')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find` ' \
+    'with argument is not id' do
+    expect_no_offenses(<<~RUBY)
+      find('a.some-id')
+      find('.some-id')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find_by_id`' do
+    expect_no_offenses(<<~RUBY)
+      find_by_id('some-id')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find` ' \
+    'with argument is id with multiple matcher' do
+    expect_no_offenses(<<~RUBY)
+      find('#some-id body')
+      find('#some-id>h1')
+      find('#some-id,h2')
+      find('#some-id+option')
+    RUBY
+  end
+end


### PR DESCRIPTION
Resolve part of the issue: https://github.com/rubocop/rubocop-rspec/issues/1326

This cop checks for there is a more specific finder offered by Capybara.

```ruby
# bad
find('#some-id')

# good
find_by_id('some-id')
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [x] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
* [x] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
