### PR TITLE
Fix a false positive for `RSpec/Capybara/SpecificMatcher` when pseudo-classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Deprecate `IgnoredPatterns` option in favor of the `AllowedPatterns` options. ([@ydah][])
 * Add `AllowedPatterns` configuration option to `RSpec/ContextWording`. ([@ydah][])
 * Add `RSpec/ClassCheck` cop. ([@r7kamura][])
+* Fix a false positive for `RSpec/Capybara/SpecificMatcher` when pseudo-classes. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/lib/rubocop/cop/rspec/mixin/css_selector.rb
+++ b/lib/rubocop/cop/rspec/mixin/css_selector.rb
@@ -56,6 +56,20 @@ module RuboCop
         end
 
         # @param selector [String]
+        # @return [Array<String>]
+        # @example
+        #   pseudo_classes('button:not([disabled])') # => ['not()']
+        #   pseudo_classes('a:enabled:not([valid])') # => ['enabled', 'not()']
+        def pseudo_classes(selector)
+          # Attributes must be excluded or else the colon in the `href`s URL
+          # will also be picked up as pseudo classes.
+          # "a:not([href='http://example.com']):enabled" => "a:not():enabled"
+          ignored_attribute = selector.gsub(/\[.*?\]/, '')
+          # "a:not():enabled" => ["not()", "enabled"]
+          ignored_attribute.scan(/:([^:]*)/).flatten
+        end
+
+        # @param selector [String]
         # @return [Boolean]
         # @example
         #   multiple_selectors?('a.cls b#id') # => true

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -194,8 +194,6 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
     expect_offense(<<-RUBY)
       expect(page).to have_css('button[disabled][name="foo"]', exact_text: 'foo')
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
-      expect(page).to have_css('button:not([name="foo"][disabled])', exact_text: 'bar')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
@@ -203,8 +201,49 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
     expect_offense(<<-RUBY)
       expect(page).to have_css('button[disabled]', exact_text: 'foo')
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+    RUBY
+  end
+
+  it 'registers an offense when using abstract matcher with ' \
+      'first argument is element with replaceable pseudo-classes' do
+    expect_offense(<<-RUBY)
       expect(page).to have_css('button:not([disabled])', exact_text: 'bar')
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([disabled][visible])')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+    RUBY
+  end
+
+  it 'registers an offense when using abstract matcher with ' \
+      'first argument is element with multiple replaceable pseudo-classes' do
+    expect_offense(<<-RUBY)
+      expect(page).to have_css('button:not([disabled]):enabled')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([disabled=false]):disabled')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([disabled]):not([disabled])')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('input:not([unchecked]):checked')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+      expect(page).to have_css('input:not([unchecked=false]):unchecked')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+      expect(page).to have_css('input:not([unchecked]):not([unchecked])')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+    RUBY
+  end
+
+  it 'does not register an offense when using abstract matcher with ' \
+      'first argument is element with replaceable pseudo-classes' \
+      'and not boolean attributes' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('button:not([name="foo"][disabled])')
+    RUBY
+  end
+
+  it 'does not register an offense when using abstract matcher with ' \
+      'first argument is element with multiple nonreplaceable pseudo-classes' do
+    expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('button:first-of-type:not([disabled])')
     RUBY
   end
 


### PR DESCRIPTION
Resolve: https://github.com/rubocop/rubocop-rspec/issues/1351

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
