### PR TITLE
Add `AllowedGroups` configuration option to `RSpec/NestedGroups`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add new `RSpec/Capybara/SpecificFinders` cop. ([@ydah][])
 * Add support for numblocks to `RSpec/AroundBlock`, `RSpec/EmptyLineAfterHook`, `RSpec/ExpectInHook`, `RSpec/HookArgument`, `RSpec/HooksBeforeExamples`, `RSpec/IteratedExpectation`, and `RSpec/NoExpectationExample`. ([@ydah][])
 * Fix incorrect documentation URLs when using `rubocop --show-docs-url`. ([@r7kamura][])
+* Add `AllowedGroups` configuration option to `RSpec/NestedGroups`. ([@ydah][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -618,8 +618,9 @@ RSpec/NestedGroups:
   Description: Checks for nested example groups.
   Enabled: true
   Max: 3
+  AllowedGroups: []
   VersionAdded: '1.7'
-  VersionChanged: '1.10'
+  VersionChanged: '2.13'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NestedGroups
 
 RSpec/NoExpectationExample:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3254,7 +3254,7 @@ end
 | Yes
 | No
 | 1.7
-| 1.10
+| 2.13
 |===
 
 Checks for nested example groups.
@@ -3311,36 +3311,55 @@ context 'using some feature as an admin' do
 end
 ----
 
-==== configuration
+==== `Max: 3` (default)
 
 [source,ruby]
 ----
-# .rubocop.yml
-# RSpec/NestedGroups:
-#   Max: 2
-
-context 'when using some feature' do
-  let(:some)    { :various }
-  let(:feature) { :setup   }
-
-  context 'when user is signed in' do
-    let(:user) do
-      UserCreate.call(user_attributes)
+# bad
+describe Foo do
+  context 'foo' do
+    context 'bar' do
+      context 'baz' do # flagged by rubocop
+      end
     end
+  end
+end
+----
 
-    let(:user_attributes) do
-      {
-        name: 'John',
-        age:  22,
-        role: role
-      }
+==== `Max: 2`
+
+[source,ruby]
+----
+# bad
+describe Foo do
+  context 'foo' do
+    context 'bar' do # flagged by rubocop
+      context 'baz' do # flagged by rubocop
+      end
     end
+  end
+end
+----
 
-    context 'when user is an admin' do # flagged by rubocop
-      let(:role) { 'admin' }
+==== `AllowedGroups: [] (default)`
 
-      it 'blah blah'
-      it 'yada yada'
+[source,ruby]
+----
+describe Foo do # <-- nested groups 1
+  context 'foo' do # <-- nested groups 2
+    context 'bar' do # <-- nested groups 3
+    end
+  end
+end
+----
+
+==== `AllowedGroups: [path]`
+
+[source,ruby]
+----
+describe Foo do # <-- nested groups 1
+  path '/foo' do # <-- nested groups 1 (not counted)
+    context 'bar' do # <-- nested groups 2
     end
   end
 end
@@ -3354,6 +3373,10 @@ end
 | Max
 | `3`
 | Integer
+
+| AllowedGroups
+| `[]`
+| Array
 |===
 
 === References

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -143,4 +143,39 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
       end
     RUBY
   end
+
+  context 'when AllowedGroups is configured as' do
+    let(:cop_config) { { 'AllowedGroups' => ['path'] } }
+
+    it 'accept nested example groups defined inside `describe`' \
+       'path is not counted' do
+      expect_no_offenses(<<-RUBY)
+        describe MyClass do
+          path '/users' do
+            context 'when foo' do
+              context 'when bar' do
+              end
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'flags nested example groups defined inside `describe`' \
+       'path is not counted but exceeded max' do
+      expect_offense(<<-RUBY)
+        describe MyClass do
+          path '/users' do
+            context 'when foo' do
+              context 'when bar' do
+                context 'when baz' do
+                ^^^^^^^^^^^^^^^^^^ Maximum example group nesting exceeded [4/3].
+                end
+              end
+            end
+          end
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Resolve: https://github.com/rubocop/rubocop-rspec/issues/1360

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
