### PR TITLE
[Fix #1292] Update `RSpec/MultipleExpectations` cop to search for conditional branches and check the number of `expect`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add some expectation methods to default configuration. ([@r7kamura][])
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher`. ([@ydah][])
 * Fix a false negative for `RSpec/Capybara/SpecificMatcher` for `have_field`. ([@ydah][])
+* Update `RSpec/MultipleExpectations` cop to search for conditional branches and check the number of `expect`. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -30,6 +30,171 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       RUBY
     end
 
+    it 'approves of some expectation examples defined in `if` branches' do
+      expect_no_offenses(<<~RUBY)
+        describe Foo do
+          it 'some expectation examples defined in `if` branches' do
+            if foo
+              expect(foo).to be(true)
+            elsif bar
+              expect(bar).to be(true)
+            else
+              expect(baz).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'approves of some expectation examples defined in `unless` branches' do
+      expect_no_offenses(<<~RUBY)
+        describe Foo do
+          it 'some expectation examples defined in `unless` branches' do
+            unless foo
+              expect(foo).to be(true)
+            else
+              expect(bar).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'approves of some expectation examples defined in `case` branches' do
+      expect_no_offenses(<<~RUBY)
+        describe Foo do
+          it 'some expectation examples defined in `case` branches' do
+            case foo
+            when foo
+              expect(foo).to be(true)
+            when bar
+              expect(bar).to be(true)
+            else
+              expect(baz).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'flags multiple expectation examples defined in `if` branches' do
+      expect_offense(<<-RUBY)
+        describe Foo do
+          it 'multiple expectation examples defined in `if` branches' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+            if foo
+              expect(foo).to be(true)
+              expect(bar).to be(true)
+            elsif bar
+              expect(bar).to be(true)
+            else
+              expect(baz).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'flags multiple expectation examples defined in `elsif` branches' do
+      expect_offense(<<-RUBY)
+        describe Foo do
+          it 'multiple expectation examples defined in `elsif` branches' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+            if foo
+              expect(foo).to be(true)
+            elsif bar
+              expect(foo).to be(true)
+              expect(bar).to be(true)
+            else
+              expect(baz).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'flags multiple expectation examples defined in `else` branches' do
+      expect_offense(<<-RUBY)
+        describe Foo do
+          it 'multiple expectation examples defined in `else` branches' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+            if foo
+              expect(foo).to be(true)
+            elsif bar
+              expect(bar).to be(true)
+            else
+              expect(baz).to be(true)
+              expect(bar).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'flags multiple expectation examples defined in `unless` branches' do
+      expect_offense(<<-RUBY)
+        describe Foo do
+          it 'multiple expectation examples defined in `unless` branches' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          unless foo
+            expect(foo).to be(true)
+            expect(bar).to be(true)
+            else
+              expect(baz).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'flags multiple expectation examples defined in `when` branches' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          it 'multiple expectation examples defined in `when` branches' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+            case foo
+            when foo
+              expect(foo).to be(true)
+              expect(foo).to be(true)
+            when bar
+              expect(bar).to be(true)
+            else
+              expect(baz).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'flags multiple expectation examples defined in ' \
+      'nested conditional branches' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          it 'multiple expectation examples defined in nested conditional branches' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [5/1].
+            expect(one).to be(true)
+            if foo
+              expect(two).to be(true)
+              unless bar
+                expect(other).to be(true)
+              else
+                expect(three).to be(true)
+                case baz
+                when baz
+                  expect(four).to be(true)
+                else
+                  do_something
+                end
+              end
+            else
+              expect(other).to be(true)
+            end
+            expect(five).to be(true)
+          end
+        end
+      RUBY
+    end
+
     it 'flags multiple expect_any_instance_of' do
       expect_offense(<<-RUBY)
         describe Foo do


### PR DESCRIPTION
Resolve: #1292

```ruby
# good
describe Foo do
  it 'some expectation examples defined in `if` branches' do
    if foo
      expect(foo).to be(true)
    elsif bar
      expect(bar).to be(true)
    else
      expect(baz).to be(true)
    end
  end
end

# bad
describe Foo do
  it 'multiple expectation examples defined in `if` branches' do
    if foo
      expect(foo).to be(true)
      expect(bar).to be(true)
    elsif bar
      expect(bar).to be(true)
    else
      expect(baz).to be(true)
    end
  end
end
```

I would like to address this in a separate PR, as putting the response to which this [comment](https://github.com/rubocop/rubocop-rspec/issues/1292#issuecomment-1143906962) refers in a PR would bloat the PR and make it not a PR for one purpose. What do you think?

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
