### PR TITLE
Mark RSpec/ReturnFromStub autocorrect as unsafe (fixes #1399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+* Declare autocorrect as unsafe for `RSpec/ReturnFromStub`. ([@ryanfb][])
 * Add `require_implicit` style to `RSpec/ImplicitSubject`. ([@r7kamura][])
 
 ## 2.13.2 (2022-09-23)
@@ -731,6 +732,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@rrosenblum]: https://github.com/rrosenblum
 [@rspeicher]: https://github.com/rspeicher
 [@RST-J]: https://github.com/RST-J
+[@ryanfb]: https://github.com/ryanfb
 [@schmijos]: https://github.com/schmijos
 [@seanpdoyle]: https://github.com/seanpdoyle
 [@sl4vr]: https://github.com/sl4vr

--- a/config/default.yml
+++ b/config/default.yml
@@ -725,11 +725,12 @@ RSpec/ReturnFromStub:
   Description: Checks for consistent style of stub's return setting.
   Enabled: true
   EnforcedStyle: and_return
+  SafeAutoCorrect: false
   SupportedStyles:
     - and_return
     - block
   VersionAdded: '1.16'
-  VersionChanged: '1.22'
+  VersionChanged: '2.14'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReturnFromStub
 
 RSpec/ScatteredLet:


### PR DESCRIPTION
This marks the autocorrects introduced by RSpec/ReturnFromStub as unsafe. Fixes #1399.

---

Before submitting the PR make sure the following are checked:

* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Updated documentation.
* [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [X] Set `VersionChanged` in `config/default.yml` to the next major version.
