### PR TITLE
Fix incorrect documentation URLs when using `rubocop --show-docs-url`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add `NegatedMatcher` configuration option to `RSpec/ChangeByZero`. ([@ydah][])
 * Add new `RSpec/Capybara/SpecificFinders` cop. ([@ydah][])
 * Add support for numblocks to `RSpec/AroundBlock`, `RSpec/EmptyLineAfterHook`, `RSpec/ExpectInHook`, `RSpec/HookArgument`, `RSpec/HooksBeforeExamples`, `RSpec/IteratedExpectation`, and `RSpec/NoExpectationExample`. ([@ydah][])
+* Fix incorrect documentation URLs when using `rubocop --show-docs-url`. ([@r7kamura][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -2,6 +2,7 @@
 RSpec:
   Enabled: true
   StyleGuideBaseURL: https://rspec.rubystyle.guide
+  DocumentationBaseURL: https://docs.rubocop.org/rubocop-rspec
   Include: &1
     - "**/*_spec.rb"
     - "**/spec/**/*"


### PR DESCRIPTION
Added `DocumentationBaseURL` for `rubocop --show-docs-url [COP1,COP2,...]` command to work correctly for rubocop-rspec cops.

### Before

```console
$ bundle exec rubocop --show-docs-url RSpec/Be
https://docs.rubocop.org/rubocop/cops_rspec.html#rspecbe
```

### After

```console
$ bundle exec rubocop --show-docs-url RSpec/Be
https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecbe
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
