### PR TITLE
Fix a false positive for `RSpec/NoExpectationExample` with pending using `skip` or `pending` inside an example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Fix an error for `RSpec/Capybara/SpecificFinders` with no parentheses. ([@ydah][])
+* Fix a false positive for `RSpec/NoExpectationExample` with pending using `skip` or `pending` inside an example. ([@ydah][])
 
 ## 2.13.1 (2022-09-12)
 

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -49,10 +49,18 @@ module RuboCop
           send_pattern('#Expectations.all')
         )
 
+        # @!method including_any_skip_example?(node)
+        # @param [RuboCop::AST::Node] node
+        # @return [Boolean]
+        def_node_search :including_any_skip_example?, <<~PATTERN
+          (send nil? {:pending :skip} ...)
+        PATTERN
+
         # @param [RuboCop::AST::BlockNode] node
         def on_block(node)
           return unless regular_or_focused_example?(node)
           return if including_any_expectation?(node)
+          return if including_any_skip_example?(node)
 
           add_offense(node)
         end

--- a/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
+++ b/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
@@ -115,6 +115,28 @@ RSpec.describe RuboCop::Cop::RSpec::NoExpectationExample do
     end
   end
 
+  context 'with no expectation pending example when using `pending` ' \
+          'inside an example' do
+    it 'registers no offenses' do
+      expect_no_offenses(<<~RUBY)
+        it "is implemented but waiting" do
+          pending "something else getting finished"
+        end
+      RUBY
+    end
+  end
+
+  context 'with no expectation skipped example when using `skip` ' \
+          'inside an example' do
+    it 'registers no offenses' do
+      expect_no_offenses(<<~RUBY)
+        it "is skipped" do
+          skip
+        end
+      RUBY
+    end
+  end
+
   context 'when Ruby 2.7', :ruby27 do
     context 'with no expectation example with it' do
       it 'registers an offense' do


### PR DESCRIPTION
Fix: #1388

---

Before submitting the PR make sure the following are checked:

* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [ ] Added the new cop to `config/default.yml`.
* [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [ ] The cop documents examples of good and bad code.
* [ ] The tests assert both that bad code is reported and that good code is not reported.
* [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
