### PR TITLE
Change `RSpec/FilePath` so that it only checks suffix when path is under spec/routing or type is defined as routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix autocorrection loop in `RSpec/ExampleWording` for insufficient example wording. ([@pirj])
 - Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])
 - Fix a false positive for `RSpec/NoExpectationExample` when allowed pattern methods with arguments. ([@ydah])
+- Change `RSpec/FilePath` so that it only checks suffix when path is under spec/routing or type is defined as routing. ([@r7kamura])
 
 ## 2.14.1 (2022-10-24)
 

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -248,6 +248,40 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     RUBY
   end
 
+  context 'when path is under spec/routing and it ends with _spec.rb' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, 'spec/routing/foo_spec.rb')
+        describe 'routes to the foo controller' do; end
+      RUBY
+    end
+  end
+
+  context 'when path is under spec/routing and it does not end with _spec.rb' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY, 'spec/routing/foo.rb')
+        describe 'routes to the foo controller' do; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
+      RUBY
+    end
+  end
+
+  context 'when `type: :routing` is used and it ends with _spec.rb' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY, 'spec/foo_spec.rb')
+        describe 'routes to the foo controller', type: :routing do; end
+      RUBY
+    end
+  end
+
+  context 'when `type: :routing` is used and it does not end with _spec.rb' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY, 'spec/foo.rb')
+        describe 'routes to the foo controller', type: :routing do; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
+      RUBY
+    end
+  end
+
   context 'when configured with CustomTransform' do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rspec/issues/1436.

Before the change, it was recognized as a routing spec if `type: :routing` was used.
After the change, it is recognized as a routing spec if `type: routing` is used OR the file path contains `spec/routing/`.

By the way, another check thay may have been missing will be also fixed in this pull request. Even if it is a routing spec, it is now also be checked if the file path ends with `_spec.rb`.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).