### PR TITLE
Skip removing routing type metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix autocorrection loop in `RSpec/ExampleWording` for insufficient example wording. ([@pirj])
+- Fix `RSpec/InferredSpecType` to skip removing `type: :routing` metadata. ([@pirj])
 - Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])
 - Fix a false positive for `RSpec/NoExpectationExample` when allowed pattern methods with arguments. ([@ydah])
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1016,7 +1016,6 @@ RSpec/Rails/InferredSpecType:
     requests: request
     integration: request
     api: request
-    routing: routing
     system: system
     views: view
 

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -141,6 +141,10 @@ After setting up rspec-rails, you will have enabled
 spec/rails_helper.rb. This cop works in conjunction with this config.
 If you disable this config, disable this cop as well.
 
+NOTE: `type: :routing` is a special case, as RSpec Rails' controller
+      and scaffold generators add "routing" to the file name, and
+      this triggers RSpec/FilePath cop.
+
 === Safety
 
 This cop is marked as unsafe because
@@ -197,7 +201,7 @@ end
 | Name | Default value | Configurable values
 
 | Inferences
-| `{"channels"=>"channel", "controllers"=>"controller", "features"=>"feature", "generator"=>"generator", "helpers"=>"helper", "jobs"=>"job", "mailboxes"=>"mailbox", "mailers"=>"mailer", "models"=>"model", "requests"=>"request", "integration"=>"request", "api"=>"request", "routing"=>"routing", "system"=>"system", "views"=>"view"}`
+| `{"channels"=>"channel", "controllers"=>"controller", "features"=>"feature", "generator"=>"generator", "helpers"=>"helper", "jobs"=>"job", "mailboxes"=>"mailbox", "mailers"=>"mailer", "models"=>"model", "requests"=>"request", "integration"=>"request", "api"=>"request", "system"=>"system", "views"=>"view"}`
 | 
 |===
 

--- a/lib/rubocop/cop/rspec/rails/inferred_spec_type.rb
+++ b/lib/rubocop/cop/rspec/rails/inferred_spec_type.rb
@@ -11,6 +11,10 @@ module RuboCop
         # spec/rails_helper.rb. This cop works in conjunction with this config.
         # If you disable this config, disable this cop as well.
         #
+        # NOTE: `type: :routing` is a special case, as RSpec Rails' controller
+        #       and scaffold generators add "routing" to the file name, and
+        #       this triggers RSpec/FilePath cop.
+        #
         # @safety
         #   This cop is marked as unsafe because
         #   `config.infer_spec_type_from_file_location!` may not be enabled.

--- a/spec/rubocop/cop/rspec/rails/inferred_spec_type_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/inferred_spec_type_spec.rb
@@ -119,6 +119,24 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::InferredSpecType do
     end
   end
 
+  describe 'with a type not on the list' do
+    it 'register and corrects an offense' do
+      expect_no_offenses(<<~RUBY, '/path/to/project/spec/alerts/red_spec.rb')
+        RSpec.describe Red, type: :alert do
+        end
+      RUBY
+    end
+  end
+
+  describe 'with a Rails routing type' do
+    it 'register and corrects an offense' do
+      expect_no_offenses(<<~RUBY, '/project/spec/routing/my_routing_spec.rb')
+        RSpec.describe Red, type: :routing do
+        end
+      RUBY
+    end
+  end
+
   describe 'with Inferences configuration' do
     let(:cop_config) do
       {


### PR DESCRIPTION
fixes #1436

We have an exception in RSpec/FilePath for routing metadata, to allow such a name for specs with type: :routing.

RSpec Rails' [controller](https://github.com/rspec/rspec-rails/blob/59a1d9a9f1fa947b00ab3e635455743b1f0956a7/lib/generators/rspec/controller/controller_generator.rb#L47) and [scaffold](https://github.com/rspec/rspec-rails/blob/59a1d9a9f1fa947b00ab3e635455743b1f0956a7/lib/generators/rspec/scaffold/scaffold_generator.rb#L64) have special file naming schema.


**Replace this text with a summary of the changes in your PR. The more detailed you are, the better.**

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).