### PR TITLE
Support `Array.new(n)` on `RSpec/FactoryBot/CreateList` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Add `RSpec/ClassCheck` cop. ([@r7kamura][])
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher` when pseudo-classes. ([@ydah][])
 * Fix a false negative for `RSpec/SubjectStub` when the subject is declared with the `subject!` method and called by name. ([@eikes][])
+* Support `Array.new(n)` on `RSpec/FactoryBot/CreateList` cop. ([@r7kamura][])
 
 ## 2.12.1 (2022-07-03)
 

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -165,6 +165,30 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList do
         end
       RUBY
     end
+
+    it 'flags usage of Array.new(n) with no arguments' do
+      expect_offense(<<~RUBY)
+        Array.new(3) { create(:user) }
+        ^^^^^^^^^^^^ Prefer create_list.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        create_list(:user, 3)
+      RUBY
+    end
+
+    it 'flags usage of Array.new(n) with block argument' do
+      expect_offense(<<~RUBY)
+        Array.new(3) do
+        ^^^^^^^^^^^^ Prefer create_list.
+          create(:user) { |user| create(:account, user: user) }
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        create_list(:user, 3) { |user| create(:account, user: user) }
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is :n_times' do


### PR DESCRIPTION
rubocop-performance's `Performance/TimesMap` cop autocorrects `n.times` into `Array.new(n)`, so it would be nice if this cop supports autocorrection from `Array.new(n) { create(:a) }` to `create_list(:a, n)`.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
