### PR TITLE
Fix bad changelog merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,7 @@
 - Update `config/default.yml` removing deprecated option to make the config correctable by users. ([@ignaciovillaverde])
 - Do not attempt to auto-correct example groups with `include_examples` in `RSpec/LetBeforeExamples`. ([@pirj])
 - Add new `RSpec/SortMetadata` cop. ([@leoarnold])
-* Add `require_implicit` style to `RSpec/ImplicitSubject`. ([@r7kamura][])
-* Fix a false positive for `RSpec/Capybara/SpecificMatcher` when `have_css("a")` without attribute. ([@ydah][])
-* Add support for subject! method to `RSpec/SubjectDeclaration`. ([@ydah][])
+- Add support for subject! method to `RSpec/SubjectDeclaration`. ([@ydah][])
 
 ## 2.13.2 (2022-09-23)
 


### PR DESCRIPTION
See https://github.com/rubocop/rubocop-rspec/pull/1376/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR17-R19

Wondering how the mdformat check passed with the `*` list syntax :thinking-face:. Cc @ydah

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).