### PR TITLE
Add spelling checks to the workflow in GitHub Actions

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,1 @@
+xdescribe

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,14 @@
+name: CodeSpell
+on:
+  - pull_request
+jobs:
+  codespell:
+    name: CodeSpell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: CodeSpell
+        uses: codespell-project/actions-codespell@master
+        with:
+          check_filenames: true
+          ignore_words_file: .codespellignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -616,7 +616,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 * Split `UnitSpecNaming` cop into `RSpecDescribeClass`, `RSpecDescribeMethod` and `RSpecFileName` and enabled them all by default. ([@geniou][])
 * Add `RSpecExampleWording` cop to prevent to use of should at the beginning of the spec description. ([@geniou][])
 * Fix `RSpecFileName` cop for non-class specs. ([@geniou][])
-* Adapt `RSpecFileName` cop to commen naming convention and skip spec with multiple top level describes. ([@geniou][])
+* Adapt `RSpecFileName` cop to common naming convention and skip spec with multiple top level describes. ([@geniou][])
 * Add `RSpecMultipleDescribes` cop to check for multiple top level describes. ([@geniou][])
 * Add `RSpecDescribedClass` to promote the use of `described_class`. ([@geniou][])
 * Add `RSpecInstanceVariable` cop to check for the usage of instance variables. ([@geniou][])

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -123,7 +123,7 @@ module RuboCop
         #     describe { it { i_run_as_well } }
         #
         #   @example source that does not match
-        #     before { it { whatever here wont run anyway } }
+        #     before { it { whatever here won't run anyway } }
         #
         #   @param node [RuboCop::AST::Node]
         #   @return [Array<RuboCop::AST::Node>] matching nodes

--- a/lib/rubocop/rspec/wording.rb
+++ b/lib/rubocop/rspec/wording.rb
@@ -31,8 +31,8 @@ module RuboCop
       attr_reader :text, :ignores, :replacements
 
       def replace_prefix(pattern, replacement)
-        text.sub(pattern) do |shouldnt|
-          uppercase?(shouldnt) ? replacement.upcase : replacement
+        text.sub(pattern) do |matched|
+          uppercase?(matched) ? replacement.upcase : replacement
         end
       end
 


### PR DESCRIPTION
We would like to leave it to codespell to verify the spelling of our code.

I propose to use codespell-project/actions-codespell, now v1.0.
- https://github.com/codespell-project/actions-codespell

The following misspellings will result in failure:

![failure](https://user-images.githubusercontent.com/13041216/186999192-c93216a5-7e74-4d47-ba1b-46fef88a2562.png)

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Updated documentation.
* [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
