### PR TITLE
Skip reordering positional arguments for include_* in RSpec/SortMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix autocorrection loop in `RSpec/ExampleWording` for insufficient example wording. ([@pirj])
+- Fix `RSpec/SortMetadata` not to reorder arguments of `include_`/`it_behaves_like`. ([@pirj])
 - Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])
 - Fix a false positive for `RSpec/NoExpectationExample` when allowed pattern methods with arguments. ([@ydah])
 

--- a/lib/rubocop/cop/rspec/sort_metadata.rb
+++ b/lib/rubocop/cop/rspec/sort_metadata.rb
@@ -26,8 +26,7 @@ module RuboCop
         def_node_matcher :rspec_metadata, <<~PATTERN
           (block
             (send
-              #rspec? {#Examples.all #ExampleGroups.all #SharedGroups.all #Hooks.all #Includes.all}
-              _ ${send str sym}* (hash $...)?)
+              #rspec? {#Examples.all #ExampleGroups.all #SharedGroups.all #Hooks.all} _ ${send str sym}* (hash $...)?)
             ...)
         PATTERN
 

--- a/spec/rubocop/cop/rspec/sort_metadata_spec.rb
+++ b/spec/rubocop/cop/rspec/sort_metadata_spec.rb
@@ -160,6 +160,17 @@ RSpec.describe RuboCop::Cop::RSpec::SortMetadata do
     RUBY
   end
 
+  it "ignores includes' positional arguments" do
+    expect_no_offenses(<<~RUBY)
+      include_examples 'z', 'a' do
+      end
+      it_behaves_like 'z', 'a' do
+      end
+      include_context 'z', 'a' do
+      end
+    RUBY
+  end
+
   context 'when using custom RSpec language ' \
           'without adjusting the RuboCop RSpec language configuration' do
     it 'does not register an offense' do
@@ -179,29 +190,11 @@ RSpec.describe RuboCop::Cop::RSpec::SortMetadata do
           'and adjusting the RuboCop RSpec language configuration' do
     before do
       other_cops.tap do |config|
-        config.dig('RSpec', 'Language', 'Includes', 'Context').push(
+        config.dig('RSpec', 'Language', 'ExampleGroups', 'Regular').push(
           'describan', 'contexto_compartido'
         )
-        config.dig('RSpec', 'Language', 'Includes', 'Examples').push('ejemplo')
+        config.dig('RSpec', 'Language', 'Examples', 'Regular').push('ejemplo')
       end
-    end
-
-    let(:language_config) do
-      <<~YAML
-        RSpec:
-          Language:
-            ExampleGroups:
-              Regular:
-                - describan
-            Examples:
-              Regular:
-                - ejemplo
-            Hooks:
-              - antes
-            SharedGroups:
-              Context:
-                - contexto_compartido
-      YAML
     end
 
     it 'registers an offense' do


### PR DESCRIPTION
fixes #1435

The arguments to `include_examples` is not regular metadata, it's arguments passed to the shared groups.
We should not reorder positional arguments, and reordering hash arguments can also have side effects, e.g. for `.each` and `keys.first`.

See [2.3 of this reference](https://github.com/rspec/rspec-core/pull/2878).
It might make sense to still reorder metadata of configuration-level `include_context`, but I'd rather skip that.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).