### PR TITLE
Fix a false positive for `RSpec/NoExpectationExample` when allowed pattern methods with arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])
+- Fix a false positive for `RSpec/NoExpectationExample` when allowed pattern methods with arguments. ([@ydah])
 
 ## 2.14.1 (2022-10-24)
 

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -77,7 +77,7 @@ module RuboCop
         def_node_search :includes_expectation?, <<~PATTERN
           {
             #{send_pattern('#Expectations.all')}
-            (send nil? `#matches_allowed_pattern?)
+            (send nil? `#matches_allowed_pattern? ...)
           }
         PATTERN
 

--- a/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
+++ b/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
@@ -165,6 +165,15 @@ RSpec.describe RuboCop::Cop::RSpec::NoExpectationExample do
       end
     end
 
+    context 'when only allowed pattern methods with arguments are used' do
+      it 'registers no offenses' do
+        expect_no_offenses(<<~RUBY)
+          it { expect_something(foo, bar) }
+          it { expect_something(foo, bar, baz) }
+        RUBY
+      end
+    end
+
     context 'when allowed pattern methods and other method are used' do
       it 'registers no offenses' do
         expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/pull/1408#discussion_r1003234748

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).