### PR TITLE
Add `NegatedMatcher` configuration option to `RSpec/ChangeByZero`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher`. ([@ydah][])
 * Fix a false negative for `RSpec/Capybara/SpecificMatcher` for `have_field`. ([@ydah][])
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher` when may not have a `href` by `have_link`. ([@ydah][])
+* Add `NegatedMatcher` configuration option to `RSpec/ChangeByZero`. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -192,8 +192,10 @@ RSpec/BeforeAfterAll:
 RSpec/ChangeByZero:
   Description: Prefer negated matchers over `to change.by(0)`.
   Enabled: pending
-  VersionAdded: 2.11.0
+  VersionAdded: '2.11'
+  VersionChanged: '2.13'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ChangeByZero
+  NegatedMatcher: ~
 
 RSpec/ContextMethod:
   Description: "`context` should not be used for specifying methods."

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -391,15 +391,23 @@ end
 | Pending
 | Yes
 | Yes
-| 2.11.0
-| -
+| 2.11
+| 2.13
 |===
 
 Prefer negated matchers over `to change.by(0)`.
 
-This cop does not support autocorrection in some cases.
+In the case of composite expectations, cop suggest using the
+negation matchers of `RSpec::Matchers#change`.
+
+By default the cop does not support autocorrect of
+compound expectations, but if you set the
+negated matcher for `change`, e.g. `not_change` with
+the `NegatedMatcher` option, the cop will perform the autocorrection.
 
 === Examples
+
+==== NegatedMatcher: ~ (default)
 
 [source,ruby]
 ----
@@ -428,6 +436,38 @@ expect { run }
   .to not_change { Foo.bar }
   .and not_change { Foo.baz }
 ----
+
+==== NegatedMatcher: not_change
+
+[source,ruby]
+----
+# bad (support autocorrection to good case)
+expect { run }
+  .to change(Foo, :bar).by(0)
+  .and change(Foo, :baz).by(0)
+expect { run }
+  .to change { Foo.bar }.by(0)
+  .and change { Foo.baz }.by(0)
+
+# good
+define_negated_matcher :not_change, :change
+expect { run }
+  .to not_change(Foo, :bar)
+  .and not_change(Foo, :baz)
+expect { run }
+  .to not_change { Foo.bar }
+  .and not_change { Foo.baz }
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| NegatedMatcher
+| `<none>`
+| 
+|===
 
 === References
 

--- a/spec/rubocop/cop/rspec/change_by_zero_spec.rb
+++ b/spec/rubocop/cop/rspec/change_by_zero_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
+RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
   it 'registers an offense when the argument to `by` is zero' do
     expect_offense(<<-RUBY)
       it do
@@ -25,54 +25,207 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
     RUBY
   end
 
-  it 'registers an offense when the argument to `by` is zero ' \
-    'with compound expectations' do
-    expect_offense(<<-RUBY)
-      it do
-        expect { foo }
-          .to change(Foo, :bar).by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-          .and change(Foo, :baz).by(0)
-               ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-        expect { foo }
-          .to change { Foo.bar }.by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-          .and change { Foo.baz }.by(0)
-               ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-        expect { foo }
-          .to change(Foo, :bar).by(0) &
-              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-              change(Foo, :baz).by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-        expect { foo }
-          .to change { Foo.bar }.by(0) &
-              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-              change { Foo.baz }.by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-        expect { foo }
-          .to change(Foo, :bar).by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-          .or change(Foo, :baz).by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-        expect { foo }
-          .to change { Foo.bar }.by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-          .or change { Foo.baz }.by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-        expect { foo }
-          .to change(Foo, :bar).by(0) |
-              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-              change(Foo, :baz).by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-        expect { foo }
-          .to change { Foo.bar }.by(0) |
-              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-              change { Foo.baz }.by(0)
-              ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
-      end
-    RUBY
+  context 'when `NegatedMatcher` is not defined (default)' do
+    it 'registers an offense when the argument to `by` is zero ' \
+      'with compound expectations by `and`' do
+      expect_offense(<<-RUBY)
+        it do
+          expect { foo }.to change(Foo, :bar).by(0).and change(Foo, :baz).by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar }.by(0).and change { Foo.baz }.by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                                                         ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+        end
+      RUBY
 
-    expect_no_corrections
+      expect_no_corrections
+    end
+
+    it 'registers an offense when the argument to `by` is zero ' \
+      'with compound expectations by `&`' do
+      expect_offense(<<-RUBY)
+        it do
+          expect { foo }.to change(Foo, :bar).by(0) & change(Foo, :baz).by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                                                      ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar }.by(0) & change { Foo.baz }.by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                                                       ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense when the argument to `by` is zero ' \
+      'with compound expectations by `or`' do
+      expect_offense(<<-RUBY)
+        it do
+          expect { foo }.to change(Foo, :bar).by(0).or change(Foo, :baz).by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                                                       ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar }.by(0).or change { Foo.baz }.by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    it 'registers an offense when the argument to `by` is zero ' \
+      'with compound expectations by `|`' do
+      expect_offense(<<-RUBY)
+        it do
+          expect { foo }.to change(Foo, :bar).by(0) | change(Foo, :baz).by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                                                      ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar }.by(0) | change { Foo.baz }.by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                                                       ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+
+    context 'when with a line break' do
+      it 'registers an offense when the argument to `by` is zero ' \
+        'with compound expectations by `and`' do
+        expect_offense(<<-RUBY)
+          it do
+            expect { foo }
+              .to change(Foo, :bar).by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+              .and change(Foo, :baz).by(0)
+                   ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+            expect { foo }
+              .to change { Foo.bar }.by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+              .and change { Foo.baz }.by(0)
+                   ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when the argument to `by` is zero ' \
+        'with compound expectations by `&`' do
+        expect_offense(<<-RUBY)
+          it do
+            expect { foo }
+              .to change(Foo, :bar).by(0) &
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                  change(Foo, :baz).by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+            expect { foo }
+              .to change { Foo.bar }.by(0) &
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                  change { Foo.baz }.by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when the argument to `by` is zero ' \
+        'with compound expectations by `or`' do
+        expect_offense(<<-RUBY)
+          it do
+            expect { foo }
+              .to change(Foo, :bar).by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+              .or change(Foo, :baz).by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+            expect { foo }
+              .to change { Foo.bar }.by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+              .or change { Foo.baz }.by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense when the argument to `by` is zero ' \
+        'with compound expectations by `|`' do
+        expect_offense(<<-RUBY)
+          it do
+            expect { foo }
+              .to change(Foo, :bar).by(0) |
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                  change(Foo, :baz).by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+            expect { foo }
+              .to change { Foo.bar }.by(0) |
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+                  change { Foo.baz }.by(0)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          end
+        RUBY
+
+        expect_no_corrections
+      end
+    end
+  end
+
+  context "with `NegatedMatcher: 'not_change'`" do
+    let(:cop_config) { { 'NegatedMatcher' => 'not_change' } }
+
+    it 'registers an offense and autocorrect when ' \
+      'the argument to `by` is zero with compound expectations' do
+      expect_offense(<<-RUBY)
+        it do
+          expect { foo }.to change(Foo, :bar).by(0).and change(Foo, :baz).by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar }.by(0).and change { Foo.baz }.by(0)
+                            ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+                                                         ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it do
+          expect { foo }.to not_change(Foo, :bar).and not_change(Foo, :baz)
+          expect { foo }.to not_change { Foo.bar }.and not_change { Foo.baz }
+        end
+      RUBY
+    end
+
+    it 'registers an offense and autocorrect when ' \
+      'the argument to `by` is zero with compound expectations ' \
+      'with line break' do
+      expect_offense(<<-RUBY)
+        it do
+          expect { foo }
+            .to change(Foo, :bar).by(0)
+                ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+            .and change(Foo, :baz).by(0)
+                 ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+          expect { foo }
+            .to change { Foo.bar }.by(0)
+                ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+            .and change { Foo.baz }.by(0)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it do
+          expect { foo }
+            .to not_change(Foo, :bar)
+            .and not_change(Foo, :baz)
+          expect { foo }
+            .to not_change { Foo.bar }
+            .and not_change { Foo.baz }
+        end
+      RUBY
+    end
   end
 
   it 'does not register an offense when the argument to `by` is not zero' do


### PR DESCRIPTION
This PR is add `NegatedMatcher` option to `RSpec/ChangeByZero`.

In the case of composite expectations, cop suggest using the negation matchers of `RSpec::Matchers#change`.
By default doe's not support autocorrect, but if you set the negation matcher of `RSpec::Matchers#change` defined in `NegatedMatcher` option, will be autocorrect.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
