### PR TITLE
Add new `RSpec/Capybara/SpecificActions` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -126,6 +126,8 @@ RSpec/VerifiedDoubleReference:
   Enabled: true
 RSpec/Capybara/NegationMatcher:
   Enabled: true
+RSpec/Capybara/SpecificActions:
+  Enabled: true
 RSpec/Capybara/SpecificFinders:
   Enabled: true
 RSpec/Capybara/SpecificMatcher:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Improve `RSpec/NoExpectationExample` cop to ignore examples skipped or pending via metatada.  ([@pirj][])
 * Add `RSpec/FactoryBot/ConsistentParenthesesStyle` cop. ([@Liberatys][])
 * Add `RSpec/Rails/InferredSpecType` cop. ([@r7kamura][])
+* Add new `RSpec/Capybara/SpecificActions` cop. ([@ydah][])
 
 ## 2.13.2 (2022-09-23)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -883,6 +883,12 @@ RSpec/Capybara/NegationMatcher:
     - not_to
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/NegationMatcher
 
+RSpec/Capybara/SpecificActions:
+  Description: Checks for there is a more specific actions offered by Capybara.
+  Enabled: pending
+  VersionAdded: '2.14'
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/SpecificActions
+
 RSpec/Capybara/SpecificFinders:
   Description: Checks if there is a more specific finder offered by Capybara.
   Enabled: pending

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -96,6 +96,7 @@
 * xref:cops_rspec_capybara.adoc#rspeccapybara/currentpathexpectation[RSpec/Capybara/CurrentPathExpectation]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/featuremethods[RSpec/Capybara/FeatureMethods]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/negationmatcher[RSpec/Capybara/NegationMatcher]
+* xref:cops_rspec_capybara.adoc#rspeccapybara/specificactions[RSpec/Capybara/SpecificActions]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/specificfinders[RSpec/Capybara/SpecificFinders]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/specificmatcher[RSpec/Capybara/SpecificMatcher]
 * xref:cops_rspec_capybara.adoc#rspeccapybara/visibilitymatcher[RSpec/Capybara/VisibilityMatcher]

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -168,6 +168,41 @@ expect(page).to have_no_css('a')
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/NegationMatcher
 
+== RSpec/Capybara/SpecificActions
+
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+| Pending
+| Yes
+| No
+| 2.14
+| -
+|===
+
+Checks for there is a more specific actions offered by Capybara.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+find('a').click
+find('button.cls').click
+find('a', exact_text: 'foo').click
+find('div button').click
+
+# good
+click_link
+click_button(class: 'cls')
+click_link(exact_text: 'foo')
+find('div').click_button
+----
+
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/SpecificActions
+
 == RSpec/Capybara/SpecificFinders
 
 |===

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -24,6 +24,7 @@ require_relative 'rubocop/cop/rspec/mixin/inside_example_group'
 require_relative 'rubocop/cop/rspec/mixin/namespace'
 require_relative 'rubocop/cop/rspec/mixin/css_selector'
 require_relative 'rubocop/cop/rspec/mixin/skip_or_pending'
+require_relative 'rubocop/cop/rspec/mixin/capybara_help'
 
 require_relative 'rubocop/rspec/concept'
 require_relative 'rubocop/rspec/example_group'

--- a/lib/rubocop/cop/rspec/capybara/specific_actions.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_actions.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module Capybara
+        # Checks for there is a more specific actions offered by Capybara.
+        #
+        # @example
+        #
+        #   # bad
+        #   find('a').click
+        #   find('button.cls').click
+        #   find('a', exact_text: 'foo').click
+        #   find('div button').click
+        #
+        #   # good
+        #   click_link
+        #   click_button(class: 'cls')
+        #   click_link(exact_text: 'foo')
+        #   find('div').click_button
+        #
+        class SpecificActions < Base
+          MSG = "Prefer `%<good_action>s` over `find('%<selector>s').click`."
+          RESTRICT_ON_SEND = %i[click].freeze
+          SPECIFIC_ACTION = {
+            'button' => 'button',
+            'a' => 'link'
+          }.freeze
+
+          # @!method click_on_selector(node)
+          def_node_matcher :click_on_selector, <<-PATTERN
+            (send _ :find (str $_) ...)
+          PATTERN
+
+          # @!method option?(node)
+          def_node_search :option?, <<-PATTERN
+            (pair (sym %) _)
+          PATTERN
+
+          def on_send(node)
+            click_on_selector(node.receiver) do |arg|
+              next unless supported_selector?(arg)
+              next unless (selector = last_selector(arg))
+              next unless (action = specific_action(selector))
+              next unless specific_action_option?(node.receiver, arg, action)
+              next unless specific_action_pseudo_classes?(arg)
+
+              range = offense_range(node, node.receiver)
+              add_offense(range, message: message(action, selector))
+            end
+          end
+
+          private
+
+          def specific_action(selector)
+            SPECIFIC_ACTION[last_selector(selector)]
+          end
+
+          def specific_action_option?(node, arg, action)
+            attrs = CssSelector.attributes(arg).keys
+            return false unless replaceable_action?(node, action, attrs)
+
+            attrs.all? do |attr|
+              CssSelector.specific_options?(action, attr)
+            end
+          end
+
+          def specific_action_pseudo_classes?(arg)
+            CssSelector.pseudo_classes(arg).all? do |pseudo_class|
+              replaceable_pseudo_class?(pseudo_class, arg)
+            end
+          end
+
+          def replaceable_pseudo_class?(pseudo_class, arg)
+            unless CssSelector.specific_pesudo_classes?(pseudo_class)
+              return false
+            end
+
+            case pseudo_class
+            when 'not()' then replaceable_pseudo_class_not?(arg)
+            else true
+            end
+          end
+
+          def replaceable_pseudo_class_not?(arg)
+            arg.scan(/not\(.*?\)/).all? do |not_arg|
+              CssSelector.attributes(not_arg).values.all? do |v|
+                v.is_a?(TrueClass) || v.is_a?(FalseClass)
+              end
+            end
+          end
+
+          def replaceable_action?(node, action, attrs)
+            case action
+            when 'link' then replaceable_to_click_link?(node, attrs)
+            else true
+            end
+          end
+
+          def replaceable_to_click_link?(node, attrs)
+            option?(node, :href) || attrs.include?('href')
+          end
+
+          def supported_selector?(selector)
+            !selector.match?(/[>,+~]/)
+          end
+
+          def last_selector(arg)
+            arg.split.last[/^\w+/, 0]
+          end
+
+          def offense_range(node, receiver)
+            receiver.loc.selector.with(end_pos: node.loc.expression.end_pos)
+          end
+
+          def message(action, selector)
+            format(MSG,
+                   good_action: good_action(action),
+                   selector: selector)
+          end
+
+          def good_action(action)
+            "click_#{action}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
@@ -26,7 +26,9 @@ module RuboCop
         #   expect(page).to have_select
         #   expect(page).to have_field('foo')
         #
-        class SpecificMatcher < Base # rubocop:disable Metrics/ClassLength
+        class SpecificMatcher < Base
+          include CapybaraHelp
+
           MSG = 'Prefer `%<good_matcher>s` over `%<bad_matcher>s`.'
           RESTRICT_ON_SEND = %i[have_selector have_no_selector have_css
                                 have_no_css].freeze
@@ -43,17 +45,12 @@ module RuboCop
             (send nil? _ (str $_) ... )
           PATTERN
 
-          # @!method option?(node)
-          def_node_search :option?, <<-PATTERN
-            (pair (sym %) _)
-          PATTERN
-
           def on_send(node)
             first_argument(node) do |arg|
               next unless (matcher = specific_matcher(arg))
               next if CssSelector.multiple_selectors?(arg)
-              next unless specific_matcher_option?(node, arg, matcher)
-              next unless specific_matcher_pseudo_classes?(arg)
+              next unless specific_option?(node, arg, matcher)
+              next unless specific_pseudo_classes?(arg)
 
               add_offense(node, message: message(node, matcher))
             end
@@ -64,51 +61,6 @@ module RuboCop
           def specific_matcher(arg)
             splitted_arg = arg[/^\w+/, 0]
             SPECIFIC_MATCHER[splitted_arg]
-          end
-
-          def specific_matcher_option?(node, arg, matcher)
-            attrs = CssSelector.attributes(arg).keys
-            return false unless replaceable_matcher?(node, matcher, attrs)
-
-            attrs.all? do |attr|
-              CssSelector.specific_options?(matcher, attr)
-            end
-          end
-
-          def specific_matcher_pseudo_classes?(arg)
-            CssSelector.pseudo_classes(arg).all? do |pseudo_class|
-              replaceable_pseudo_class?(pseudo_class, arg)
-            end
-          end
-
-          def replaceable_pseudo_class?(pseudo_class, arg)
-            unless CssSelector.specific_pesudo_classes?(pseudo_class)
-              return false
-            end
-
-            case pseudo_class
-            when 'not()' then replaceable_pseudo_class_not?(arg)
-            else true
-            end
-          end
-
-          def replaceable_pseudo_class_not?(arg)
-            arg.scan(/not\(.*?\)/).all? do |not_arg|
-              CssSelector.attributes(not_arg).values.all? do |v|
-                v.is_a?(TrueClass) || v.is_a?(FalseClass)
-              end
-            end
-          end
-
-          def replaceable_matcher?(node, matcher, attrs)
-            case matcher
-            when 'link' then replaceable_to_have_link?(node, attrs)
-            else true
-            end
-          end
-
-          def replaceable_to_have_link?(node, attrs)
-            option?(node, :href) || attrs.include?('href')
           end
 
           def message(node, matcher)

--- a/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
@@ -37,34 +37,6 @@ module RuboCop
             'select' => 'select',
             'input' => 'field'
           }.freeze
-          SPECIFIC_MATCHER_OPTIONS = {
-            'button' => (
-              CssSelector::COMMON_OPTIONS + %w[disabled name value title type]
-            ).freeze,
-            'link' => (
-              CssSelector::COMMON_OPTIONS + %w[href alt title download]
-            ).freeze,
-            'table' => (
-              CssSelector::COMMON_OPTIONS + %w[
-                caption with_cols cols with_rows rows
-              ]
-            ).freeze,
-            'select' => (
-              CssSelector::COMMON_OPTIONS + %w[
-                disabled name placeholder options enabled_options
-                disabled_options selected with_selected multiple with_options
-              ]
-            ).freeze,
-            'field' => (
-              CssSelector::COMMON_OPTIONS + %w[
-                checked unchecked disabled valid name placeholder
-                validation_message readonly with type multiple
-              ]
-            ).freeze
-          }.freeze
-          SPECIFIC_MATCHER_PSEUDO_CLASSES = %w[
-            not() disabled enabled checked unchecked
-          ].freeze
 
           # @!method first_argument(node)
           def_node_matcher :first_argument, <<-PATTERN
@@ -99,7 +71,7 @@ module RuboCop
             return false unless replaceable_matcher?(node, matcher, attrs)
 
             attrs.all? do |attr|
-              SPECIFIC_MATCHER_OPTIONS.fetch(matcher, []).include?(attr)
+              CssSelector.specific_options?(matcher, attr)
             end
           end
 
@@ -110,7 +82,7 @@ module RuboCop
           end
 
           def replaceable_pseudo_class?(pseudo_class, arg)
-            unless SPECIFIC_MATCHER_PSEUDO_CLASSES.include?(pseudo_class)
+            unless CssSelector.specific_pesudo_classes?(pseudo_class)
               return false
             end
 

--- a/lib/rubocop/cop/rspec/mixin/capybara_help.rb
+++ b/lib/rubocop/cop/rspec/mixin/capybara_help.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Help methods for capybara.
+      module CapybaraHelp
+        module_function
+
+        # @param node [RuboCop::AST::SendNode]
+        # @param locator [String]
+        # @param element [String]
+        # @return [Boolean]
+        def specific_option?(node, locator, element)
+          attrs = CssSelector.attributes(locator).keys
+          return false unless replaceable_element?(node, element, attrs)
+
+          attrs.all? do |attr|
+            CssSelector.specific_options?(element, attr)
+          end
+        end
+
+        # @param locator [String]
+        # @return [Boolean]
+        def specific_pseudo_classes?(locator)
+          CssSelector.pseudo_classes(locator).all? do |pseudo_class|
+            replaceable_pseudo_class?(pseudo_class, locator)
+          end
+        end
+
+        # @param pseudo_class [String]
+        # @param locator [String]
+        # @return [Boolean]
+        def replaceable_pseudo_class?(pseudo_class, locator)
+          return false unless CssSelector.specific_pesudo_classes?(pseudo_class)
+
+          case pseudo_class
+          when 'not()' then replaceable_pseudo_class_not?(locator)
+          else true
+          end
+        end
+
+        # @param locator [String]
+        # @return [Boolean]
+        def replaceable_pseudo_class_not?(locator)
+          locator.scan(/not\(.*?\)/).all? do |negation|
+            CssSelector.attributes(negation).values.all? do |v|
+              v.is_a?(TrueClass) || v.is_a?(FalseClass)
+            end
+          end
+        end
+
+        # @param node [RuboCop::AST::SendNode]
+        # @param element [String]
+        # @param attrs [Array<String>]
+        # @return [Boolean]
+        def replaceable_element?(node, element, attrs)
+          case element
+          when 'link' then replaceable_to_link?(node, attrs)
+          else true
+          end
+        end
+
+        # @param node [RuboCop::AST::SendNode]
+        # @param attrs [Array<String>]
+        # @return [Boolean]
+        def replaceable_to_link?(node, attrs)
+          include_option?(node, :href) || attrs.include?('href')
+        end
+
+        # @param node [RuboCop::AST::SendNode]
+        # @param option [Symbol]
+        # @return [Boolean]
+        def include_option?(node, option)
+          node.each_descendant(:sym).find { |opt| opt.value == option }
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec/mixin/css_selector.rb
+++ b/lib/rubocop/cop/rspec/mixin/css_selector.rb
@@ -10,8 +10,55 @@ module RuboCop
           id class style visible obscured exact exact_text normalize_ws match
           wait filter_set focused
         ].freeze
+        SPECIFIC_OPTIONS = {
+          'button' => (
+            COMMON_OPTIONS + %w[disabled name value title type]
+          ).freeze,
+          'link' => (
+            COMMON_OPTIONS + %w[href alt title download]
+          ).freeze,
+          'table' => (
+            COMMON_OPTIONS + %w[
+              caption with_cols cols with_rows rows
+            ]
+          ).freeze,
+          'select' => (
+            COMMON_OPTIONS + %w[
+              disabled name placeholder options enabled_options
+              disabled_options selected with_selected multiple with_options
+            ]
+          ).freeze,
+          'field' => (
+            COMMON_OPTIONS + %w[
+              checked unchecked disabled valid name placeholder
+              validation_message readonly with type multiple
+            ]
+          ).freeze
+        }.freeze
+        SPECIFIC_PSEUDO_CLASSES = %w[
+          not() disabled enabled checked unchecked
+        ].freeze
 
         module_function
+
+        # @param element [String]
+        # @param attribute [String]
+        # @return [Boolean]
+        # @example
+        #   specific_pesudo_classes?('button', 'name') # => true
+        #   specific_pesudo_classes?('link', 'invalid') # => false
+        def specific_options?(element, attribute)
+          SPECIFIC_OPTIONS.fetch(element, []).include?(attribute)
+        end
+
+        # @param pseudo_class [String]
+        # @return [Boolean]
+        # @example
+        #   specific_pesudo_classes?('disabled') # => true
+        #   specific_pesudo_classes?('first-of-type') # => false
+        def specific_pesudo_classes?(pseudo_class)
+          SPECIFIC_PSEUDO_CLASSES.include?(pseudo_class)
+        end
 
         # @param selector [String]
         # @return [Boolean]
@@ -75,7 +122,7 @@ module RuboCop
         #   multiple_selectors?('a.cls b#id') # => true
         #   multiple_selectors?('a.cls') # => false
         def multiple_selectors?(selector)
-          selector.match?(/[ >,+]/)
+          selector.match?(/[ >,+~]/)
         end
 
         # @param value [String]

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -3,6 +3,7 @@
 require_relative 'rspec/capybara/current_path_expectation'
 require_relative 'rspec/capybara/feature_methods'
 require_relative 'rspec/capybara/negation_matcher'
+require_relative 'rspec/capybara/specific_actions'
 require_relative 'rspec/capybara/specific_finders'
 require_relative 'rspec/capybara/specific_matcher'
 require_relative 'rspec/capybara/visibility_matcher'

--- a/spec/rubocop/cop/rspec/capybara/specific_actions_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_actions_spec.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificActions, :config do
+  it 'does not register an offense for find and click action when ' \
+     'first argument is link' do
+    expect_no_offenses(<<~RUBY)
+      find('a').click
+    RUBY
+  end
+
+  it 'registers an offense when using find and click action when ' \
+     'first argument is link with href' do
+    expect_offense(<<~RUBY)
+      find('a', href: 'http://example.com').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+      find("a[href]").click
+      ^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+      find("a[href='http://example.com']").click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+    RUBY
+  end
+
+  it 'registers an offense when using find and click action when ' \
+     'first argument is button' do
+    expect_offense(<<~RUBY)
+      find('button').click
+      ^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'registers an offense when using find and click action when ' \
+     'first argument is button with class' do
+    expect_offense(<<~RUBY)
+      find('button.cls').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'registers an offense when using find and click action when ' \
+     'consecutive chain methods' do
+    expect_offense(<<~RUBY)
+      find("a").find('button').click
+                ^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'registers an offense when using find and click action with ' \
+     'other argument' do
+    expect_offense(<<~RUBY)
+      find('button', exact_text: 'foo').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'registers an offense when using find and click aciton when ' \
+     'first argument is multiple selector ` `' do
+    expect_offense(<<~RUBY)
+      find('div button').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'does not register an offense for find and click aciton when ' \
+     'first argument is multiple selector `,`' do
+    expect_no_offenses(<<-RUBY)
+      find('button,a').click
+      find('a, button').click
+    RUBY
+  end
+
+  it 'does not register an offense for find and click aciton when ' \
+     'first argument is multiple selector `>`' do
+    expect_no_offenses(<<-RUBY)
+      find('button>a').click
+      find('a > button').click
+    RUBY
+  end
+
+  it 'does not register an offense for find and click aciton when ' \
+     'first argument is multiple selector `+`' do
+    expect_no_offenses(<<-RUBY)
+      find('button+a').click
+      find('a + button').click
+    RUBY
+  end
+
+  it 'does not register an offense for find and click aciton when ' \
+     'first argument is multiple selector `~`' do
+    expect_no_offenses(<<-RUBY)
+      find('button~a').click
+      find('a ~ button').click
+    RUBY
+  end
+
+  %i[above below left_of right_of near count minimum maximum between
+     text id class style visible obscured exact exact_text normalize_ws
+     match wait filter_set focused disabled name value
+     title type].each do |attr|
+    it 'registers an offense for abstract action when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `click_button`' do
+      expect_offense(<<-RUBY, attr: attr)
+        find("button[#{attr}=foo]").click
+        ^^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+        find("button[#{attr}]").click
+        ^^^^^^^^^^^^^^{attr}^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+      RUBY
+    end
+  end
+
+  %i[above below left_of right_of near count minimum maximum between text id
+     class style visible obscured exact exact_text normalize_ws match wait
+     filter_set focused alt title download].each do |attr|
+    it 'does not register an offense for abstract action when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `click_link` without `href`' do
+      expect_no_offenses(<<-RUBY, attr: attr)
+        find("a[#{attr}=foo]").click
+        find("a[#{attr}]").click
+      RUBY
+    end
+
+    it 'registers an offense for abstract action when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `click_link` with attribute `href`' do
+      expect_offense(<<-RUBY, attr: attr)
+        find("a[#{attr}=foo][href]").click
+        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+        find("a[#{attr}][href='http://example.com']").click
+        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+      RUBY
+    end
+
+    it 'registers an offense for abstract action when ' \
+       "first argument is element with replaceable attributes #{attr} " \
+       'for `click_link` with option `href`' do
+      expect_offense(<<-RUBY, attr: attr)
+        find("a[#{attr}=foo]", href: 'http://example.com').click
+        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+        find("a[#{attr}]", text: 'foo', href: 'http://example.com').click
+        ^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_link` over `find('a').click`.
+      RUBY
+    end
+  end
+
+  it 'registers an offense when using abstract action with ' \
+     'first argument is element with multiple replaceable attributes' do
+    expect_offense(<<-RUBY)
+      find('button[disabled][name="foo"]', exact_text: 'foo').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'registers an offense when using abstract action with state' do
+    expect_offense(<<-RUBY)
+      find('button[disabled]', exact_text: 'foo').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'registers an offense when using abstract action with ' \
+     'first argument is element with replaceable pseudo-classes' do
+    expect_offense(<<-RUBY)
+      find('button:not([disabled])', exact_text: 'bar').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+      find('button:not([disabled][visible])').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'registers an offense when using abstract action with ' \
+     'first argument is element with multiple replaceable pseudo-classes' do
+    expect_offense(<<-RUBY)
+      find('button:not([disabled]):enabled').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+      find('button:not([disabled=false]):disabled').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+      find('button:not([disabled]):not([disabled])').click
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `click_button` over `find('button').click`.
+    RUBY
+  end
+
+  it 'does not register an offense when using abstract action with ' \
+     'first argument is element with replaceable pseudo-classes' \
+     'and not boolean attributes' do
+    expect_no_offenses(<<-RUBY)
+      find('button:not([name="foo"][disabled])').click
+    RUBY
+  end
+
+  it 'does not register an offense when using abstract action with ' \
+     'first argument is element with multiple nonreplaceable pseudo-classes' do
+    expect_no_offenses(<<-RUBY)
+      find('button:first-of-type:not([disabled])').click
+    RUBY
+  end
+
+  it 'does not register an offense for abstract action when ' \
+     'first argument is element with nonreplaceable attributes' do
+    expect_no_offenses(<<-RUBY)
+      find('button[data-disabled]').click
+      find('button[foo=bar]').click
+      find('button[foo-bar=baz]', exact_text: 'foo').click
+    RUBY
+  end
+
+  it 'does not register an offense for abstract action when ' \
+     'first argument is element with multiple nonreplaceable attributes' do
+    expect_no_offenses(<<-RUBY)
+      find('button[disabled][foo]').click
+      find('button[foo][disabled]').click
+      find('button[foo][disabled][bar]').click
+      find('button[disabled][foo=bar]').click
+      find('button[disabled=foo][bar]', exact_text: 'foo').click
+    RUBY
+  end
+
+  it 'does not register an offense for find and click aciton when ' \
+     'first argument is not a replaceable element' do
+    expect_no_offenses(<<-RUBY)
+      find('article').click
+      find('body').click
+    RUBY
+  end
+
+  it 'does not register an offense for find and click aciton when ' \
+     'first argument is not an element' do
+    expect_no_offenses(<<-RUBY)
+      find('.a').click
+      find('#button').click
+      find('[a]').click
+    RUBY
+  end
+end


### PR DESCRIPTION
Add new `RSpec/Capybara/SpecificActions` cop

Fix: https://github.com/rubocop/rubocop-rspec/issues/1326

We would like to eventually add autocorrect, but as with `RSpec/Capybara/SpecificMatcher`, the checks are complex and it would be better to introduce them step by step.
What do you think? I would like to hear your opinion.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

* [x] Added the new cop to `config/default.yml`.
* [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
* [x] The cop is configured as `Enabled: true` in `.rubocop.yml`.
* [x] The cop documents examples of good and bad code.
* [x] The tests assert both that bad code is reported and that good code is not reported.
* [x] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

* [-] Set `VersionChanged` in `config/default.yml` to the next major version.
