### PR TITLE
Fix infinite correction loop in RSpec/ExampleWording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix autocorrection loop in `RSpec/ExampleWording` for insufficient example wording. ([@pirj])
 - Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])
 - Fix a false positive for `RSpec/NoExpectationExample` when allowed pattern methods with arguments. ([@ydah])
 

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -68,19 +68,14 @@ module RuboCop
               add_wording_offense(description_node, MSG_SHOULD)
             elsif message.match?(IT_PREFIX)
               add_wording_offense(description_node, MSG_IT)
-            else
-              check_and_handle_insufficient_examples(description_node)
+            elsif insufficient_docstring?(description_node)
+              add_offense(docstring(description_node),
+                          message: MSG_INSUFFICIENT_DESCRIPTION)
             end
           end
         end
 
         private
-
-        def check_and_handle_insufficient_examples(description)
-          if insufficient_examples.include?(preprocess(text(description)))
-            add_wording_offense(description, MSG_INSUFFICIENT_DESCRIPTION)
-          end
-        end
 
         def add_wording_offense(node, message)
           docstring = docstring(node)
@@ -135,6 +130,10 @@ module RuboCop
 
         def ignored_words
           cop_config.fetch('IgnoredWords', [])
+        end
+
+        def insufficient_docstring?(description_node)
+          insufficient_examples.include?(preprocess(text(description_node)))
         end
 
         def insufficient_examples


### PR DESCRIPTION
fixes #1433

Since we don't have any corrections for an insufficient example wording like "works", we keep "replacing" the description with itself.

NOTE: `expect_no_corrections` was passing. But RuboCop was (falsely?) detecting that a change has been made, and was re-running the cop over and over.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).