### PR TITLE
Fix a false positive for `RSpec/Capybara/SpecificMatcher` when `have_css("a")` without attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 * Add `require_implicit` style to `RSpec/ImplicitSubject`. ([@r7kamura][])
+* Fix a false positive for `RSpec/Capybara/SpecificMatcher` when `have_css("a")` without attribute. ([@ydah][])
 
 ## 2.13.2 (2022-09-23)
 

--- a/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
@@ -96,7 +96,6 @@ module RuboCop
 
           def specific_matcher_option?(node, arg, matcher)
             attrs = CssSelector.attributes(arg).keys
-            return true if attrs.empty?
             return false unless replaceable_matcher?(node, matcher, attrs)
 
             attrs.all? do |attr|

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_link` without `href`' do
       expect_no_offenses(<<-RUBY, attr: attr)
+        expect(page).to have_css("a")
         expect(page).to have_css("a[#{attr}=foo]")
         expect(page).to have_css("a[#{attr}]")
       RUBY


### PR DESCRIPTION
This PR is fix a false positive for `RSpec/Capybara/SpecificMatcher` when may not have a `href`.

We fixed a similar correction at https://github.com/rubocop/rubocop-rspec/pull/1345, but the following cases remained false positive.

```
expect(page).to have_css("a")
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [-] Added the new cop to `config/default.yml`.
* [-] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [-] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [-] The cop documents examples of good and bad code.
* [-] The tests assert both that bad code is reported and that good code is not reported.
* [-] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
