### PR TITLE
Improve `RSpec/NoExpectationExample` cop to ignore examples skipped or pending via metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update `RSpec/ExampleWording` cop to raise error for insufficient descriptions. ([@akrox58][])
 * Add new `RSpec/Capybara/NegationMatcher` cop. ([@ydah][])
 * Add `AllowedPatterns` configuration option to `RSpec/NoExpectationExample`.  ([@ydah][])
+* Improve `RSpec/NoExpectationExample` cop to ignore examples skipped or pending via metatada.  ([@pirj][])
 
 ## 2.13.2 (2022-09-23)
 

--- a/lib/rubocop-rspec.rb
+++ b/lib/rubocop-rspec.rb
@@ -23,6 +23,7 @@ require_relative 'rubocop/cop/rspec/mixin/empty_line_separation'
 require_relative 'rubocop/cop/rspec/mixin/inside_example_group'
 require_relative 'rubocop/cop/rspec/mixin/namespace'
 require_relative 'rubocop/cop/rspec/mixin/css_selector'
+require_relative 'rubocop/cop/rspec/mixin/skip_or_pending'
 
 require_relative 'rubocop/rspec/concept'
 require_relative 'rubocop/rspec/example_group'

--- a/lib/rubocop/cop/rspec/mixin/skip_or_pending.rb
+++ b/lib/rubocop/cop/rspec/mixin/skip_or_pending.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Helps check offenses with variable definitions
+      module SkipOrPending
+        extend RuboCop::NodePattern::Macros
+
+        # @!method skipped_in_metadata?(node)
+        def_node_matcher :skipped_in_metadata?, <<-PATTERN
+          {
+            (send _ _ <#skip_or_pending? ...>)
+            (send _ _ ... (hash <(pair #skip_or_pending? { true str }) ...>))
+          }
+        PATTERN
+
+        # @!method skip_or_pending?(node)
+        def_node_matcher :skip_or_pending?, '{(sym :skip) (sym :pending)}'
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -57,6 +57,8 @@ module RuboCop
       #
       class NoExpectationExample < Base
         include AllowedPattern
+        include SkipOrPending
+
         MSG = 'No expectation found in this example.'
 
         # @!method regular_or_focused_example?(node)
@@ -91,6 +93,7 @@ module RuboCop
           return unless regular_or_focused_example?(node)
           return if includes_expectation?(node)
           return if includes_skip_example?(node)
+          return if skipped_in_metadata?(node.send_node)
 
           add_offense(node)
         end

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -33,6 +33,8 @@ module RuboCop
       #   end
       #
       class Pending < Base
+        include SkipOrPending
+
         MSG = 'Pending spec found.'
 
         # @!method skippable?(node)
@@ -40,17 +42,6 @@ module RuboCop
                          send_pattern(<<~PATTERN)
                            {#ExampleGroups.regular #Examples.regular}
                          PATTERN
-
-        # @!method skipped_in_metadata?(node)
-        def_node_matcher :skipped_in_metadata?, <<-PATTERN
-          {
-            (send _ _ <#skip_or_pending? ...>)
-            (send _ _ ... (hash <(pair #skip_or_pending? { true str }) ...>))
-          }
-        PATTERN
-
-        # @!method skip_or_pending?(node)
-        def_node_matcher :skip_or_pending?, '{(sym :skip) (sym :pending)}'
 
         # @!method pending_block?(node)
         def_node_matcher :pending_block?,

--- a/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
+++ b/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
@@ -137,6 +137,23 @@ RSpec.describe RuboCop::Cop::RSpec::NoExpectationExample do
     end
   end
 
+  it 'registers no offense for skipped/pending with metadata' do
+    expect_no_offenses(<<~RUBY)
+      it 'is skipped', :skip do
+        foo
+      end
+      it 'is skipped', skip: true do
+        foo
+      end
+      it 'is pending', :pending do
+        foo
+      end
+      it 'is pending', pending: true do
+        foo
+      end
+    RUBY
+  end
+
   context 'when `AllowedPatterns: [^expect_]`' do
     let(:cop_config) { { 'AllowedPatterns' => ['^expect_'] } }
 


### PR DESCRIPTION
### NOT DONE

One step further would be to teach the cop to ignore pending/skip metadata that is set on ancestor's example group, but I'm unsure if it's worth the stretch and performance impact apart from making the cop intentionally unsafe.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).