### PR TITLE
Add `AllowedPatterns` configuration option to `RSpec/NoExpectationExample`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix a false positive for `RSpec/Capybara/SpecificMatcher` when `have_css("a")` without attribute. ([@ydah][])
 * Update `RSpec/ExampleWording` cop to raise error for insufficient descriptions. ([@akrox58][])
 * Add new `RSpec/Capybara/NegationMatcher` cop. ([@ydah][])
+* Add `AllowedPatterns` configuration option to `RSpec/NoExpectationExample`.  ([@ydah][])
 
 ## 2.13.2 (2022-09-23)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -643,7 +643,11 @@ RSpec/NoExpectationExample:
   Enabled: pending
   Safe: false
   VersionAdded: '2.13'
+  VersionChanged: '2.14'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NoExpectationExample
+  AllowedPatterns:
+    - "^expect_"
+    - "^assert_"
 
 RSpec/NotToNot:
   Description: Checks for consistent method usage for negating expectations.

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3525,7 +3525,7 @@ end
 | No
 | No
 | 2.13
-| -
+| 2.14
 |===
 
 Checks if an example contains any expectation.
@@ -3542,6 +3542,10 @@ add the following configuration:
       Expectations:
         - custom_expect
 
+This cop can be customized with an allowed expectation methods pattern
+with an `AllowedPatterns` option. ^expect_ and ^assert_ are allowed
+by default.
+
 === Examples
 
 [source,ruby]
@@ -3556,6 +3560,44 @@ it do
   expect(a?).to be(true)
 end
 ----
+
+==== `AllowedPatterns` configuration
+
+[source,ruby]
+----
+# .rubocop.yml
+# RSpec/NoExpectationExample:
+#   AllowedPatterns:
+#     - ^expect_
+#     - ^assert_
+----
+
+[source,ruby]
+----
+# bad
+it do
+  not_expect_something
+end
+
+# good
+it do
+  expect_something
+end
+
+it do
+  assert_something
+end
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedPatterns
+| `^expect_`, `^assert_`
+| Array
+|===
 
 === References
 

--- a/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
+++ b/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
@@ -137,6 +137,53 @@ RSpec.describe RuboCop::Cop::RSpec::NoExpectationExample do
     end
   end
 
+  context 'when `AllowedPatterns: [^expect_]`' do
+    let(:cop_config) { { 'AllowedPatterns' => ['^expect_'] } }
+
+    context 'when only allowed pattern methods are used' do
+      it 'registers no offenses' do
+        expect_no_offenses(<<~RUBY)
+          it { expect_something }
+        RUBY
+      end
+    end
+
+    context 'when allowed pattern methods and other method are used' do
+      it 'registers no offenses' do
+        expect_no_offenses(<<~RUBY)
+          it do
+            do_something
+            expect_something
+            do_something
+          end
+        RUBY
+      end
+    end
+
+    context 'when nested allowed pattern methods and other method are used' do
+      it 'registers no offenses' do
+        expect_no_offenses(<<~RUBY)
+          it do
+            do_something
+            some_patterns.each do
+              expect_something
+            end
+            do_something
+          end
+        RUBY
+      end
+    end
+
+    context 'when only not allowed pattern methods are used' do
+      it 'does something' do
+        expect_offense(<<~RUBY)
+          it { not_expect_something }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ No expectation found in this example.
+        RUBY
+      end
+    end
+  end
+
   context 'when Ruby 2.7', :ruby27 do
     context 'with no expectation example with it' do
       it 'registers an offense' do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1385

This cop can be customized allowed expectation methods pattern with `AllowedPatterns`. \Aexpect_ and \Aassert_ are allowed by default.

### @ example `AllowedPatterns: [^expect_]`
```ruby
# bad
it do
  not_expect_something
end

# good
it do
  expect_something
end
```

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

* [x] Set `VersionChanged` in `config/default.yml` to the next major version.
