### PR TITLE
Fix cop header comment

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1993,8 +1993,7 @@ Checks for before/around/after hooks that come after an example.
 
 [source,ruby]
 ----
-# Bad
-
+# bad
 it 'checks what foo does' do
   expect(foo).to be
 end
@@ -2002,7 +2001,7 @@ end
 before { prepare }
 after { clean_up }
 
-# Good
+# good
 before { prepare }
 after { clean_up }
 
@@ -2432,28 +2431,28 @@ Enforce that subject is the first definition in the test.
 [source,ruby]
 ----
 # bad
-  let(:params) { blah }
-  subject { described_class.new(params) }
+let(:params) { blah }
+subject { described_class.new(params) }
 
-  before { do_something }
-  subject { described_class.new(params) }
+before { do_something }
+subject { described_class.new(params) }
 
-  it { expect_something }
-  subject { described_class.new(params) }
-  it { expect_something_else }
-
-# good
-  subject { described_class.new(params) }
-  let(:params) { blah }
+it { expect_something }
+subject { described_class.new(params) }
+it { expect_something_else }
 
 # good
-  subject { described_class.new(params) }
-  before { do_something }
+subject { described_class.new(params) }
+let(:params) { blah }
 
 # good
-  subject { described_class.new(params) }
-  it { expect_something }
-  it { expect_something_else }
+subject { described_class.new(params) }
+before { do_something }
+
+# good
+subject { described_class.new(params) }
+it { expect_something }
+it { expect_something_else }
 ----
 
 === References
@@ -2595,7 +2594,7 @@ Checks for `let` definitions that come after an example.
 
 [source,ruby]
 ----
-# Bad
+# bad
 let(:foo) { bar }
 
 it 'checks what foo does' do
@@ -2608,7 +2607,7 @@ it 'checks what some does' do
   expect(some).to be
 end
 
-# Good
+# good
 let(:foo) { bar }
 let(:some) { other }
 
@@ -2643,20 +2642,20 @@ Checks unreferenced `let!` calls being used for test setup.
 
 [source,ruby]
 ----
-# Bad
+# bad
 let!(:my_widget) { create(:widget) }
 
 it 'counts widgets' do
   expect(Widget.count).to eq(1)
 end
 
-# Good
+# good
 it 'counts widgets' do
   create(:widget)
   expect(Widget.count).to eq(1)
 end
 
-# Good
+# good
 before { create(:widget) }
 
 it 'counts widgets' do
@@ -2689,7 +2688,7 @@ Check that chains of messages are not being stubbed.
 # bad
 allow(foo).to receive_message_chain(:bar, :baz).and_return(42)
 
-# better
+# good
 thing = Thing.new(baz: 42)
 allow(foo).to receive(:bar).and_return(thing)
 ----
@@ -3294,7 +3293,7 @@ context 'when using some feature' do
   end
 end
 
-# better
+# good
 context 'using some feature as an admin' do
   let(:some)    { :various }
   let(:feature) { :setup   }

--- a/lib/rubocop/cop/rspec/align_left_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_left_let_brace.rb
@@ -6,16 +6,15 @@ module RuboCop
       # Checks that left braces for adjacent single line lets are aligned.
       #
       # @example
+      #   # bad
+      #   let(:foobar) { blahblah }
+      #   let(:baz) { bar }
+      #   let(:a) { b }
       #
-      #     # bad
-      #     let(:foobar) { blahblah }
-      #     let(:baz) { bar }
-      #     let(:a) { b }
-      #
-      #     # good
-      #     let(:foobar) { blahblah }
-      #     let(:baz)    { bar }
-      #     let(:a)      { b }
+      #   # good
+      #   let(:foobar) { blahblah }
+      #   let(:baz)    { bar }
+      #   let(:a)      { b }
       #
       class AlignLeftLetBrace < Base
         extend AutoCorrector

--- a/lib/rubocop/cop/rspec/align_right_let_brace.rb
+++ b/lib/rubocop/cop/rspec/align_right_let_brace.rb
@@ -6,16 +6,15 @@ module RuboCop
       # Checks that right braces for adjacent single line lets are aligned.
       #
       # @example
+      #   # bad
+      #   let(:foobar) { blahblah }
+      #   let(:baz)    { bar }
+      #   let(:a)      { b }
       #
-      #     # bad
-      #     let(:foobar) { blahblah }
-      #     let(:baz)    { bar }
-      #     let(:a)      { b }
-      #
-      #     # good
-      #     let(:foobar) { blahblah }
-      #     let(:baz)    { bar      }
-      #     let(:a)      { b        }
+      #   # good
+      #   let(:foobar) { blahblah }
+      #   let(:baz)    { bar      }
+      #   let(:a)      { b        }
       #
       class AlignRightLetBrace < Base
         extend AutoCorrector

--- a/lib/rubocop/cop/rspec/any_instance.rb
+++ b/lib/rubocop/cop/rspec/any_instance.rb
@@ -22,6 +22,7 @@ module RuboCop
       #       allow(my_instance).to receive(:foo)
       #     end
       #   end
+      #
       class AnyInstance < Base
         MSG = 'Avoid stubbing using `%<method>s`.'
         RESTRICT_ON_SEND = %i[

--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -25,6 +25,7 @@ module RuboCop
       #     some_method
       #     test.run
       #   end
+      #
       class AroundBlock < Base
         MSG_NO_ARG     = 'Test object should be passed to around block.'
         MSG_UNUSED_ARG = 'You should call `%<arg>s.call` ' \

--- a/lib/rubocop/cop/rspec/be.rb
+++ b/lib/rubocop/cop/rspec/be.rb
@@ -10,7 +10,6 @@ module RuboCop
       # cases it's better to specify what exactly is the expected value.
       #
       # @example
-      #
       #   # bad
       #   expect(foo).to be
       #

--- a/lib/rubocop/cop/rspec/be_eq.rb
+++ b/lib/rubocop/cop/rspec/be_eq.rb
@@ -10,7 +10,6 @@ module RuboCop
       # the `be` matcher is preferable as it is a more strict test.
       #
       # @example
-      #
       #   # bad
       #   expect(foo).to eq(true)
       #   expect(foo).to eq(false)

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -11,7 +11,6 @@ module RuboCop
       # preferable as it is a more strict test.
       #
       # @example
-      #
       #   # bad
       #   expect(foo).to eql(1)
       #   expect(foo).to eql(1.0)

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -23,6 +23,7 @@ module RuboCop
       #     before(:each) { Widget.create }
       #     after(:each) { Widget.delete_all }
       #   end
+      #
       class BeforeAfterAll < Base
         MSG = 'Beware of using `%<hook>s` as it may cause state to leak ' \
               'between tests. If you are using `rspec-rails`, and ' \

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -40,6 +40,7 @@ module RuboCop
         #       # ...
         #     end
         #   end
+        #
         class FeatureMethods < Base
           extend AutoCorrector
           include InsideExampleGroup

--- a/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
@@ -16,7 +16,6 @@ module RuboCop
         # https://www.rubydoc.info/gems/capybara/Capybara%2FNode%2FFinders:all[the documentation].
         #
         # @example
-        #
         #   # bad
         #   expect(page).to have_selector('.foo', visible: false)
         #   expect(page).to have_css('.foo', visible: true)

--- a/lib/rubocop/cop/rspec/context_method.rb
+++ b/lib/rubocop/cop/rspec/context_method.rb
@@ -23,6 +23,7 @@ module RuboCop
       #   describe '.foo_bar' do
       #     # ...
       #   end
+      #
       class ContextMethod < Base
         extend AutoCorrector
 

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -14,7 +14,6 @@ module RuboCop
       # @see http://www.betterspecs.org/#contexts
       #
       # @example `Prefixes` configuration
-      #
       #   # .rubocop.yml
       #   # RSpec/ContextWording:
       #   #   Prefixes:
@@ -35,6 +34,7 @@ module RuboCop
       #   context 'when the display name is not present' do
       #     # ...
       #   end
+      #
       class ContextWording < Base
         MSG = 'Start context description with %<prefixes>s.'
 

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -10,7 +10,6 @@ module RuboCop
       # Ignores Rails and Aruba `type` metadata by default.
       #
       # @example `IgnoredMetadata` configuration
-      #
       #   # .rubocop.yml
       #   # RSpec/DescribeClass:
       #   #   IgnoredMetadata:
@@ -34,6 +33,7 @@ module RuboCop
       #
       #   describe "A feature example", type: :feature do
       #   end
+      #
       class DescribeClass < Base
         include TopLevelGroup
 

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -16,6 +16,7 @@ module RuboCop
       #
       #   describe MyClass, '.my_class_method' do
       #   end
+      #
       class DescribeMethod < Base
         include TopLevelGroup
 

--- a/lib/rubocop/cop/rspec/dialect.rb
+++ b/lib/rubocop/cop/rspec/dialect.rb
@@ -41,6 +41,7 @@ module RuboCop
       #   describe 'display name presence' do
       #     # ...
       #   end
+      #
       class Dialect < Base
         extend AutoCorrector
         include MethodPreference

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -6,7 +6,6 @@ module RuboCop
       # Checks if an example group does not include any tests.
       #
       # @example usage
-      #
       #   # bad
       #   describe Bacon do
       #     let(:bacon)      { Bacon.new(chunkiness) }
@@ -35,6 +34,7 @@ module RuboCop
       #   describe Bacon do
       #     pending 'will add tests later'
       #   end
+      #
       class EmptyExampleGroup < Base
         extend AutoCorrector
 

--- a/lib/rubocop/cop/rspec/empty_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_hook.rb
@@ -22,6 +22,7 @@ module RuboCop
       #     create_feed
       #   end
       #   after(:all) { cleanup_feed }
+      #
       class EmptyHook < Base
         extend AutoCorrector
         include RuboCop::Cop::RangeHelp

--- a/lib/rubocop/cop/rspec/empty_line_after_example.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example.rb
@@ -30,7 +30,6 @@ module RuboCop
       #   end
       #
       # @example with AllowConsecutiveOneLiners configuration
-      #
       #   # rubocop.yml
       #   # RSpec/EmptyLineAfterExample:
       #   #   AllowConsecutiveOneLiners: false

--- a/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_final_let.rb
@@ -16,6 +16,7 @@ module RuboCop
       #   let(:something) { other }
       #
       #   it { does_something }
+      #
       class EmptyLineAfterFinalLet < Base
         extend AutoCorrector
         include EmptyLineSeparation

--- a/lib/rubocop/cop/rspec/empty_line_after_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_hook.rb
@@ -49,6 +49,7 @@ module RuboCop
       #   after { do_something }
       #
       #   it { does_something }
+      #
       class EmptyLineAfterHook < Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/rspec/empty_line_after_subject.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_subject.rb
@@ -14,6 +14,7 @@ module RuboCop
       #   subject(:obj) { described_class }
       #
       #   let(:foo) { bar }
+      #
       class EmptyLineAfterSubject < Base
         extend AutoCorrector
         include EmptyLineSeparation

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -47,6 +47,7 @@ module RuboCop
       #       content.
       #     HEREDOC
       #   end                 # 5 points
+      #
       class ExampleLength < Base
         include CodeLength
 

--- a/lib/rubocop/cop/rspec/example_without_description.rb
+++ b/lib/rubocop/cop/rspec/example_without_description.rb
@@ -47,6 +47,7 @@ module RuboCop
       #     result = service.call
       #     expect(result).to be(true)
       #   end
+      #
       class ExampleWithoutDescription < Base
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -29,6 +29,7 @@ module RuboCop
       #   # good
       #   it 'does things' do
       #   end
+      #
       class ExampleWording < Base
         extend AutoCorrector
 

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -22,6 +22,7 @@ module RuboCop
       #   # good
       #   context 'when a condition is met' do
       #   end
+      #
       class ExcessiveDocstringSpacing < Base
         extend AutoCorrector
 

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -20,6 +20,7 @@ module RuboCop
       #   it do
       #     expect(something).to eq 'foo'
       #   end
+      #
       class ExpectInHook < Base
         MSG = 'Do not use `%<expect>s` in `%<hook>s` hook'
 

--- a/lib/rubocop/cop/rspec/expect_output.rb
+++ b/lib/rubocop/cop/rspec/expect_output.rb
@@ -14,6 +14,7 @@ module RuboCop
       #
       #   # good
       #   expect { my_app.print_report }.to output('Hello World').to_stdout
+      #
       class ExpectOutput < Base
         MSG = 'Use `expect { ... }.to output(...).to_%<name>s` ' \
               'instead of mutating $%<name>s.'

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -24,6 +24,7 @@ module RuboCop
         #
         #   # good
         #   count { 1 }
+        #
         class AttributeDefinedStatically < Base
           extend AutoCorrector
 

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -30,6 +30,7 @@ module RuboCop
         #
         #   # good
         #   3.times { create :user }
+        #
         class CreateList < Base
           extend AutoCorrector
           include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
@@ -19,6 +19,7 @@ module RuboCop
         #   # good
         #   factory :foo, class: 'Foo' do
         #   end
+        #
         class FactoryClassName < Base
           extend AutoCorrector
 

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -57,6 +57,7 @@ module RuboCop
       #   before(:example) do
       #     # ...
       #   end
+      #
       class HookArgument < Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -6,8 +6,7 @@ module RuboCop
       # Checks for before/around/after hooks that come after an example.
       #
       # @example
-      #   # Bad
-      #
+      #   # bad
       #   it 'checks what foo does' do
       #     expect(foo).to be
       #   end
@@ -15,7 +14,7 @@ module RuboCop
       #   before { prepare }
       #   after { clean_up }
       #
-      #   # Good
+      #   # good
       #   before { prepare }
       #   after { clean_up }
       #

--- a/lib/rubocop/cop/rspec/identical_equality_assertion.rb
+++ b/lib/rubocop/cop/rspec/identical_equality_assertion.rb
@@ -6,7 +6,6 @@ module RuboCop
       # Checks for equality assertions with identical expressions on both sides.
       #
       # @example
-      #
       #   # bad
       #   expect(foo.bar).to eq(foo.bar)
       #   expect(foo.bar).to eql(foo.bar)

--- a/lib/rubocop/cop/rspec/implicit_block_expectation.rb
+++ b/lib/rubocop/cop/rspec/implicit_block_expectation.rb
@@ -16,6 +16,7 @@ module RuboCop
       #   it 'changes something to a new value' do
       #     expect { do_something }.to change(something).to(new_value)
       #   end
+      #
       class ImplicitBlockExpectation < Base
         MSG = 'Avoid implicit block expectations.'
         RESTRICT_ON_SEND = %i[is_expected should should_not].freeze

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -9,7 +9,6 @@ module RuboCop
       # and supports the `--auto-gen-config` flag.
       #
       # @example `EnforcedStyle: is_expected` (default)
-      #
       #   # bad
       #   it { should be_truthy }
       #
@@ -17,7 +16,6 @@ module RuboCop
       #   it { is_expected.to be_truthy }
       #
       # @example `EnforcedStyle: should`
-      #
       #   # bad
       #   it { is_expected.to be_truthy }
       #

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -24,7 +24,6 @@ module RuboCop
       #   end
       #
       # @example with AssignmentOnly configuration
-      #
       #   # rubocop.yml
       #   # RSpec/InstanceVariable:
       #   #   AssignmentOnly: false

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -18,6 +18,7 @@ module RuboCop
       #
       #   # good
       #   it_should_behave_like 'a foo'
+      #
       class ItBehavesLike < Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -15,6 +15,7 @@ module RuboCop
       #   it 'validates users' do
       #     expect([user1, user2, user3]).to all(be_valid)
       #   end
+      #
       class IteratedExpectation < Base
         MSG = 'Prefer using the `all` matcher instead ' \
               'of iterating over an array.'

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -7,29 +7,29 @@ module RuboCop
       #
       # @example
       #   # bad
-      #     let(:params) { blah }
-      #     subject { described_class.new(params) }
+      #   let(:params) { blah }
+      #   subject { described_class.new(params) }
       #
-      #     before { do_something }
-      #     subject { described_class.new(params) }
+      #   before { do_something }
+      #   subject { described_class.new(params) }
       #
-      #     it { expect_something }
-      #     subject { described_class.new(params) }
-      #     it { expect_something_else }
+      #   it { expect_something }
+      #   subject { described_class.new(params) }
+      #   it { expect_something_else }
       #
-      #
-      #   # good
-      #     subject { described_class.new(params) }
-      #     let(:params) { blah }
       #
       #   # good
-      #     subject { described_class.new(params) }
-      #     before { do_something }
+      #   subject { described_class.new(params) }
+      #   let(:params) { blah }
       #
       #   # good
-      #     subject { described_class.new(params) }
-      #     it { expect_something }
-      #     it { expect_something_else }
+      #   subject { described_class.new(params) }
+      #   before { do_something }
+      #
+      #   # good
+      #   subject { described_class.new(params) }
+      #   it { expect_something }
+      #   it { expect_something_else }
       #
       class LeadingSubject < Base
         extend AutoCorrector

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -6,7 +6,7 @@ module RuboCop
       # Checks for `let` definitions that come after an example.
       #
       # @example
-      #   # Bad
+      #   # bad
       #   let(:foo) { bar }
       #
       #   it 'checks what foo does' do
@@ -19,7 +19,7 @@ module RuboCop
       #     expect(some).to be
       #   end
       #
-      #   # Good
+      #   # good
       #   let(:foo) { bar }
       #   let(:some) { other }
       #

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -6,20 +6,20 @@ module RuboCop
       # Checks unreferenced `let!` calls being used for test setup.
       #
       # @example
-      #   # Bad
+      #   # bad
       #   let!(:my_widget) { create(:widget) }
       #
       #   it 'counts widgets' do
       #     expect(Widget.count).to eq(1)
       #   end
       #
-      #   # Good
+      #   # good
       #   it 'counts widgets' do
       #     create(:widget)
       #     expect(Widget.count).to eq(1)
       #   end
       #
-      #   # Good
+      #   # good
       #   before { create(:widget) }
       #
       #   it 'counts widgets' do

--- a/lib/rubocop/cop/rspec/message_chain.rb
+++ b/lib/rubocop/cop/rspec/message_chain.rb
@@ -9,7 +9,7 @@ module RuboCop
       #   # bad
       #   allow(foo).to receive_message_chain(:bar, :baz).and_return(42)
       #
-      #   # better
+      #   # good
       #   thing = Thing.new(baz: 42)
       #   allow(foo).to receive(:bar).and_return(thing)
       #

--- a/lib/rubocop/cop/rspec/missing_example_group_argument.rb
+++ b/lib/rubocop/cop/rspec/missing_example_group_argument.rb
@@ -19,6 +19,7 @@ module RuboCop
       #
       #   describe "A feature example" do
       #   end
+      #
       class MissingExampleGroupArgument < Base
         MSG = 'The first argument to `%<method>s` should not be empty.'
 

--- a/lib/rubocop/cop/rspec/mixin/css_selector.rb
+++ b/lib/rubocop/cop/rspec/mixin/css_selector.rb
@@ -64,7 +64,7 @@ module RuboCop
           selector.match?(/[ >,+]/)
         end
 
-        # @param selector [String]
+        # @param value [String]
         # @return [Boolean, String]
         # @example
         #   normalize_value('true') # => true

--- a/lib/rubocop/cop/rspec/multiple_describes.rb
+++ b/lib/rubocop/cop/rspec/multiple_describes.rb
@@ -22,6 +22,7 @@ module RuboCop
       #     describe '.do_something_else' do
       #     end
       #   end
+      #
       class MultipleDescribes < Base
         include TopLevelGroup
 

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -11,7 +11,6 @@ module RuboCop
       # and works with `--auto-gen-config`.
       #
       # @example
-      #
       #   # bad
       #   describe UserCreator do
       #     it 'builds a user' do
@@ -32,7 +31,6 @@ module RuboCop
       #   end
       #
       # @example `aggregate_failures: true` (default)
-      #
       #  # good - the cop ignores when RSpec aggregates failures
       #   describe UserCreator do
       #     it 'builds a user', :aggregate_failures do
@@ -42,7 +40,6 @@ module RuboCop
       #   end
       #
       # @example `aggregate_failures: false`
-      #
       #  # Detected as an offense
       #   describe UserCreator do
       #     it 'builds a user', aggregate_failures: false do
@@ -52,7 +49,6 @@ module RuboCop
       #   end
       #
       # @example configuration
-      #
       #   # .rubocop.yml
       #   # RSpec/MultipleExpectations:
       #   #   Max: 2

--- a/lib/rubocop/cop/rspec/multiple_memoized_helpers.rb
+++ b/lib/rubocop/cop/rspec/multiple_memoized_helpers.rb
@@ -56,7 +56,6 @@ module RuboCop
       #   end
       #
       # @example when disabling AllowSubject configuration
-      #
       #   # rubocop.yml
       #   # RSpec/MultipleMemoizedHelpers:
       #   #   AllowSubject: false
@@ -72,7 +71,6 @@ module RuboCop
       #   end
       #
       # @example with Max configuration
-      #
       #   # rubocop.yml
       #   # RSpec/MultipleMemoizedHelpers:
       #   #   Max: 1

--- a/lib/rubocop/cop/rspec/multiple_subjects.rb
+++ b/lib/rubocop/cop/rspec/multiple_subjects.rb
@@ -6,7 +6,6 @@ module RuboCop
       # Checks if an example group defines `subject` multiple times.
       #
       # @example
-      #
       #   # bad
       #   describe Foo do
       #     subject(:user) { User.new }

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -41,6 +41,7 @@ module RuboCop
       #
       #     it { is_expected.to be_valid }
       #   end
+      #
       class NamedSubject < Base
         MSG = 'Name your test subject if you need to reference it explicitly.'
 

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -36,7 +36,7 @@ module RuboCop
       #     end
       #   end
       #
-      #   # better
+      #   # good
       #   context 'using some feature as an admin' do
       #     let(:some)    { :various }
       #     let(:feature) { :setup   }

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -18,7 +18,6 @@ module RuboCop
       #         - custom_expect
       #
       # @example
-      #
       #   # bad
       #   it do
       #     a?
@@ -28,6 +27,7 @@ module RuboCop
       #   it do
       #     expect(a?).to be(true)
       #   end
+      #
       class NoExpectationExample < Base
         MSG = 'No expectation found in this example.'
 

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -6,7 +6,6 @@ module RuboCop
       # Checks for consistent method usage for negating expectations.
       #
       # @example `EnforcedStyle: not_to` (default)
-      #
       #   # bad
       #   it '...' do
       #     expect(false).to_not be_true
@@ -18,7 +17,6 @@ module RuboCop
       #   end
       #
       # @example `EnforcedStyle: to_not`
-      #
       #   # bad
       #   it '...' do
       #     expect(false).not_to be_true
@@ -28,6 +26,7 @@ module RuboCop
       #   it '...' do
       #     expect(false).to_not be_true
       #   end
+      #
       class NotToNot < Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -21,6 +21,7 @@ module RuboCop
       #   let(:foo) { bar }
       #   let(:baz) { baz }
       #   let!(:other) { other }
+      #
       class OverwritingSetup < Base
         MSG = '`%<name>s` is already defined.'
 

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -31,6 +31,7 @@ module RuboCop
       #   # good
       #   describe MyClass do
       #   end
+      #
       class Pending < Base
         MSG = 'Pending spec found.'
 

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -276,6 +276,7 @@ module RuboCop
       #
       #   # good - the above code is rewritten to it by this cop
       #   expect(foo.something?).to be_truthy
+      #
       class PredicateMatcher < Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/rspec/rails/avoid_setup_hook.rb
+++ b/lib/rubocop/cop/rspec/rails/avoid_setup_hook.rb
@@ -7,7 +7,6 @@ module RuboCop
         # Checks that tests use RSpec `before` hook over Rails `setup` method.
         #
         # @example
-        #
         #   # bad
         #   setup do
         #     allow(foo).to receive(:bar)

--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -6,22 +6,21 @@ module RuboCop
       # Check for `once` and `twice` receive counts matchers usage.
       #
       # @example
+      #   # bad
+      #   expect(foo).to receive(:bar).exactly(1).times
+      #   expect(foo).to receive(:bar).exactly(2).times
+      #   expect(foo).to receive(:bar).at_least(1).times
+      #   expect(foo).to receive(:bar).at_least(2).times
+      #   expect(foo).to receive(:bar).at_most(1).times
+      #   expect(foo).to receive(:bar).at_most(2).times
       #
-      #     # bad
-      #     expect(foo).to receive(:bar).exactly(1).times
-      #     expect(foo).to receive(:bar).exactly(2).times
-      #     expect(foo).to receive(:bar).at_least(1).times
-      #     expect(foo).to receive(:bar).at_least(2).times
-      #     expect(foo).to receive(:bar).at_most(1).times
-      #     expect(foo).to receive(:bar).at_most(2).times
-      #
-      #     # good
-      #     expect(foo).to receive(:bar).once
-      #     expect(foo).to receive(:bar).twice
-      #     expect(foo).to receive(:bar).at_least(:once)
-      #     expect(foo).to receive(:bar).at_least(:twice)
-      #     expect(foo).to receive(:bar).at_most(:once)
-      #     expect(foo).to receive(:bar).at_most(:twice).times
+      #   # good
+      #   expect(foo).to receive(:bar).once
+      #   expect(foo).to receive(:bar).twice
+      #   expect(foo).to receive(:bar).at_least(:once)
+      #   expect(foo).to receive(:bar).at_least(:twice)
+      #   expect(foo).to receive(:bar).at_most(:once)
+      #   expect(foo).to receive(:bar).at_most(:twice).times
       #
       class ReceiveCounts < Base
         extend AutoCorrector

--- a/lib/rubocop/cop/rspec/receive_never.rb
+++ b/lib/rubocop/cop/rspec/receive_never.rb
@@ -6,12 +6,11 @@ module RuboCop
       # Prefer `not_to receive(...)` over `receive(...).never`.
       #
       # @example
+      #   # bad
+      #   expect(foo).to receive(:bar).never
       #
-      #     # bad
-      #     expect(foo).to receive(:bar).never
-      #
-      #     # good
-      #     expect(foo).not_to receive(:bar)
+      #   # good
+      #   expect(foo).not_to receive(:bar)
       #
       class ReceiveNever < Base
         extend AutoCorrector

--- a/lib/rubocop/cop/rspec/repeated_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_description.rb
@@ -6,39 +6,38 @@ module RuboCop
       # Check for repeated description strings in example groups.
       #
       # @example
-      #
-      #     # bad
-      #     RSpec.describe User do
-      #       it 'is valid' do
-      #         # ...
-      #       end
-      #
-      #       it 'is valid' do
-      #         # ...
-      #       end
+      #   # bad
+      #   RSpec.describe User do
+      #     it 'is valid' do
+      #       # ...
       #     end
       #
-      #     # good
-      #     RSpec.describe User do
-      #       it 'is valid when first and last name are present' do
-      #         # ...
-      #       end
+      #     it 'is valid' do
+      #       # ...
+      #     end
+      #   end
       #
-      #       it 'is valid when last name only is present' do
-      #         # ...
-      #       end
+      #   # good
+      #   RSpec.describe User do
+      #     it 'is valid when first and last name are present' do
+      #       # ...
       #     end
       #
-      #     # good
-      #     RSpec.describe User do
-      #       it 'is valid' do
-      #         # ...
-      #       end
-      #
-      #       it 'is valid', :flag do
-      #         # ...
-      #       end
+      #     it 'is valid when last name only is present' do
+      #       # ...
       #     end
+      #   end
+      #
+      #   # good
+      #   RSpec.describe User do
+      #     it 'is valid' do
+      #       # ...
+      #     end
+      #
+      #     it 'is valid', :flag do
+      #       # ...
+      #     end
+      #   end
       #
       class RepeatedDescription < Base
         MSG = "Don't repeat descriptions within an example group."

--- a/lib/rubocop/cop/rspec/repeated_example_group_body.rb
+++ b/lib/rubocop/cop/rspec/repeated_example_group_body.rb
@@ -6,42 +6,41 @@ module RuboCop
       # Check for repeated describe and context block body.
       #
       # @example
+      #   # bad
+      #   describe 'cool feature x' do
+      #     it { cool_predicate }
+      #   end
       #
-      #    # bad
-      #    describe 'cool feature x' do
-      #      it { cool_predicate }
-      #    end
+      #   describe 'cool feature y' do
+      #     it { cool_predicate }
+      #   end
       #
-      #    describe 'cool feature y' do
-      #      it { cool_predicate }
-      #    end
+      #   # good
+      #   describe 'cool feature' do
+      #     it { cool_predicate }
+      #   end
       #
-      #    # good
-      #    describe 'cool feature' do
-      #      it { cool_predicate }
-      #    end
+      #   describe 'another cool feature' do
+      #     it { another_predicate }
+      #   end
       #
-      #    describe 'another cool feature' do
-      #      it { another_predicate }
-      #    end
+      #   # good
+      #   context 'when case x', :tag do
+      #     it { cool_predicate }
+      #   end
       #
-      #    # good
-      #    context 'when case x', :tag do
-      #      it { cool_predicate }
-      #    end
+      #   context 'when case y' do
+      #     it { cool_predicate }
+      #   end
       #
-      #    context 'when case y' do
-      #      it { cool_predicate }
-      #    end
+      #   # good
+      #   context Array do
+      #     it { is_expected.to respond_to :each }
+      #   end
       #
-      #    # good
-      #    context Array do
-      #      it { is_expected.to respond_to :each }
-      #    end
-      #
-      #    context Hash do
-      #      it { is_expected.to respond_to :each }
-      #    end
+      #   context Hash do
+      #     it { is_expected.to respond_to :each }
+      #   end
       #
       class RepeatedExampleGroupBody < Base
         MSG = 'Repeated %<group>s block body on line(s) %<loc>s'

--- a/lib/rubocop/cop/rspec/repeated_example_group_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_example_group_description.rb
@@ -6,42 +6,41 @@ module RuboCop
       # Check for repeated example group descriptions.
       #
       # @example
+      #   # bad
+      #   describe 'cool feature' do
+      #     # example group
+      #   end
       #
-      #    # bad
-      #    describe 'cool feature' do
-      #      # example group
-      #    end
+      #   describe 'cool feature' do
+      #     # example group
+      #   end
       #
-      #    describe 'cool feature' do
-      #      # example group
-      #    end
+      #   # bad
+      #   context 'when case x' do
+      #     # example group
+      #   end
       #
-      #    # bad
-      #    context 'when case x' do
-      #      # example group
-      #    end
+      #   describe 'when case x' do
+      #     # example group
+      #   end
       #
-      #    describe 'when case x' do
-      #      # example group
-      #    end
+      #   # good
+      #   describe 'cool feature' do
+      #     # example group
+      #   end
       #
-      #    # good
-      #    describe 'cool feature' do
-      #      # example group
-      #    end
+      #   describe 'another cool feature' do
+      #     # example group
+      #   end
       #
-      #    describe 'another cool feature' do
-      #      # example group
-      #    end
+      #   # good
+      #   context 'when case x' do
+      #     # example group
+      #   end
       #
-      #    # good
-      #    context 'when case x' do
-      #      # example group
-      #    end
-      #
-      #    context 'when another case' do
-      #      # example group
-      #    end
+      #   context 'when another case' do
+      #     # example group
+      #   end
       #
       class RepeatedExampleGroupDescription < Base
         MSG = 'Repeated %<group>s block description on line(s) %<loc>s'

--- a/lib/rubocop/cop/rspec/repeated_include_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_include_example.rb
@@ -6,45 +6,44 @@ module RuboCop
       # Check for repeated include of shared examples.
       #
       # @example
+      #   # bad
+      #   describe 'foo' do
+      #     include_examples 'cool stuff'
+      #     include_examples 'cool stuff'
+      #   end
       #
-      #    # bad
-      #    describe 'foo' do
-      #      include_examples 'cool stuff'
-      #      include_examples 'cool stuff'
-      #    end
+      #   # bad
+      #   describe 'foo' do
+      #     it_behaves_like 'a cool', 'thing'
+      #     it_behaves_like 'a cool', 'thing'
+      #   end
       #
-      #    # bad
-      #    describe 'foo' do
-      #      it_behaves_like 'a cool', 'thing'
-      #      it_behaves_like 'a cool', 'thing'
-      #    end
+      #   # bad
+      #   context 'foo' do
+      #     it_should_behave_like 'a duck'
+      #     it_should_behave_like 'a duck'
+      #   end
       #
-      #    # bad
-      #    context 'foo' do
-      #      it_should_behave_like 'a duck'
-      #      it_should_behave_like 'a duck'
-      #    end
+      #   # good
+      #   describe 'foo' do
+      #     include_examples 'cool stuff'
+      #   end
       #
-      #    # good
-      #    describe 'foo' do
-      #      include_examples 'cool stuff'
-      #    end
+      #   describe 'bar' do
+      #     include_examples 'cool stuff'
+      #   end
       #
-      #    describe 'bar' do
-      #      include_examples 'cool stuff'
-      #    end
+      #   # good
+      #   describe 'foo' do
+      #     it_behaves_like 'a cool', 'thing'
+      #     it_behaves_like 'a cool', 'person'
+      #   end
       #
-      #    # good
-      #    describe 'foo' do
-      #      it_behaves_like 'a cool', 'thing'
-      #      it_behaves_like 'a cool', 'person'
-      #    end
-      #
-      #    # good
-      #    context 'foo' do
-      #      it_should_behave_like 'a duck'
-      #      it_should_behave_like 'a goose'
-      #    end
+      #   # good
+      #   context 'foo' do
+      #     it_should_behave_like 'a duck'
+      #     it_should_behave_like 'a goose'
+      #   end
       #
       class RepeatedIncludeExample < Base
         MSG = 'Repeated include of shared_examples %<name>s ' \

--- a/lib/rubocop/cop/rspec/stubbed_mock.rb
+++ b/lib/rubocop/cop/rspec/stubbed_mock.rb
@@ -6,7 +6,6 @@ module RuboCop
       # Checks that message expectations do not have a configured response.
       #
       # @example
-      #
       #   # bad
       #   expect(foo).to receive(:bar).with(42).and_return("hello world")
       #

--- a/lib/rubocop/cop/rspec/subject_declaration.rb
+++ b/lib/rubocop/cop/rspec/subject_declaration.rb
@@ -6,7 +6,6 @@ module RuboCop
       # Ensure that subject is defined using subject helper.
       #
       # @example
-      #
       #   # bad
       #   let(:subject) { foo }
       #   let!(:subject) { foo }

--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -10,26 +10,26 @@ module RuboCop
       # to `raise_error`
       #
       # @example
+      #   # bad
+      #   expect {
+      #     raise StandardError.new('error')
+      #   }.to raise_error
       #
-      #     # bad
-      #     expect {
-      #       raise StandardError.new('error')
-      #     }.to raise_error
+      #   # good
+      #   expect {
+      #     raise StandardError.new('error')
+      #   }.to raise_error(StandardError)
       #
-      #     # good
-      #     expect {
-      #       raise StandardError.new('error')
-      #     }.to raise_error(StandardError)
+      #   expect {
+      #     raise StandardError.new('error')
+      #   }.to raise_error('error')
       #
-      #     expect {
-      #       raise StandardError.new('error')
-      #     }.to raise_error('error')
+      #   expect {
+      #     raise StandardError.new('error')
+      #   }.to raise_error(/err/)
       #
-      #     expect {
-      #       raise StandardError.new('error')
-      #     }.to raise_error(/err/)
+      #   expect { do_something }.not_to raise_error
       #
-      #     expect { do_something }.not_to raise_error
       class UnspecifiedException < Base
         MSG = 'Specify the exception being captured'
         RESTRICT_ON_SEND = %i[to].freeze

--- a/lib/rubocop/cop/rspec/variable_definition.rb
+++ b/lib/rubocop/cop/rspec/variable_definition.rb
@@ -22,6 +22,7 @@ module RuboCop
       #   # good
       #   subject('user') { create_user }
       #   let('user_name') { 'Adam' }
+      #
       class VariableDefinition < Base
         extend AutoCorrector
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/rspec/variable_name.rb
+++ b/lib/rubocop/cop/rspec/variable_name.rb
@@ -27,7 +27,6 @@ module RuboCop
       #   let(:userName2) { 'Adam' }
       #
       # @example IgnoredPatterns configuration
-      #
       #   # rubocop.yml
       #   # RSpec/VariableName:
       #   #   EnforcedStyle: snake_case

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -22,6 +22,7 @@ module RuboCop
       #   let(:foo) do
       #     instance_double("ClassName", method_name: 'returned value')
       #   end
+      #
       class VerifiedDoubles < Base
         MSG = 'Prefer using verifying doubles over normal doubles.'
         RESTRICT_ON_SEND = %i[double spy].freeze

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -11,6 +11,7 @@ module RuboCop
       #
       #   # good
       #   expect(something).to be(1)
+      #
       class VoidExpect < Base
         MSG = 'Do not use `expect()` without `.to` or `.not_to`. ' \
               'Chain the methods or remove it.'

--- a/lib/rubocop/cop/rspec/yield.rb
+++ b/lib/rubocop/cop/rspec/yield.rb
@@ -11,6 +11,7 @@ module RuboCop
       #
       #   # good
       #   expect(foo).to receive(:bar).and_yield(1)
+      #
       class Yield < Base
         extend AutoCorrector
         include RangeHelp


### PR DESCRIPTION
The following unification/fixes were implemented.
- Line break after `@example`
- Good/Bad -> good/bad
- better -> good
- Add empty comment line at the end of header comment
- Fixed indentation errors
- Fixed function header errors

The indentation will also be modified on the document as follows.

### before
<img src="https://user-images.githubusercontent.com/13041216/186650712-9e249c2b-9a63-4a9c-b185-9222a94f0f7f.png" width="500px">

### after
<img src="https://user-images.githubusercontent.com/13041216/186650753-d63c1764-f5cd-447b-8541-01a8fde39d81.png" width="500px">

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [x] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
