### PR TITLE
Ignore commits in the blame view 4874a5a

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Add mdformat to the workflow in GitHub Actions
+4874a5a4a2a58e76d343aaa02279cd93b16f5a30


### PR DESCRIPTION
This PR is ignore commits in the blame view.
Ignored formatting changes in markdowns: 4874a5a4a2a58e76d343aaa02279cd93b16f5a30

Ref: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).