### PR TITLE
Bump version to 2.13.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,9 +91,6 @@ RSpec/DescribeClass:
 RSpec/MultipleExpectations:
   Max: 2
 
-RSpec/NoExpectationExample:
-  Enabled: true
-
 Style/FormatStringToken:
   Exclude:
     - spec/rubocop/**/*.rb
@@ -111,6 +108,8 @@ RSpec/ClassCheck:
 RSpec/ExcessiveDocstringSpacing:
   Enabled: true
 RSpec/IdenticalEqualityAssertion:
+  Enabled: true
+RSpec/NoExpectationExample:
   Enabled: true
 RSpec/SubjectDeclaration:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.13.0 (2022-09-12)
+
 * Fix `RSpec/FilePath` cop missing mismatched expanded namespace. ([@sl4vr][])
 * Add new `AllowConsecutiveOneLiners` (default true) option for `Rspec/EmptyLineAfterHook` cop. ([@ngouy][])
 * Add autocorrect support for `RSpec/EmptyExampleGroup`. ([@r7kamura][])

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: master
+version: '2.13'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.12.1'
+      STRING = '2.13.0'
     end
   end
 end


### PR DESCRIPTION
@rubocop/rubocop-rspec I think it’s high time for a new release. Are there any open PRs that we should get merged before cutting v2.13.0?

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
