### PR TITLE
Fix an error for `RSpec/Rails/InferredSpecType` with redundant type before other Hash metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])
+- Fix an error for `RSpec/Rails/InferredSpecType` with redundant type before other Hash metadata. ([@ydah])
 
 ## 2.14.0 (2022-10-23)
 

--- a/lib/rubocop/cop/rspec/rails/inferred_spec_type.rb
+++ b/lib/rubocop/cop/rspec/rails/inferred_spec_type.rb
@@ -89,11 +89,21 @@ module RuboCop
           # @param [RuboCop::AST::Corrector] corrector
           # @param [RuboCop::AST::Node] node
           def autocorrect(corrector, node)
-            corrector.remove(
-              node.location.expression.with(
-                begin_pos: node.left_sibling.location.expression.end_pos
+            corrector.remove(remove_range(node))
+          end
+
+          # @param [RuboCop::AST::Node] node
+          # @return [Parser::Source::Range]
+          def remove_range(node)
+            if node.left_sibling
+              node.loc.expression.with(
+                begin_pos: node.left_sibling.loc.expression.end_pos
               )
-            )
+            elsif node.right_sibling
+              node.loc.expression.with(
+                end_pos: node.right_sibling.loc.expression.begin_pos
+              )
+            end
           end
 
           # @param [RuboCop::AST::PairNode] node

--- a/spec/rubocop/cop/rspec/rails/inferred_spec_type_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/inferred_spec_type_spec.rb
@@ -40,7 +40,22 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::InferredSpecType do
     end
   end
 
-  describe 'with redundant type and other Hash metadata' do
+  describe 'with redundant type before other Hash metadata' do
+    it 'register and corrects an offense' do
+      expect_offense(<<~RUBY, '/path/to/project/spec/models/user_spec.rb')
+        RSpec.describe User, type: :model, other: true do
+                             ^^^^^^^^^^^^ Remove redundant spec type.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe User, other: true do
+        end
+      RUBY
+    end
+  end
+
+  describe 'with redundant type after other Hash metadata' do
     it 'register and corrects an offense' do
       expect_offense(<<~RUBY, '/path/to/project/spec/models/user_spec.rb')
         RSpec.describe User, other: true, type: :model do


### PR DESCRIPTION
Fix: #1429

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
