### PR TITLE
Tweak `ConfigFormatter`

### DIFF
--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -28,21 +28,16 @@ module RuboCop
 
       def unified_config
         cops.each_with_object(config.dup) do |cop, unified|
-          next if SUBDEPARTMENTS.include?(cop)
-          next if AMENDMENTS.include?(cop)
+          next if SUBDEPARTMENTS.include?(cop) || AMENDMENTS.include?(cop)
 
-          replace(cop, unified)
+          replace_nil(unified[cop])
+          unified[cop].merge!(descriptions.fetch(cop))
+          unified[cop]['Reference'] = reference(cop)
         end
       end
 
       def cops
         (descriptions.keys | config.keys).grep(EXTENSION_ROOT_DEPARTMENT)
-      end
-
-      def replace(cop, unified)
-        replace_nil(unified[cop])
-        unified[cop].merge!(descriptions.fetch(cop))
-        unified[cop]['Reference'] = reference(cop)
       end
 
       def replace_nil(config)


### PR DESCRIPTION
Resolve: https://github.com/rubocop/rubocop-rspec/pull/1352#discussion_r937246931

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
