### PR TITLE
Fix a false negative for `RSpec/Capybara/VisibilityMatcher` with negative matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix an error for `RSpec/Capybara/SpecificFinders` with no parentheses. ([@ydah][])
 * Fix a false positive for `RSpec/NoExpectationExample` with pending using `skip` or `pending` inside an example. ([@ydah][])
 * Exclude `have_text` and `have_content` that raise `ArgumentError` with `RSpec/Capybara/VisibilityMatcher` where `:visible` is an invalid option. ([@ydah][])
+* Fix a false negative for `RSpec/Capybara/VisibilityMatcher` with negative matchers. ([@ydah][])
 
 ## 2.13.1 (2022-09-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix an error for `RSpec/Capybara/SpecificFinders` with no parentheses. ([@ydah][])
 * Fix a false positive for `RSpec/NoExpectationExample` with pending using `skip` or `pending` inside an example. ([@ydah][])
+* Exclude `have_text` and `have_content` that raise `ArgumentError` with `RSpec/Capybara/VisibilityMatcher` where `:visible` is an invalid option. ([@ydah][])
 
 ## 2.13.1 (2022-09-12)
 

--- a/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
@@ -29,18 +29,20 @@ module RuboCop
         class VisibilityMatcher < Base
           MSG_FALSE = 'Use `:all` or `:hidden` instead of `false`.'
           MSG_TRUE = 'Use `:visible` instead of `true`.'
-          CAPYBARA_MATCHER_METHODS = %i[
-            have_selector
-            have_css
-            have_xpath
-            have_link
-            have_button
-            have_field
-            have_select
-            have_table
-            have_checked_field
-            have_unchecked_field
-          ].freeze
+          CAPYBARA_MATCHER_METHODS = %w[
+            button
+            checked_field
+            css
+            field
+            link
+            select
+            selector
+            table
+            unchecked_field
+            xpath
+          ].flat_map do |element|
+            ["have_#{element}".to_sym, "have_no_#{element}".to_sym]
+          end
 
           RESTRICT_ON_SEND = CAPYBARA_MATCHER_METHODS
 

--- a/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
@@ -40,8 +40,6 @@ module RuboCop
             have_table
             have_checked_field
             have_unchecked_field
-            have_text
-            have_content
           ].freeze
 
           RESTRICT_ON_SEND = CAPYBARA_MATCHER_METHODS

--- a/spec/rubocop/cop/rspec/capybara/visibility_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/visibility_matcher_spec.rb
@@ -35,10 +35,6 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::VisibilityMatcher do
                                                 ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
       expect(page).to have_unchecked_field('cat', visible: false)
                                                   ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
-      expect(page).to have_text('My homepage', visible: false)
-                                               ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
-      expect(page).to have_content('Success', visible: false)
-                                              ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
     RUBY
   end
 

--- a/spec/rubocop/cop/rspec/capybara/visibility_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/visibility_matcher_spec.rb
@@ -38,6 +38,29 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::VisibilityMatcher do
     RUBY
   end
 
+  it 'recognizes multiple negative matchers' do
+    expect_offense(<<-RUBY)
+      expect(page).to have_no_css('.profile', visible: false)
+                                              ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_no_xpath('.//profile', visible: false)
+                                                  ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_no_link('news', visible: false)
+                                           ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_no_button('login', visible: false)
+                                              ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_no_field('name', visible: false)
+                                            ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_no_select('sauce', visible: false)
+                                              ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_no_table('arrivals', visible: false)
+                                                ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_no_checked_field('cat', visible: false)
+                                                   ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+      expect(page).to have_no_unchecked_field('cat', visible: false)
+                                                     ^^^^^^^^^^^^^^ Use `:all` or `:hidden` instead of `false`.
+    RUBY
+  end
+
   it 'registers an offense when using a selector`' do
     expect_offense(<<-RUBY)
       expect(page).to have_selector(:css, '.my_element', visible: false)


### PR DESCRIPTION
This PR fixes a problem with `RSpec/Capybara/VisibilityMatcher`
It is difficult to separate the PRs, and we have divided them into two commits in the PR and as a changelog, but please let us know if we need to separate the PRs.

### @ commit 1 https://github.com/rubocop/rubocop-rspec/pull/1391/commits/9778492811425e750a061871d15a87c3a70f4581
If `:visible` is specified for `have_text` and its alias method, `have_content`, it will result in an `ArgumentError` as follows.
Therefore, This PR is excluded `have_text` and `have_content` for `RSpec/Capybara/VisibilityMatcher`.

```command
      Failure/Error: expect(page).to have_text('a', visible: true)

      ArgumentError:
        Invalid option(s) :visible, should be one of :count, :minimum, :maximum, :between, :wait, :exact, :normalize_ws
      # ./spec/capybara/sandbox_spec.rb:20:in `block (2 levels) in <top (required)>'

      Failure/Error: expect(page).to have_content('a', visible: true)

      ArgumentError:
        Invalid option(s) :visible, should be one of :count, :minimum, :maximum, :between, :wait, :exact, :normalize_ws
      # ./spec/capybara/sandbox_spec.rb:68:in `block (2 levels) in <top (required)>'
```

### @ commit 2 https://github.com/rubocop/rubocop-rspec/pull/1391/commits/b8883bc9e64918cb0bdd34c2c61b66a7a5c134b3
Fix: #1390

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [-] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
