### PR TITLE
Ignore groups with include_examples for autocorrection by LetBeforeExamples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@
 * Update `RSpec/ExampleWording` cop to raise error for insufficient descriptions. ([@akrox58][])
 * Add new `RSpec/Capybara/NegationMatcher` cop. ([@ydah][])
 * Add `AllowedPatterns` configuration option to `RSpec/NoExpectationExample`.  ([@ydah][])
-* Improve `RSpec/NoExpectationExample` cop to ignore examples skipped or pending via metatada.  ([@pirj][])
+* Improve `RSpec/NoExpectationExample` cop to ignore examples skipped or pending via metadata.  ([@pirj][])
 * Add `RSpec/FactoryBot/ConsistentParenthesesStyle` cop. ([@Liberatys][])
 * Add `RSpec/Rails/InferredSpecType` cop. ([@r7kamura][])
 * Add new `RSpec/Capybara/SpecificActions` cop. ([@ydah][])
 * Update `config/default.yml` removing deprecated option to make the config correctable by users. ([@ignaciovillaverde][])
+* Do not attempt to auto-correct example groups with `include_examples` in `RSpec/LetBeforeExamples`. ([@pirj][])
 
 ## 2.13.2 (2022-09-23)
 


### PR DESCRIPTION
fixes #1392

Moving `let` above `include_examples` that defines the same variable may break the spec as the order of definition changes.

---

Before submitting the PR make sure the following are checked:

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [-] Updated documentation.
* [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
* [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).