### PR TITLE
[Fix #1342] Fix a false negative for `RSpec/Capybara/SpecificMatcher` for `have_field`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add `RSpec/NoExpectationExample`. ([@r7kamura][])
 * Add some expectation methods to default configuration. ([@r7kamura][])
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher`. ([@ydah][])
+* Fix a false negative for `RSpec/Capybara/SpecificMatcher` for `have_field`. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -131,6 +131,7 @@ expect(page).to have_css('button')
 expect(page).to have_no_css('a.cls', exact_text: 'foo')
 expect(page).to have_css('table.cls')
 expect(page).to have_css('select')
+expect(page).to have_css('input', exact_text: 'foo')
 
 # good
 expect(page).to have_button
@@ -139,6 +140,7 @@ expect(page).to have_button
 expect(page).to have_no_link('foo', class: 'cls')
 expect(page).to have_table(class: 'cls')
 expect(page).to have_select
+expect(page).to have_field('foo')
 ----
 
 === References

--- a/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
@@ -15,6 +15,7 @@ module RuboCop
         #   expect(page).to have_no_css('a.cls', exact_text: 'foo')
         #   expect(page).to have_css('table.cls')
         #   expect(page).to have_css('select')
+        #   expect(page).to have_css('input', exact_text: 'foo')
         #
         #   # good
         #   expect(page).to have_button
@@ -23,6 +24,7 @@ module RuboCop
         #   expect(page).to have_no_link('foo', class: 'cls')
         #   expect(page).to have_table(class: 'cls')
         #   expect(page).to have_select
+        #   expect(page).to have_field('foo')
         #
         class SpecificMatcher < Base
           MSG = 'Prefer `%<good_matcher>s` over `%<bad_matcher>s`.'
@@ -32,7 +34,8 @@ module RuboCop
             'button' => 'button',
             'a' => 'link',
             'table' => 'table',
-            'select' => 'select'
+            'select' => 'select',
+            'input' => 'field'
           }.freeze
           COMMON_OPTIONS = %w[
             above below left_of right_of near count minimum maximum between text
@@ -53,6 +56,12 @@ module RuboCop
               COMMON_OPTIONS + %w[
                 disabled name placeholder options enabled_options
                 disabled_options selected with_selected multiple with_options
+              ]
+            ).freeze,
+            'field' => (
+              COMMON_OPTIONS + %w[
+                checked unchecked disabled valid name placeholder
+                validation_message readonly with type multiple
               ]
             ).freeze
           }.freeze

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -142,6 +142,22 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
     end
   end
 
+  %i[above below left_of right_of near count minimum maximum between
+     text id class style visible obscured exact exact_text normalize_ws
+     match wait filter_set checked unchecked disabled valid name
+     placeholder validation_message ].each do |attr|
+    it 'registers an offense for abstract matcher when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `have_field`' do
+      expect_offense(<<-RUBY, attr: attr)
+        expect(page).to have_css("input[#{attr}=foo]")
+                        ^^^^^^^^^^^^^^^^^^{attr}^^^^^^ Prefer `have_field` over `have_css`.
+        expect(page).to have_css("input[#{attr}]")
+                        ^^^^^^^^^^^^^^^^^^{attr}^^ Prefer `have_field` over `have_css`.
+      RUBY
+    end
+  end
+
   it 'registers an offense when using abstract matcher with ' \
      'first argument is element with multiple replaceable attributes' do
     expect_offense(<<-RUBY)


### PR DESCRIPTION
This PR is fix a false negative for `RSpec/Capybara/SpecificMatcher` for `have_field`.

Resolve part of the issue: https://github.com/rubocop/rubocop-rspec/issues/1342

```ruby
expect(page).to have_css('input')
expect(page).to have_css('input[type="checkbox"]')
expect(page).to have_css('textarea')
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
