### PR TITLE
Add documentation on cases that does not support autocorrection in cop

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -397,6 +397,8 @@ end
 
 Prefer negated matchers over `to change.by(0)`.
 
+This cop does not support autocorrection in some cases.
+
 === Examples
 
 [source,ruby]
@@ -405,7 +407,7 @@ Prefer negated matchers over `to change.by(0)`.
 expect { run }.to change(Foo, :bar).by(0)
 expect { run }.to change { Foo.bar }.by(0)
 
-# bad - compound expectations
+# bad - compound expectations (does not support autocorrection)
 expect { run }
   .to change(Foo, :bar).by(0)
   .and change(Foo, :baz).by(0)
@@ -1529,6 +1531,9 @@ expect("John").to eq(name)
 expect(price).to eq(5)
 expect(pattern).to eq(/foo/)
 expect(name).to eq("John")
+
+# bad (not supported autocorrection)
+expect(false).to eq(true)
 ----
 
 === Configurable attributes
@@ -1794,6 +1799,8 @@ my_class_spec.rb         # describe MyClass, '#method'
 
 Checks if examples are focused.
 
+This cop does not support autocorrection in some cases.
+
 === Examples
 
 [source,ruby]
@@ -1811,6 +1818,21 @@ end
 # good
 describe MyClass do
 end
+
+# bad
+fdescribe 'test' do; end
+
+# good
+describe 'test' do; end
+
+# bad
+fdescribe 'test' do; end
+
+# good
+describe 'test' do; end
+
+# bad (does not support autocorrection)
+focus 'test' do; end
 ----
 
 === References
@@ -3063,6 +3085,7 @@ end
 
 Checks if an example group defines `subject` multiple times.
 
+This cop does not support autocorrection in some cases.
 The autocorrect behavior for this cop depends on the type of
 duplication:
 
@@ -3092,6 +3115,20 @@ end
 describe Foo do
   let(:user) { User.new }
   subject(:post) { Post.new }
+end
+
+# bad (does not support autocorrection)
+describe Foo do
+  subject!(:user) { User.new }
+  subject!(:post) { Post.new }
+end
+
+# good
+describe Foo do
+  before do
+    User.new
+    Post.new
+  end
 end
 ----
 

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -22,17 +22,23 @@ https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-java
 which ensures that preceding actions (like `click_link`) have
 completed.
 
+This cop does not support autocorrection in some cases.
+
 === Examples
 
 [source,ruby]
 ----
 # bad
 expect(current_path).to eq('/callback')
-expect(page.current_path).to match(/widgets/)
 
 # good
-expect(page).to have_current_path("/callback")
-expect(page).to have_current_path(/widgets/)
+expect(page).to have_current_path('/callback')
+
+# bad (does not support autocorrection)
+expect(page.current_path).to match(variable)
+
+# good
+expect(page).to have_current_path('/callback')
 ----
 
 === References

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -14,14 +14,20 @@ module RuboCop
         # which ensures that preceding actions (like `click_link`) have
         # completed.
         #
+        # This cop does not support autocorrection in some cases.
+        #
         # @example
         #   # bad
         #   expect(current_path).to eq('/callback')
-        #   expect(page.current_path).to match(/widgets/)
         #
         #   # good
-        #   expect(page).to have_current_path("/callback")
-        #   expect(page).to have_current_path(/widgets/)
+        #   expect(page).to have_current_path('/callback')
+        #
+        #   # bad (does not support autocorrection)
+        #   expect(page.current_path).to match(variable)
+        #
+        #   # good
+        #   expect(page).to have_current_path('/callback')
         #
         class CurrentPathExpectation < Base
           extend AutoCorrector

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -5,12 +5,14 @@ module RuboCop
     module RSpec
       # Prefer negated matchers over `to change.by(0)`.
       #
+      # This cop does not support autocorrection in some cases.
+      #
       # @example
       #   # bad
       #   expect { run }.to change(Foo, :bar).by(0)
       #   expect { run }.to change { Foo.bar }.by(0)
       #
-      #   # bad - compound expectations
+      #   # bad - compound expectations (does not support autocorrection)
       #   expect { run }
       #     .to change(Foo, :bar).by(0)
       #     .and change(Foo, :baz).by(0)

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -18,6 +18,9 @@ module RuboCop
       #   expect(pattern).to eq(/foo/)
       #   expect(name).to eq("John")
       #
+      #   # bad (not supported autocorrection)
+      #   expect(false).to eq(true)
+      #
       class ExpectActual < Base
         extend AutoCorrector
 

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -5,6 +5,8 @@ module RuboCop
     module RSpec
       # Checks if examples are focused.
       #
+      # This cop does not support autocorrection in some cases.
+      #
       # @example
       #   # bad
       #   describe MyClass, focus: true do
@@ -19,6 +21,22 @@ module RuboCop
       #   # good
       #   describe MyClass do
       #   end
+      #
+      #   # bad
+      #   fdescribe 'test' do; end
+      #
+      #   # good
+      #   describe 'test' do; end
+      #
+      #   # bad
+      #   fdescribe 'test' do; end
+      #
+      #   # good
+      #   describe 'test' do; end
+      #
+      #   # bad (does not support autocorrection)
+      #   focus 'test' do; end
+      #
       class Focus < Base
         extend AutoCorrector
         include RangeHelp

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -19,6 +19,21 @@ module RuboCop
       #     subject(:post) { Post.new }
       #   end
       #
+      #   # bad (does not support autocorrection)
+      #   describe Foo do
+      #     subject!(:user) { User.new }
+      #     subject!(:post) { Post.new }
+      #   end
+      #
+      #   # good
+      #   describe Foo do
+      #     before do
+      #       User.new
+      #       Post.new
+      #     end
+      #   end
+      #
+      # This cop does not support autocorrection in some cases.
       # The autocorrect behavior for this cop depends on the type of
       # duplication:
       #
@@ -33,6 +48,7 @@ module RuboCop
       #   - If subjects are defined with `subject!` then we don't autocorrect.
       #     This is enough of an edge case that people can just move this to
       #     a `before` hook on their own
+      #
       class MultipleSubjects < Base
         extend AutoCorrector
         include RangeHelp


### PR DESCRIPTION
This PR added an explanation of the cases that does not support autocorrection.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
