### PR TITLE
Fix `InternalAffairs/NumblockHandler` offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher` when may not have a `href` by `have_link`. ([@ydah][])
 * Add `NegatedMatcher` configuration option to `RSpec/ChangeByZero`. ([@ydah][])
 * Add new `RSpec/Capybara/SpecificFinders` cop. ([@ydah][])
+* Add support for numblocks to `RSpec/AroundBlock`, `RSpec/EmptyLineAfterHook`, `RSpec/ExpectInHook`, `RSpec/HookArgument`, `RSpec/HooksBeforeExamples`, `RSpec/IteratedExpectation`, and `RSpec/NoExpectationExample`. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -68,7 +68,7 @@ module RuboCop
             ...)
           PATTERN
 
-          def on_block(node)
+          def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
             return unless inside_example_group?(node)
 
             feature_method(node) do |send_node, match|

--- a/lib/rubocop/cop/rspec/context_method.rb
+++ b/lib/rubocop/cop/rspec/context_method.rb
@@ -33,7 +33,7 @@ module RuboCop
           (block (send #rspec? :context $(str #method_name?) ...) ...)
         PATTERN
 
-        def on_block(node)
+        def on_block(node)  # rubocop:disable InternalAffairs/NumblockHandler
           context_method(node) do |context|
             add_offense(context) do |corrector|
               corrector.replace(node.send_node.loc.selector, 'describe')

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -43,7 +43,7 @@ module RuboCop
           (block (send #rspec? { :context :shared_context } $(str #bad_prefix?) ...) ...)
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           context_wording(node) do |context|
             add_offense(context,
                         message: format(MSG, prefixes: joined_prefixes))

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -82,7 +82,7 @@ module RuboCop
         def_node_search :contains_described_class?,
                         '(send nil? :described_class)'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           # In case the explicit style is used, we need to remember what's
           # being described.
           @described_class, body = described_constant(node)

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -134,7 +134,7 @@ module RuboCop
           }
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return if node.each_ancestor(:def, :defs).any?
           return if node.each_ancestor(:block).any? { |block| example?(block) }
 

--- a/lib/rubocop/cop/rspec/empty_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_hook.rb
@@ -33,7 +33,7 @@ module RuboCop
           (block $#{send_pattern('#Hooks.all')} _ nil?)
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           empty_hook?(node) do |hook|
             add_offense(hook) do |corrector|
               corrector.remove(

--- a/lib/rubocop/cop/rspec/empty_line_after_example.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example.rb
@@ -47,7 +47,7 @@ module RuboCop
 
         MSG = 'Add an empty line after `%<example>s`.'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example?(node)
           return if allowed_one_liner?(node)
 

--- a/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
@@ -29,7 +29,7 @@ module RuboCop
 
         MSG = 'Add an empty line after `%<example_group>s`.'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group?(node)
 
           missing_separating_line_offense(node) do |method|

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -22,7 +22,7 @@ module RuboCop
 
         MSG = 'Add an empty line after the last `%<let>s`.'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group_with_body?(node)
 
           final_let = node.body.child_nodes.reverse.find { |child| let?(child) }

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -66,6 +66,8 @@ module RuboCop
           end
         end
 
+        alias on_numblock on_block
+
         private
 
         def chained_single_line_hooks?(node)

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -21,7 +21,7 @@ module RuboCop
 
         MSG = 'Add an empty line after `%<subject>s`.'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless subject?(node)
           return unless inside_example_group?(node)
 

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -52,7 +52,7 @@ module RuboCop
 
         LABEL = 'Example'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example?(node)
 
           check_code_length(node)

--- a/lib/rubocop/cop/rspec/example_without_description.rb
+++ b/lib/rubocop/cop/rspec/example_without_description.rb
@@ -57,7 +57,7 @@ module RuboCop
         # @!method example_description(node)
         def_node_matcher :example_description, '(send nil? _ $(str $_))'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example?(node)
 
           check_example_without_description(node.send_node)

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -46,7 +46,7 @@ module RuboCop
           } ...) ...)
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           it_description(node) do |description_node, message|
             if message.match?(SHOULD_PREFIX)
               add_wording_offense(description_node, MSG_SHOULD)

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -69,7 +69,7 @@ module RuboCop
           end
         end
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless style == :method_call
 
           expect_change_with_block(node) do |receiver, message|

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -26,7 +26,7 @@ module RuboCop
         # @!method expectation(node)
         def_node_search :expectation, send_pattern('#Expectations.all')
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless hook?(node)
           return if node.body.nil?
 
@@ -35,6 +35,8 @@ module RuboCop
                         message: message(expect, node))
           end
         end
+
+        alias on_numblock on_block
 
         private
 

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -39,7 +39,7 @@ module RuboCop
             (block (send _ #attribute_defining_method? ...) _ { (begin $...) $(send ...) } )
           PATTERN
 
-          def on_block(node)
+          def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
             attributes = factory_attributes(node) || []
             attributes = [attributes] unless attributes.is_a?(Array) # rubocop:disable Style/ArrayCoercion, Lint/RedundantCopDisableDirective
 

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -71,7 +71,7 @@ module RuboCop
             (send {nil? #factory_bot?} :create_list (sym _) (int $_) ...)
           PATTERN
 
-          def on_block(node)
+          def on_block(node) # rubocop:todo InternalAffairs/NumblockHandler
             return unless style == :create_list
 
             return unless n_times_block?(node)

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -66,11 +66,13 @@ module RuboCop
 
         # @!method scoped_hook(node)
         def_node_matcher :scoped_hook, <<-PATTERN
-          (block $(send _ #Hooks.all (sym ${:each :example})) ...)
+          ({block numblock} $(send _ #Hooks.all (sym ${:each :example})) ...)
         PATTERN
 
         # @!method unscoped_hook(node)
-        def_node_matcher :unscoped_hook, '(block $(send _ #Hooks.all) ...)'
+        def_node_matcher :unscoped_hook, <<-PATTERN
+          ({block numblock} $(send _ #Hooks.all) ...)
+        PATTERN
 
         def on_block(node)
           hook(node) do |method_send, scope_name|
@@ -85,6 +87,8 @@ module RuboCop
             end
           end
         end
+
+        alias on_numblock on_block
 
         private
 

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -32,6 +32,7 @@ module RuboCop
         def_node_matcher :example_or_group?, <<-PATTERN
           {
             #{block_pattern('{#ExampleGroups.all #Examples.all}')}
+            #{numblock_pattern('{#ExampleGroups.all #Examples.all}')}
             #{send_pattern('#Includes.examples')}
           }
         PATTERN
@@ -41,6 +42,8 @@ module RuboCop
 
           check_hooks(node.body) if multiline_block?(node.body)
         end
+
+        alias on_numblock on_block
 
         private
 

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -42,7 +42,7 @@ module RuboCop
           ...)
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example?(node)
 
           null_double(node) do |var, receiver|

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -28,6 +28,13 @@ module RuboCop
           )
         PATTERN
 
+        # @!method each_numblock?(node)
+        def_node_matcher :each_numblock?, <<-PATTERN
+          (numblock
+            (send ... :each) _ $(...)
+          )
+        PATTERN
+
         # @!method expectation?(node)
         def_node_matcher :expectation?, <<-PATTERN
           (send (send nil? :expect (lvar %)) :to ...)
@@ -36,6 +43,14 @@ module RuboCop
         def on_block(node)
           each?(node) do |arg, body|
             if single_expectation?(body, arg) || only_expectations?(body, arg)
+              add_offense(node.send_node)
+            end
+          end
+        end
+
+        def on_numblock(node)
+          each_numblock?(node) do |body|
+            if single_expectation?(body, :_1) || only_expectations?(body, :_1)
               add_offense(node.send_node)
             end
           end

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         MSG = 'Declare `subject` above any other `%<offending>s` declarations.'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless subject?(node)
           return unless inside_example_group?(node)
 

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -43,7 +43,7 @@ module RuboCop
           }
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group_with_body?(node)
 
           check_let_declarations(node.body) if multiline_block?(node.body)

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -49,7 +49,7 @@ module RuboCop
         # @!method method_called?(node)
         def_node_search :method_called?, '(send nil? %)'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_or_shared_group_or_including?(node)
 
           unused_let_bang(node) do |let|

--- a/lib/rubocop/cop/rspec/missing_example_group_argument.rb
+++ b/lib/rubocop/cop/rspec/missing_example_group_argument.rb
@@ -22,7 +22,7 @@ module RuboCop
       class MissingExampleGroupArgument < Base
         MSG = 'The first argument to `%<method>s` should not be empty.'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group?(node)
           return if node.send_node.arguments?
 

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -88,7 +88,7 @@ module RuboCop
           (block (send nil? :aggregate_failures ...) ...)
         PATTERN
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example?(node)
 
           return if example_with_aggregate_failures?(node)

--- a/lib/rubocop/cop/rspec/multiple_memoized_helpers.rb
+++ b/lib/rubocop/cop/rspec/multiple_memoized_helpers.rb
@@ -89,7 +89,7 @@ module RuboCop
 
         MSG = 'Example group has too many memoized helpers [%<count>d/%<max>d]'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless spec_group?(node)
 
           count = all_helpers(node).uniq.count

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -55,7 +55,7 @@ module RuboCop
 
         MSG = 'Do not set more than one subject per example group'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group?(node)
 
           subjects = RuboCop::RSpec::ExampleGroup.new(node).subjects

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -55,7 +55,7 @@ module RuboCop
         # @!method subject_usage(node)
         def_node_search :subject_usage, '$(send nil? :subject)'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           if !example_or_hook_block?(node) || ignored_shared_example?(node)
             return
           end

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -34,10 +34,12 @@ module RuboCop
         # @!method regular_or_focused_example?(node)
         # @param [RuboCop::AST::Node] node
         # @return [Boolean]
-        def_node_matcher(
-          :regular_or_focused_example?,
-          block_pattern('{#Examples.regular | #Examples.focused}')
-        )
+        def_node_matcher :regular_or_focused_example?, <<~PATTERN
+          {
+            #{block_pattern('{#Examples.regular | #Examples.focused}')}
+            #{numblock_pattern('{#Examples.regular | #Examples.focused}')}
+          }
+        PATTERN
 
         # @!method including_any_expectation?(node)
         # @param [RuboCop::AST::Node] node
@@ -54,6 +56,8 @@ module RuboCop
 
           add_offense(node)
         end
+
+        alias on_numblock on_block
       end
     end
   end

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -30,7 +30,7 @@ module RuboCop
         # @!method first_argument_name(node)
         def_node_matcher :first_argument_name, '(send _ _ ({str sym} $_))'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group_with_body?(node)
 
           find_duplicates(node.body) do |duplicate, name|

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -291,7 +291,7 @@ module RuboCop
           end
         end
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           check_explicit(node) if style == :explicit
         end
 

--- a/lib/rubocop/cop/rspec/rails/avoid_setup_hook.rb
+++ b/lib/rubocop/cop/rspec/rails/avoid_setup_hook.rb
@@ -30,7 +30,7 @@ module RuboCop
               (args) _)
           PATTERN
 
-          def on_block(node)
+          def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
             setup_call(node) do |setup|
               add_offense(node) do |corrector|
                 corrector.replace setup, 'before'

--- a/lib/rubocop/cop/rspec/repeated_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_description.rb
@@ -43,7 +43,7 @@ module RuboCop
       class RepeatedDescription < Base
         MSG = "Don't repeat descriptions within an example group."
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group?(node)
 
           repeated_descriptions(node).each do |repeated_description|

--- a/lib/rubocop/cop/rspec/repeated_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_example.rb
@@ -18,7 +18,7 @@ module RuboCop
       class RepeatedExample < Base
         MSG = "Don't repeat examples within an example group."
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group?(node)
 
           repeated_examples(node).each do |repeated_example|

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -59,7 +59,7 @@ module RuboCop
           check_and_return_call(node)
         end
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless style == :and_return
           return unless stub_with_block?(node)
 

--- a/lib/rubocop/cop/rspec/scattered_let.rb
+++ b/lib/rubocop/cop/rspec/scattered_let.rb
@@ -31,7 +31,7 @@ module RuboCop
 
         MSG = 'Group all let/let! blocks in the example group together.'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group_with_body?(node)
 
           check_let_declarations(node.body)

--- a/lib/rubocop/cop/rspec/scattered_setup.rb
+++ b/lib/rubocop/cop/rspec/scattered_setup.rb
@@ -26,7 +26,7 @@ module RuboCop
         MSG = 'Do not define multiple `%<hook_name>s` hooks in the same ' \
               'example group (also defined on %<lines>s).'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group?(node)
 
           repeated_hooks(node).each do |occurrences|

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -79,7 +79,7 @@ module RuboCop
         def_node_matcher :shared_example,
                          block_pattern('#SharedGroups.examples')
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           context_with_only_examples(node) do
             add_offense(node.send_node, message: MSG_EXAMPLES) do |corrector|
               corrector.replace(node.send_node.loc.selector, 'shared_examples')

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -32,7 +32,7 @@ module RuboCop
           check_expect(node)
         end
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless expect_block?(node)
 
           check_expect(node)

--- a/lib/rubocop/cop/rspec/yield.rb
+++ b/lib/rubocop/cop/rspec/yield.rb
@@ -26,7 +26,7 @@ module RuboCop
         # @!method block_call?(node)
         def_node_matcher :block_call?, '(send (lvar %) :call ...)'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless method_on_stub?(node.send_node)
 
           block_arg(node.arguments) do |block|

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -41,7 +41,12 @@ module RuboCop
       def_node_matcher :example?, block_pattern('#Examples.all')
 
       # @!method hook?(node)
-      def_node_matcher :hook?, block_pattern('#Hooks.all')
+      def_node_matcher :hook?, <<-PATTERN
+        {
+          #{block_pattern('#Hooks.all')}
+          #{numblock_pattern('#Hooks.all')}
+        }
+      PATTERN
 
       # @!method let?(node)
       def_node_matcher :let?, <<-PATTERN

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -12,6 +12,10 @@ module RuboCop
         def block_pattern(string)
           "(block #{send_pattern(string)} ...)"
         end
+
+        def numblock_pattern(string)
+          "(numblock #{send_pattern(string)} ...)"
+        end
       end
     end
   end

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -116,4 +116,66 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
       RUBY
     end
   end
+
+  context 'when Ruby 2.7', :ruby27 do
+    context 'when the yielded value is unused' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY)
+          around { _1 }
+                   ^^ You should call `_1.call` or `_1.run`.
+        RUBY
+      end
+    end
+
+    context 'when a method other than #run or #call is called' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY)
+          around do
+            _1.inspect
+            ^^^^^^^^^^ You should call `_1.call` or `_1.run`.
+          end
+        RUBY
+      end
+    end
+
+    context 'when #run is called' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY)
+          around do
+            _1.run
+          end
+        RUBY
+      end
+    end
+
+    context 'when #call is called' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY)
+          around do
+            _1.call
+          end
+        RUBY
+      end
+    end
+
+    context 'when used as a block arg' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY)
+          around do
+            1.times(&_1)
+          end
+        RUBY
+      end
+    end
+
+    context 'when passed to another method' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY)
+          around do
+            something_that_might_run_test(_1, another_arg)
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/base_spec.rb
+++ b/spec/rubocop/cop/rspec/base_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe RuboCop::Cop::RSpec::Base do
     before do
       stub_const('RuboCop::RSpec::ExampleGroupHaterCop',
                  Class.new(described_class) do
-                   def on_block(node)
+                   def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
                      example_group?(node) do
                        add_offense(node, message: 'I flag example groups')
                      end

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -451,5 +451,37 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
     end
+
+    context 'when Ruby 2.7', :ruby27 do
+      it 'registers an offense for empty line after `around` hook' do
+        expect_offense(<<-RUBY)
+          RSpec.describe User do
+            around { _1.run }
+            ^^^^^^^^^^^^^^^^^ Add an empty line after `around`.
+            it { does_something }
+          end
+        RUBY
+
+        expect_correction(<<-RUBY)
+          RSpec.describe User do
+            around { _1.run }
+
+            it { does_something }
+          end
+        RUBY
+      end
+
+      it 'does not register an offense for multiline `around` block' do
+        expect_no_offenses(<<-RUBY)
+          RSpec.describe User do
+            around do
+              _1.run
+            end
+
+            it { does_something }
+          end
+        RUBY
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -74,4 +74,20 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
       end
     RUBY
   end
+
+  context 'when Ruby 2.7', :ruby27 do
+    it 'adds an offense for `expect` in `around` hook' do
+      expect_offense(<<-RUBY)
+        around do
+          expect(something).to eq('foo')
+          ^^^^^^ Do not use `expect` in `around` hook
+          is_expected(something).to eq('foo')
+          ^^^^^^^^^^^ Do not use `is_expected` in `around` hook
+          expect_any_instance_of(Something).to receive(:foo)
+          ^^^^^^^^^^^^^^^^^^^^^^ Do not use `expect_any_instance_of` in `around` hook
+          _1.run
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -230,5 +230,13 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList do
         SomeFactory.create_list :user, 3
       RUBY
     end
+
+    context 'when Ruby 2.7', :ruby27 do
+      it 'ignores n.times with numblock' do
+        expect_no_offenses(<<~RUBY)
+          3.times { create :user, position: _1 }
+        RUBY
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -88,6 +88,36 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     include_examples 'an example hook'
+
+    context 'when Ruby 2.7', :ruby27 do
+      it 'detects :each for hooks' do
+        expect_offense(<<-RUBY)
+          around(:each) { _1 }
+          ^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
+        RUBY
+
+        expect_correction(<<-RUBY)
+          around { _1 }
+        RUBY
+      end
+
+      it 'detects :example for hooks' do
+        expect_offense(<<-RUBY)
+          around(:example) { _1 }
+          ^^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
+        RUBY
+
+        expect_correction(<<-RUBY)
+          around { _1 }
+        RUBY
+      end
+
+      it 'does not flag hooks without default scopes' do
+        expect_no_offenses(<<-RUBY)
+          around { _1 }
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is :each' do
@@ -143,6 +173,36 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     include_examples 'an example hook'
+
+    context 'when Ruby 2.7', :ruby27 do
+      it 'does not flag :each for hooks' do
+        expect_no_offenses(<<-RUBY)
+          around(:each) { _1 }
+        RUBY
+      end
+
+      it 'detects :example for hooks' do
+        expect_offense(<<-RUBY)
+          around(:example) { _1 }
+          ^^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
+        RUBY
+
+        expect_correction(<<-RUBY)
+          around(:each) { _1 }
+        RUBY
+      end
+
+      it 'detects hooks without default scopes' do
+        expect_offense(<<-RUBY)
+          around { _1 }
+          ^^^^^^ Use `:each` for RSpec hooks.
+        RUBY
+
+        expect_correction(<<-RUBY)
+          around(:each) { _1 }
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is :example' do
@@ -198,5 +258,35 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     include_examples 'an example hook'
+
+    context 'when Ruby 2.7', :ruby27 do
+      it 'does not flag :example for hooks' do
+        expect_no_offenses(<<-RUBY)
+          around(:example) { _1 }
+        RUBY
+      end
+
+      it 'detects :each for hooks' do
+        expect_offense(<<-RUBY)
+          around(:each) { _1 }
+          ^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
+        RUBY
+
+        expect_correction(<<-RUBY)
+          around(:example) { _1 }
+        RUBY
+      end
+
+      it 'detects hooks without default scopes' do
+        expect_offense(<<-RUBY)
+          around { _1 }
+          ^^^^^^ Use `:example` for RSpec hooks.
+        RUBY
+
+        expect_correction(<<-RUBY)
+          around(:example) { _1 }
+        RUBY
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
@@ -166,4 +166,65 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
       end
     RUBY
   end
+
+  context 'when Ruby 2.7', :ruby27 do
+    it 'flags `around` after `it`' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          it { is_expected.to be_after_around_hook }
+          around { _1 }
+          ^^^^^^^^^^^^^ Move `around` above the examples in the group.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          around { _1 }
+          it { is_expected.to be_after_around_hook }
+        end
+      RUBY
+    end
+
+    it 'flags `around` after `context`' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          context 'a context' do
+            it { is_expected.to be_after_around_hook }
+          end
+
+          around { _1 }
+          ^^^^^^^^^^^^^ Move `around` above the examples in the group.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          around { _1 }
+          context 'a context' do
+            it { is_expected.to be_after_around_hook }
+          end
+
+        end
+      RUBY
+    end
+
+    it 'flags `around` after `include_examples`' do
+      expect_offense(<<-RUBY)
+        RSpec.describe User do
+          include_examples('should be after around-hook')
+
+          around { _1 }
+          ^^^^^^^^^^^^^ Move `around` above the examples in the group.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        RSpec.describe User do
+          around { _1 }
+          include_examples('should be after around-hook')
+
+        end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
+++ b/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
@@ -114,4 +114,19 @@ RSpec.describe RuboCop::Cop::RSpec::NoExpectationExample do
       RUBY
     end
   end
+
+  context 'when Ruby 2.7', :ruby27 do
+    context 'with no expectation example with it' do
+      it 'registers an offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            it { _1 }
+            ^^^^^^^^^ No expectation found in this example.
+
+            it { expect(baz).to be_truthy }
+          end
+        RUBY
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/yield_spec.rb
+++ b/spec/rubocop/cop/rspec/yield_spec.rb
@@ -76,4 +76,21 @@ RSpec.describe RuboCop::Cop::RSpec::Yield do
       end
     RUBY
   end
+
+  context 'when Ruby 2.7', :ruby27 do
+    it 'ignores `receive` with no block arguments' do
+      expect_no_offenses(<<-RUBY)
+        allow(foo).to receive(:bar) { _1.call }
+      RUBY
+    end
+
+    it 'ignores stub when `block.call` is not the only statement' do
+      expect_no_offenses(<<-RUBY)
+        allow(foo).to receive(:bar) do
+          result = _1.call
+          transform(result)
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
In this PR, corrections were made to the following internal cop additions where they were in offense.
- https://github.com/rubocop/rubocop/pull/10915

This PR correction of each offense for each cop in separate commits, just as we did with the original PR.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [-] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [x] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
* [x] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
