### PR TITLE
Fix an error for `RSpec/Capybara/SpecificFinders` with no parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+* Fix an error for `RSpec/Capybara/SpecificFinders` with no parentheses. ([@ydah][])
+
 ## 2.13.1 (2022-09-12)
 
 * Include config/obsoletion.yml in the gemspec. ([@hosamaly][])

--- a/lib/rubocop/cop/rspec/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_finders.rb
@@ -76,8 +76,15 @@ module RuboCop
           end
 
           def offense_range(node)
-            range_between(node.loc.selector.begin_pos,
-                          node.loc.end.end_pos)
+            range_between(node.loc.selector.begin_pos, end_pos(node))
+          end
+
+          def end_pos(node)
+            if node.loc.end
+              node.loc.end.end_pos
+            else
+              node.loc.expression.end_pos
+            end
           end
         end
       end

--- a/spec/rubocop/cop/rspec/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_finders_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
     RUBY
   end
 
+  it 'registers an offense when using `find` with no parentheses' do
+    expect_offense(<<~RUBY)
+      find "#some-id"
+      ^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id 'some-id'
+    RUBY
+  end
+
   it 'registers an offense when using `find` and other args' do
     expect_offense(<<~RUBY)
       find('#some-id', exact_text: 'foo')
@@ -20,6 +31,18 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
 
     expect_correction(<<~RUBY)
       find_by_id('some-id', exact_text: 'foo')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` and other args ' \
+    'with no parentheses' do
+    expect_offense(<<~RUBY)
+      find '#some-id', exact_text: 'foo'
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id 'some-id', exact_text: 'foo'
     RUBY
   end
 


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1386

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
