### PR TITLE
Enable some new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -101,6 +101,8 @@ Layout/LineContinuationSpacing:
   Enabled: true
 Layout/LineEndStringConcatenationIndentation:
   Enabled: true
+Style/EmptyHeredoc:
+  Enabled: true
 
 # Enable our own pending cops.
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -95,6 +95,11 @@ Style/FormatStringToken:
   Exclude:
     - spec/rubocop/**/*.rb
 
+# Enable some of RuboCop's pending cops.
+
+Layout/LineContinuationSpacing:
+  Enabled: true
+
 # Enable our own pending cops.
 
 RSpec/BeEq:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,6 +99,8 @@ Style/FormatStringToken:
 
 Layout/LineContinuationSpacing:
   Enabled: true
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: true
 
 # Enable our own pending cops.
 

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -61,7 +61,7 @@ module RuboCop
         extend AutoCorrector
         MSG = 'Prefer `not_to change` over `to change.by(0)`.'
         MSG_COMPOUND = 'Prefer %<preferred>s with compound expectations ' \
-                          'over `change.by(0)`.'
+                       'over `change.by(0)`.'
         RESTRICT_ON_SEND = %i[change].freeze
 
         # @!method expect_change_with_arguments(node)

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -238,8 +238,8 @@ module RuboCop
               indent = ' ' * node.body.loc.column
               indent_end = ' ' * node.parent.loc.column
               " do #{node.arguments.source}\n" \
-              "#{indent}#{node.body.source}\n" \
-              "#{indent_end}end"
+                "#{indent}#{node.body.source}\n" \
+                "#{indent_end}end"
             end
 
             def format_singleline_block(node)

--- a/lib/rubocop/cop/rspec/repeated_include_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_include_example.rb
@@ -47,7 +47,7 @@ module RuboCop
       #
       class RepeatedIncludeExample < Base
         MSG = 'Repeated include of shared_examples %<name>s ' \
-          'on line(s) %<repeat>s'
+              'on line(s) %<repeat>s'
 
         # @!method several_include_examples?(node)
         def_node_matcher :several_include_examples?, <<-PATTERN

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect' do # rubocop:disable RSpec/DescribeC
   include_context 'when cli spec behavior'
 
   context 'when corrects `RSpec/Capybara/CurrentPathExpectation` with ' \
-    '`Style/TrailingCommaInArguments`' do
+          '`Style/TrailingCommaInArguments`' do
     before do
       RuboCop::ConfigLoader
         .default_configuration

--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll do
   def message(hook)
     "Beware of using `#{hook}` as it may cause state to leak between tests. " \
-    'If you are using `rspec-rails`, and `use_transactional_fixtures` is ' \
-    "enabled, then records created in `#{hook}` are not automatically rolled " \
-    'back.'
+      'If you are using `rspec-rails`, and `use_transactional_fixtures` is ' \
+      "enabled, then records created in `#{hook}` are not automatically " \
+      'rolled back.'
   end
 
   context 'when using before all' do

--- a/spec/rubocop/cop/rspec/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_finders_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
   end
 
   it 'registers an offense when using `find` and other args ' \
-    'with no parentheses' do
+     'with no parentheses' do
     expect_offense(<<~RUBY)
       find '#some-id', exact_text: 'foo'
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
   end
 
   it 'registers an offense when using `find ' \
-    'with argument is attribute specified id' do
+     'with argument is attribute specified id' do
     expect_offense(<<~RUBY)
       find('[id=some-id]')
       ^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
   end
 
   it 'does not register an offense when using `find ' \
-    'with argument is attribute not specified id' do
+     'with argument is attribute not specified id' do
     expect_no_offenses(<<~RUBY)
       find('[visible]')
       find('[class=some-cls][visible]')
@@ -86,21 +86,21 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
   end
 
   it 'does not register an offense when using `find ' \
-    'with argument is element with id' do
+     'with argument is element with id' do
     expect_no_offenses(<<~RUBY)
       find('h1#some-id')
     RUBY
   end
 
   it 'does not register an offense when using `find ' \
-    'with argument is element with attribute specified id' do
+     'with argument is element with attribute specified id' do
     expect_no_offenses(<<~RUBY)
       find('h1[id=some-id]')
     RUBY
   end
 
   it 'does not register an offense when using `find` ' \
-    'with argument is not id' do
+     'with argument is not id' do
     expect_no_offenses(<<~RUBY)
       find('a.some-id')
       find('.some-id')
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
   end
 
   it 'does not register an offense when using `find` ' \
-    'with argument is id with multiple matcher' do
+     'with argument is id with multiple matcher' do
     expect_no_offenses(<<~RUBY)
       find('#some-id body')
       find('#some-id>h1')

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   it 'does not register an offense for abstract matcher when ' \
-    'first argument is not a replaceable element' do
+     'first argument is not a replaceable element' do
     expect_no_offenses(<<-RUBY)
       expect(page).to have_selector('article')
       expect(page).to have_no_selector('body')
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   end
 
   it 'does not register an offense for abstract matcher when ' \
-    'first argument is not an element' do
+     'first argument is not an element' do
     expect_no_offenses(<<-RUBY)
       expect(page).to have_no_css('.a')
       expect(page).to have_selector('#button')
@@ -206,7 +206,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   end
 
   it 'registers an offense when using abstract matcher with ' \
-      'first argument is element with replaceable pseudo-classes' do
+     'first argument is element with replaceable pseudo-classes' do
     expect_offense(<<-RUBY)
       expect(page).to have_css('button:not([disabled])', exact_text: 'bar')
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
@@ -216,7 +216,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   end
 
   it 'registers an offense when using abstract matcher with ' \
-      'first argument is element with multiple replaceable pseudo-classes' do
+     'first argument is element with multiple replaceable pseudo-classes' do
     expect_offense(<<-RUBY)
       expect(page).to have_css('button:not([disabled]):enabled')
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
@@ -234,22 +234,22 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   end
 
   it 'does not register an offense when using abstract matcher with ' \
-      'first argument is element with replaceable pseudo-classes' \
-      'and not boolean attributes' do
+     'first argument is element with replaceable pseudo-classes' \
+     'and not boolean attributes' do
     expect_no_offenses(<<-RUBY)
       expect(page).to have_css('button:not([name="foo"][disabled])')
     RUBY
   end
 
   it 'does not register an offense when using abstract matcher with ' \
-      'first argument is element with multiple nonreplaceable pseudo-classes' do
+     'first argument is element with multiple nonreplaceable pseudo-classes' do
     expect_no_offenses(<<-RUBY)
       expect(page).to have_css('button:first-of-type:not([disabled])')
     RUBY
   end
 
   it 'does not register an offense for abstract matcher when ' \
-    'first argument is element with nonreplaceable attributes' do
+     'first argument is element with nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
       expect(page).to have_css('button[data-disabled]')
       expect(page).to have_css('button[foo=bar]')
@@ -258,7 +258,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   end
 
   it 'does not register an offense for abstract matcher when ' \
-    'first argument is element with multiple nonreplaceable attributes' do
+     'first argument is element with multiple nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
       expect(page).to have_css('button[disabled][foo]')
       expect(page).to have_css('button[foo][disabled]')
@@ -269,7 +269,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   end
 
   it 'does not register an offense for abstract matcher when ' \
-  'first argument is element with sub matcher' do
+     'first argument is element with sub matcher' do
     expect_no_offenses(<<-RUBY)
       expect(page).to have_css('button body')
       expect(page).to have_css('a,h1')
@@ -279,7 +279,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   end
 
   it 'does not register an offense for abstract matcher when ' \
-    'first argument is dstr' do
+     'first argument is dstr' do
     expect_no_offenses(<<-'RUBY')
       expect(page).to have_css(%{a[href="#{foo}"]}, text: "bar")
     RUBY

--- a/spec/rubocop/cop/rspec/change_by_zero_spec.rb
+++ b/spec/rubocop/cop/rspec/change_by_zero_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
 
   context 'when `NegatedMatcher` is not defined (default)' do
     it 'registers an offense when the argument to `by` is zero ' \
-      'with compound expectations by `and`' do
+       'with compound expectations by `and`' do
       expect_offense(<<-RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0).and change(Foo, :baz).by(0)
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
     end
 
     it 'registers an offense when the argument to `by` is zero ' \
-      'with compound expectations by `&`' do
+       'with compound expectations by `&`' do
       expect_offense(<<-RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0) & change(Foo, :baz).by(0)
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
     end
 
     it 'registers an offense when the argument to `by` is zero ' \
-      'with compound expectations by `or`' do
+       'with compound expectations by `or`' do
       expect_offense(<<-RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0).or change(Foo, :baz).by(0)
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
     end
 
     it 'registers an offense when the argument to `by` is zero ' \
-      'with compound expectations by `|`' do
+       'with compound expectations by `|`' do
       expect_offense(<<-RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0) | change(Foo, :baz).by(0)
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
 
     context 'when with a line break' do
       it 'registers an offense when the argument to `by` is zero ' \
-        'with compound expectations by `and`' do
+         'with compound expectations by `and`' do
         expect_offense(<<-RUBY)
           it do
             expect { foo }
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
       end
 
       it 'registers an offense when the argument to `by` is zero ' \
-        'with compound expectations by `&`' do
+         'with compound expectations by `&`' do
         expect_offense(<<-RUBY)
           it do
             expect { foo }
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
       end
 
       it 'registers an offense when the argument to `by` is zero ' \
-        'with compound expectations by `or`' do
+         'with compound expectations by `or`' do
         expect_offense(<<-RUBY)
           it do
             expect { foo }
@@ -152,7 +152,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
       end
 
       it 'registers an offense when the argument to `by` is zero ' \
-        'with compound expectations by `|`' do
+         'with compound expectations by `|`' do
         expect_offense(<<-RUBY)
           it do
             expect { foo }
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
     let(:cop_config) { { 'NegatedMatcher' => 'not_change' } }
 
     it 'registers an offense and autocorrect when ' \
-      'the argument to `by` is zero with compound expectations' do
+       'the argument to `by` is zero with compound expectations' do
       expect_offense(<<-RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0).and change(Foo, :baz).by(0)
@@ -198,8 +198,8 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
     end
 
     it 'registers an offense and autocorrect when ' \
-      'the argument to `by` is zero with compound expectations ' \
-      'with line break' do
+       'the argument to `by` is zero with compound expectations ' \
+       'with line break' do
       expect_offense(<<-RUBY)
         it do
           expect { foo }

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
   end
 
   it 'flags an empty example group with no examples defined in `case`' \
-    'branches' do
+     'branches' do
     expect_offense(<<~RUBY)
       describe Foo do
       ^^^^^^^^^^^^ Empty example group detected.

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -41,8 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
       end
     RUBY
 
-    expect_correction(<<~RUBY)
-    RUBY
+    expect_correction('')
   end
 
   it 'flags example group with examples defined in hooks' do

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'flags a missing empty line after a `rubocop:enable` directive ' \
-      'when it is followed by a `rubocop:disable` directive' do
+     'when it is followed by a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
     RUBY
   end
 
-  it 'flags a missing empty line after a `rubocop:enable` directive '\
+  it 'flags a missing empty line after a `rubocop:enable` directive ' \
       'when it is followed by a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do

--- a/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'flags a missing empty line after a `rubocop:enable` directive ' \
-      'when it is followed by a `rubocop:disable` directive' do
+     'when it is followed by a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo

--- a/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
     RUBY
   end
 
-  it 'flags a missing empty line after a `rubocop:enable` directive '\
+  it 'flags a missing empty line after a `rubocop:enable` directive ' \
       'when it is followed by a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'does not register an offense for comment '\
+  it 'does not register an offense for comment ' \
      'followed by an empty line after let' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe User do
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
     RUBY
   end
 
-  it 'flags a missing empty line after a `rubocop:enable` directive '\
+  it 'flags a missing empty line after a `rubocop:enable` directive ' \
       'when it is followed by a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'flags a missing empty line after a `rubocop:enable` directive ' \
-      'when it is followed by a `rubocop:disable` directive' do
+     'when it is followed by a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -254,7 +254,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'flags a missing empty line after a `rubocop:enable` directive ' \
-        'when it is followed by a `rubocop:disable` directive' do
+       'when it is followed by a `rubocop:disable` directive' do
       expect_offense(<<-RUBY)
         RSpec.describe User do
           # rubocop:disable RSpec/Foo

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -253,7 +253,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
       RUBY
     end
 
-    it 'flags a missing empty line after a `rubocop:enable` directive '\
+    it 'flags a missing empty line after a `rubocop:enable` directive ' \
         'when it is followed by a `rubocop:disable` directive' do
       expect_offense(<<-RUBY)
         RSpec.describe User do

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
     RUBY
   end
 
-  it 'flags a missing empty line after a `rubocop:enable` directive '\
+  it 'flags a missing empty line after a `rubocop:enable` directive ' \
       'when it is followed by a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe User do

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'flags a missing empty line after a `rubocop:enable` directive ' \
-      'when it is followed by a `rubocop:disable` directive' do
+     'when it is followed by a `rubocop:disable` directive' do
     expect_offense(<<-RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'does not register an offense for example groups '\
+  it 'does not register an offense for example groups ' \
      'do not describe a class / method' do
     expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
       describe 'Test something' do; end
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
-  it 'does not register an offense for an arbitrary spec name '\
+  it 'does not register an offense for an arbitrary spec name ' \
      'for an operator method' do
     filename = 'my_little_class/spaceship_operator_spec.rb'
     expect_no_offenses(<<-RUBY, filename)

--- a/spec/rubocop/cop/rspec/repeated_include_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_include_example_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
         end
 
         it "registers an offense for repeated #{include_method} " \
-          'with parentheses' do
+           'with parentheses' do
           expect_offense(<<~RUBY, include_method: include_method)
             describe 'foo' do
               %{include_method}('an x')
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
         end
 
         it "registers an offense for repeated #{include_method} " \
-          'with parentheses' do
+           'with parentheses' do
           expect_offense(<<~RUBY, include_method: include_method)
             describe 'foo' do
               %{include_method}('an x', 'y')
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
         end
 
         it "accepts repeated #{include_method} with different parameters " \
-          'with parentheses' do
+           'with parentheses' do
           expect_no_offenses(<<~RUBY)
             describe 'foo' do
               #{include_method}('an x', 'y')


### PR DESCRIPTION
I know we have have RuboCop’s new cops disabled (see #1065) because they were a bit unstable, and we want to test on CI against the latest version of RuboCop _without_ getting hit by bugs in new cops. But a while back I added a couple of new cops (`Layout/LineContinuationSpacing` and `Layout/LineEndStringConcatenationIndentation`), and I really miss having them enabled in this repository. So here they are (plus one extra “easy” cop that caused offense).

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Updated documentation.
* [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
