### PR TITLE
Fix a false positive for `RSpec/Capybara/SpecificMatcher` when may not have a `href`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add some expectation methods to default configuration. ([@r7kamura][])
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher`. ([@ydah][])
 * Fix a false negative for `RSpec/Capybara/SpecificMatcher` for `have_field`. ([@ydah][])
+* Fix a false positive for `RSpec/Capybara/SpecificMatcher` when may not have a `href` by `have_link`. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -128,7 +128,7 @@ Checks for there is a more specific matcher offered by Capybara.
 expect(page).to have_selector('button')
 expect(page).to have_no_selector('button.cls')
 expect(page).to have_css('button')
-expect(page).to have_no_css('a.cls', exact_text: 'foo')
+expect(page).to have_no_css('a.cls', href: 'http://example.com')
 expect(page).to have_css('table.cls')
 expect(page).to have_css('select')
 expect(page).to have_css('input', exact_text: 'foo')
@@ -137,7 +137,7 @@ expect(page).to have_css('input', exact_text: 'foo')
 expect(page).to have_button
 expect(page).to have_no_button(class: 'cls')
 expect(page).to have_button
-expect(page).to have_no_link('foo', class: 'cls')
+expect(page).to have_no_link('foo', class: 'cls', href: 'http://example.com')
 expect(page).to have_table(class: 'cls')
 expect(page).to have_select
 expect(page).to have_field('foo')

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
     expect_offense(<<-RUBY)
       expect(page).to have_selector('button')
                       ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_selector`.
-      expect(page).to have_selector('a')
-                      ^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_selector`.
       expect(page).to have_selector('table')
                       ^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_table` over `have_selector`.
       expect(page).to have_selector('select')
                       ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_select` over `have_selector`.
+      expect(page).to have_selector('input')
+                      ^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_selector`.
     RUBY
   end
 
@@ -62,19 +62,19 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
 
   it 'registers an offense when using abstract matcher with class selector' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('a.cls')
-                      ^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
-      expect(page).to have_css('a.cls', text: 'foo')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+      expect(page).to have_css('button.cls')
+                      ^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button.cls', text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher with id selector' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('a#id')
-                      ^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
-      expect(page).to have_css('a#id', text: 'foo')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+      expect(page).to have_css('button#id')
+                      ^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button#id', text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
@@ -96,17 +96,48 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
 
   %i[above below left_of right_of near count minimum maximum between text id
      class style visible obscured exact exact_text normalize_ws match wait
-     filter_set focused href alt title download].each do |attr|
-    it 'registers an offense for abstract matcher when ' \
+     filter_set focused alt title download].each do |attr|
+    it 'does not register an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
-       'for `have_link`' do
-      expect_offense(<<-RUBY, attr: attr)
+       'for `have_link` without `href`' do
+      expect_no_offenses(<<-RUBY, attr: attr)
         expect(page).to have_css("a[#{attr}=foo]")
-                        ^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_link` over `have_css`.
         expect(page).to have_css("a[#{attr}]")
-                        ^^^^^^^^^^^^^{attr}^^^ Prefer `have_link` over `have_css`.
       RUBY
     end
+
+    it 'registers an offense for abstract matcher when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `have_link` with attribute `href`' do
+      expect_offense(<<-RUBY, attr: attr)
+        expect(page).to have_css("a[#{attr}=foo][href]")
+                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+        expect(page).to have_css("a[#{attr}][href='http://example.com']")
+                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+      RUBY
+    end
+
+    it 'registers an offense for abstract matcher when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `have_link` with option `href`' do
+      expect_offense(<<-RUBY, attr: attr)
+        expect(page).to have_css("a[#{attr}=foo]", href: 'http://example.com')
+                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+        expect(page).to have_css("a[#{attr}]", text: 'foo', href: 'http://example.com')
+                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+      RUBY
+    end
+  end
+
+  it 'registers an offense for abstract matcher when ' \
+     'first argument is element with replaceable attributes href ' \
+     'for `have_link`' do
+    expect_offense(<<-RUBY)
+      expect(page).to have_css("a[href]")
+                      ^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+      expect(page).to have_css("a[href='http://example.com']")
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+    RUBY
   end
 
   %i[above below left_of right_of near count minimum maximum between


### PR DESCRIPTION
This PR is fix a false positive for `RSpec/Capybara/SpecificMatcher` when may not have a `href`.

For example, the following href cannot be obtained with `have_link`.
```html
<a class='cls'>Hello world!</a>
```

If you try to retrieve it with the following code,
you will not be able to retrieve it.
```ruby
expect(page).to have_link(class: "cls")
```

`a` tags without an `href` are not links, they are placeholders for links.
So you cannot get it with `have_link`.

Since the test code does not know if the actually has a `href` or not, it is not offense for matchers that do not specify a href.

Refs: https://togithub.com/teamcapybara/capybara/issues/379#issuecomment-1339947

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
