### PR TITLE
Add `require_implicit` style to `RSpec/ImplicitSubject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Add `require_implicit` style to `RSpec/ImplicitSubject`. ([@r7kamura][])
+
 ## 2.13.2 (2022-09-23)
 
 * Fix an error for `RSpec/Capybara/SpecificFinders` with no parentheses. ([@ydah][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -492,8 +492,9 @@ RSpec/ImplicitSubject:
     - single_line_only
     - single_statement_only
     - disallow
+    - require_implicit
   VersionAdded: '1.29'
-  VersionChanged: '1.30'
+  VersionChanged: '2.13'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitSubject
 
 RSpec/InstanceSpy:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2232,7 +2232,7 @@ it { should be_truthy }
 | Yes
 | Yes
 | 1.29
-| 1.30
+| 2.13
 |===
 
 Checks for usage of implicit subject (`is_expected` / `should`).
@@ -2288,6 +2288,30 @@ it { is_expected.to be_truthy }
 it { expect(subject).to be_truthy }
 ----
 
+==== `EnforcedStyle: require_implicit`
+
+[source,ruby]
+----
+# bad
+it { expect(subject).to be_truthy }
+
+# good
+it { is_expected.to be_truthy }
+
+# bad
+it do
+  expect(subject).to be_truthy
+end
+
+# good
+it do
+  is_expected.to be_truthy
+end
+
+# good
+it { expect(named_subject).to be_truthy }
+----
+
 === Configurable attributes
 
 |===
@@ -2295,7 +2319,7 @@ it { expect(subject).to be_truthy }
 
 | EnforcedStyle
 | `single_line_only`
-| `single_line_only`, `single_statement_only`, `disallow`
+| `single_line_only`, `single_statement_only`, `disallow`, `require_implicit`
 |===
 
 === References

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -183,4 +183,72 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
       RUBY
     end
   end
+
+  context 'with EnforcedStyle `require_implicit`' do
+    let(:enforced_style) { 'require_implicit' }
+
+    context 'with `is_expected`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY)
+          it { is_expected.to be_good }
+        RUBY
+      end
+    end
+
+    context 'with `expect { subject }`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY)
+          it { expect { subject }.to change(goodness, :count) }
+        RUBY
+      end
+    end
+
+    context 'with `its`' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY)
+          its(:quality) { is_expected.to be(:high) }
+        RUBY
+      end
+    end
+
+    context 'with named subject' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY)
+          subject(:instance) { described_class.new }
+
+          it { expect(instance).to be_good }
+        RUBY
+      end
+    end
+
+    context 'with `expect(subject)` in one-line' do
+      it 'registers and autocorrects an offense' do
+        expect_offense(<<-RUBY)
+          it { expect(subject).to be_good }
+               ^^^^^^^^^^^^^^^ Don't use explicit subject.
+        RUBY
+
+        expect_correction(<<-RUBY)
+          it { is_expected.to be_good }
+        RUBY
+      end
+    end
+
+    context 'with `expect(subject)` in multi-lines' do
+      it 'registers and autocorrects an offense' do
+        expect_offense(<<-RUBY)
+          it do
+            expect(subject).to be_good
+            ^^^^^^^^^^^^^^^ Don't use explicit subject.
+          end
+        RUBY
+
+        expect_correction(<<-RUBY)
+          it do
+            is_expected.to be_good
+          end
+        RUBY
+      end
+    end
+  end
 end


### PR DESCRIPTION
Although the explicit style is recommended by default, some users may prefer the implicit style. For such users, it would be better if there is an option to make the style consistent with the explicit style, rather than asking them to disable this cop.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
