### PR TITLE
[Fix #1337] Update the cop to raise error for insufficient descriptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `require_implicit` style to `RSpec/ImplicitSubject`. ([@r7kamura][])
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher` when `have_css("a")` without attribute. ([@ydah][])
+* Update `RSpec/ExampleWording` cop to raise error for insufficient descriptions. ([@akrox58][])
 
 ## 2.13.2 (2022-09-23)
 
@@ -650,6 +651,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@abrom]: https://github.com/abrom
 [@ahukkanen]: https://github.com/ahukkanen
 [@akiomik]: https://github.com/akiomik
+[@akrox58]: https://github.com/akrox58
 [@AlexWayfer]: https://github.com/AlexWayfer
 [@andrykonchin]: https://github.com/andrykonchin
 [@andyw8]: https://github.com/andyw8

--- a/config/default.yml
+++ b/config/default.yml
@@ -194,7 +194,7 @@ RSpec/ChangeByZero:
   Description: Prefer negated matchers over `to change.by(0)`.
   Enabled: pending
   VersionAdded: '2.11'
-  VersionChanged: '2.13'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ChangeByZero
   NegatedMatcher: ~
 
@@ -383,8 +383,10 @@ RSpec/ExampleWording:
     have: has
     HAVE: HAS
   IgnoredWords: []
+  DisallowedExamples:
+    - works
   VersionAdded: '1.0'
-  VersionChanged: '1.2'
+  VersionChanged: '2.13'
   StyleGuide: https://rspec.rubystyle.guide/#should-in-example-docstrings
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -392,7 +392,7 @@ end
 | Yes
 | Yes
 | 2.11
-| 2.13
+| <<next>>
 |===
 
 Prefer negated matchers over `to change.by(0)`.
@@ -1534,15 +1534,20 @@ end
 | Yes
 | Yes
 | 1.0
-| 1.2
+| 2.13
 |===
 
 Checks for common mistakes in example descriptions.
 
 This cop will correct docstrings that begin with 'should' and 'it'.
+This cop will also look for insufficient examples and call them out.
 
 The autocorrect is experimental - use with care! It can be configured
 with CustomTransform (e.g. have => has) and IgnoredWords (e.g. only).
+
+Use the DisallowedExamples setting to prevent unclear or insufficient
+descriptions. Please note that this config will not be treated as
+case sensitive.
 
 === Examples
 
@@ -1568,6 +1573,19 @@ it 'does things' do
 end
 ----
 
+==== `DisallowedExamples: ['works']` (default)
+
+[source,ruby]
+----
+# bad
+it 'works' do
+end
+
+# good
+it 'marks the task as done' do
+end
+----
+
 === Configurable attributes
 
 |===
@@ -1579,6 +1597,10 @@ end
 
 | IgnoredWords
 | `[]`
+| Array
+
+| DisallowedExamples
+| `works`
 | Array
 |===
 

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -187,4 +187,65 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
       end
     RUBY
   end
+
+  it 'flags an unclear description' do
+    expect_offense(<<-'RUBY')
+      it "works" do
+          ^^^^^ Your example description is insufficient.
+      end
+    RUBY
+  end
+
+  it 'flags an unclear description despite extra spaces' do
+    expect_offense(<<-'RUBY')
+      it "  works    " do
+          ^^^^^^^^^^^ Your example description is insufficient.
+      end
+    RUBY
+  end
+
+  it 'flags an unclear description despite uppercase and lowercase strings' do
+    expect_offense(<<-'RUBY')
+      it "WOrKs " do
+          ^^^^^^ Your example description is insufficient.
+      end
+    RUBY
+  end
+
+  context 'when `DisallowedExamples: Workz`' do
+    let(:cop_config) { { 'DisallowedExamples' => ['Workz'] } }
+
+    it 'finds a valid sentence across two lines' do
+      expect_no_offenses(<<-'RUBY')
+        it "workz " \
+          "totally fine " do
+        end
+      RUBY
+    end
+
+    it 'finds an invalid example across two lines' do
+      expect_offense(<<-'RUBY')
+        it "workz" \
+            ^^^^^^^^ Your example description is insufficient.
+          " " do
+        end
+      RUBY
+    end
+
+    it 'flags an unclear description' do
+      expect_offense(<<-'RUBY')
+        it "workz" do
+            ^^^^^ Your example description is insufficient.
+        end
+      RUBY
+    end
+
+    it 'flags an unclear description despite uppercase and lowercase strings' do
+      expect_offense(<<-'RUBY')
+        it "WOrKz " do
+            ^^^^^^ Your example description is insufficient.
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Per issue #1337, I tried to add a generic way to the ExampleWordingCop to call out insufficient descriptions. For now, I've used "works" and "throws errors" as that is a phrase I see used often as well. I didn't use a new cop since insufficient descriptions seemed to be along the same lines as "should not start with should or it" as they are both description related.

---

Before submitting the PR make sure the following are checked:

* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Updated documentation.
* [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [X] Set `VersionChanged` in `config/default.yml` to the next major version.