### PR TITLE
Add support for subject! method to `RSpec/SubjectDeclaration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Update `config/default.yml` removing deprecated option to make the config correctable by users. ([@ignaciovillaverde])
 - Do not attempt to auto-correct example groups with `include_examples` in `RSpec/LetBeforeExamples`. ([@pirj])
 - Add new `RSpec/SortMetadata` cop. ([@leoarnold])
+* Add `require_implicit` style to `RSpec/ImplicitSubject`. ([@r7kamura][])
+* Fix a false positive for `RSpec/Capybara/SpecificMatcher` when `have_css("a")` without attribute. ([@ydah][])
+* Add support for subject! method to `RSpec/SubjectDeclaration`. ([@ydah][])
 
 ## 2.13.2 (2022-09-23)
 

--- a/lib/rubocop/cop/rspec/subject_declaration.rb
+++ b/lib/rubocop/cop/rspec/subject_declaration.rb
@@ -25,7 +25,7 @@ module RuboCop
 
         # @!method offensive_subject_declaration?(node)
         def_node_matcher :offensive_subject_declaration?, <<~PATTERN
-          (send nil? ${#Subjects.all #Helpers.all} {(sym :subject) (str "subject")} ...)
+          (send nil? ${#Subjects.all #Helpers.all} {(sym #Subjects.all) (str #Subjects.all)} ...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rspec/subject_declaration_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_declaration_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectDeclaration do
 
   include_examples 'flag unclear subject declaration', :subject
   include_examples 'flag unclear subject declaration', 'subject'
+  include_examples 'flag unclear subject declaration', :subject!
+  include_examples 'flag unclear subject declaration', 'subject!'
 
   context 'when subject helper is used directly' do
     it 'does not register an offense on named subject' do


### PR DESCRIPTION
In this PR, follow up on the following comments:

Refs: https://github.com/rubocop/rubocop-rspec/pull/1375#pullrequestreview-1096722970

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
