### PR TITLE
Fix and re-enable a Changelog spec

### DIFF
--- a/spec/project/changelog_spec.rb
+++ b/spec/project/changelog_spec.rb
@@ -24,9 +24,11 @@ RSpec.describe 'CHANGELOG.md' do
       expect(contributors.sort_by(&:downcase)).to eq(contributors)
     end
 
-    it 'links to github profiles', :pending do
+    it 'links to github profiles' do
       expect(contributors).to all(
-        match(%r{\A\[@([^\]]+)\]: https://github.com/\1\n\z})
+        # The footnote reference will be lowercase, but the github path can be
+        # mixed case.
+        match(%r{\A\[@([^\]]+)\]: https://github.com/(?i)\1\n\z})
       )
     end
   end


### PR DESCRIPTION
Enabling the spec we marked as pending in #1371, where I didn’t know how to fix the spec. But [today I learned](https://ruby-doc.org/core-3.1.2/Regexp.html#class-Regexp-label-Options) about "subexpression modifiers" like `(?i)` and `(?-i)` to toggle case insensitivity on parts of a regular expression.✨

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).