### PR TITLE
Catches SubjectStub violations: subject!(:foo) with expect(foo).to receive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add `AllowedPatterns` configuration option to `RSpec/ContextWording`. ([@ydah][])
 * Add `RSpec/ClassCheck` cop. ([@r7kamura][])
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher` when pseudo-classes. ([@ydah][])
+* Fix a false negative for `RSpec/SubjectStub` when the subject is declared with the `subject!` method and called by name. ([@eikes][])
 
 ## 2.12.1 (2022-07-03)
 
@@ -656,6 +657,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@dswij]: https://github.com/dswij
 [@dvandersluis]: https://github.com/dvandersluis
 [@edgibbs]: https://github.com/edgibbs
+[@eikes]: https://github.com/eikes
 [@eitoball]: https://github.com/eitoball
 [@elebow]: https://github.com/elebow
 [@EliseFitz15]: https://github.com/EliseFitz15

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -72,7 +72,7 @@ module RuboCop
         def_node_matcher :subject?, <<-PATTERN
           (block
             (send nil?
-              {:subject (sym $_) | $:subject}
+              { #Subjects.all (sym $_) | $#Subjects.all }
             ) args ...)
         PATTERN
 

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -74,6 +74,45 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
     RUBY
   end
 
+  it 'flags when a forced subject! is mocked and called as subject' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject!(:foo) { described_class.new }
+
+        it 'uses bang subject!' do
+          expect(subject).to receive(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags when a forced subject! is mocked and called by name' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject!(:foo) { described_class.new }
+
+        it 'uses bang subject! by name' do
+          expect(foo).to receive(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags when an unnamed forced subject! is mocked' do
+    expect_offense(<<-RUBY)
+      describe Foo do
+        subject! { described_class.new }
+
+        it 'uses bang subject!' do
+          expect(subject).to receive(:bar)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
+
   it 'flags an expectation made on an unnamed subject' do
     expect_offense(<<-RUBY)
       describe Foo do


### PR DESCRIPTION
The following code should be caught:

```ruby
      describe Foo do
        subject!(:foo) { described_class.new }

        it 'uses bang subject! by name' do
          expect(foo).to receive(:bar)
        end
      end
```
