### PR TITLE
Support for using `~` when converting null values to `ConfigFormatter`

### DIFF
--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -51,7 +51,7 @@ module RuboCop
         end
       end
 
-      def refarence(cop)
+      def reference(cop)
         COP_DOC_BASE_URL + cop.sub('RSpec/', '')
       end
 

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -42,7 +42,7 @@ module RuboCop
       def replace(cop, unified)
         replace_nil(unified[cop])
         unified[cop].merge!(descriptions.fetch(cop))
-        unified[cop]['Reference'] = refarence(cop)
+        unified[cop]['Reference'] = reference(cop)
       end
 
       def replace_nil(config)

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -21,6 +21,7 @@ module RuboCop
           .gsub(EXTENSION_ROOT_DEPARTMENT, "\n\\1")
           .gsub(*AMENDMENTS, "\n\\0")
           .gsub(/^(\s+)- /, '\1  - ')
+          .gsub('"~"', '~')
       end
 
       private
@@ -30,13 +31,28 @@ module RuboCop
           next if SUBDEPARTMENTS.include?(cop)
           next if AMENDMENTS.include?(cop)
 
-          unified[cop].merge!(descriptions.fetch(cop))
-          unified[cop]['Reference'] = COP_DOC_BASE_URL + cop.sub('RSpec/', '')
+          replace(cop, unified)
         end
       end
 
       def cops
         (descriptions.keys | config.keys).grep(EXTENSION_ROOT_DEPARTMENT)
+      end
+
+      def replace(cop, unified)
+        replace_nil(unified[cop])
+        unified[cop].merge!(descriptions.fetch(cop))
+        unified[cop]['Reference'] = refarence(cop)
+      end
+
+      def replace_nil(config)
+        config.each do |key, value|
+          config[key] = '~' if value.nil?
+        end
+      end
+
+      def refarence(cop)
+        COP_DOC_BASE_URL + cop.sub('RSpec/', '')
       end
 
       attr_reader :config, :descriptions

--- a/spec/rubocop/rspec/config_formatter_spec.rb
+++ b/spec/rubocop/rspec/config_formatter_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
         'Enabled' => true
       },
       'RSpec/Bar' => {
-        'Enabled' => true
+        'Enabled' => true,
+        'Nullable' => nil
       },
       'RSpec/Baz' => {
         'Enabled' => true,
@@ -52,6 +53,7 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
       |
       |RSpec/Bar:
       |  Enabled: true
+      |  Nullable: ~
       |  Description: Wow
       |  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Bar
       |


### PR DESCRIPTION
Resolve: https://github.com/rubocop/rubocop-rspec/pull/1349#discussion_r937187685

Setting default.yml to null value always caused CI to fail.

Like this:
```yml
Foo:
  NegatedMatcher: ~
```

```
Run bundle exec rake confirm_config documentation_syntax_check confirm_documentation
bin/build_config
rake aborted!
default.yml is out of sync:

diff --git a/config/default.yml b/config/default.yml
index 5b1e3ef..d2fedab 100644
--- a/config/default.yml
+++ b/config/default.yml
@@ -195,7 +195,7 @@ RSpec/ChangeByZero:
   VersionAdded: '2.11'
   VersionChanged: '2.13'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ChangeByZero
-  NegatedMatcher: ~
+  NegatedMatcher: 
```

I think the null value is missing because this is dumping what this read in YAML.

https://github.com/rubocop/rubocop-rspec/blob/223afd510574148c0dea9753546db01ff4eebcc6/bin/build_config#L24-L33

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
