### PR TITLE
Fix an incorrect autocorrect for `FactoryBot/ConsistentParenthesesStyle` with `omit_parentheses` option when method name and first argument are not on same line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix an incorrect autocorrect for `FactoryBot/ConsistentParenthesesStyle` with `omit_parentheses` option when method name and first argument are not on same line. ([@ydah])
 - Fix autocorrection loop in `RSpec/ExampleWording` for insufficient example wording. ([@pirj])
 - Fix `RSpec/SortMetadata` not to reorder arguments of `include_`/`it_behaves_like`. ([@pirj])
 - Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -96,6 +96,16 @@ create :user
 build :user
 create :login
 create :login
+
+# also good
+# when method name and first argument are not on same line
+create(
+  :user
+)
+build(
+  :user,
+  name: 'foo'
+)
 ----
 
 === Configurable attributes

--- a/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
@@ -30,6 +30,16 @@ module RuboCop
         #   create :login
         #   create :login
         #
+        #   # also good
+        #   # when method name and first argument are not on same line
+        #   create(
+        #     :user
+        #   )
+        #   build(
+        #     :user,
+        #     name: 'foo'
+        #   )
+        #
         class ConsistentParenthesesStyle < Base
           extend AutoCorrector
           include ConfigurableEnforcedStyle
@@ -66,6 +76,7 @@ module RuboCop
 
           def process_with_parentheses(node)
             return unless style == :omit_parentheses
+            return unless same_line?(node, node.first_argument)
 
             add_offense(node.loc.selector,
                         message: MSG_OMIT_PARENS) do |corrector|

--- a/spec/rubocop/cop/rspec/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/consistent_parentheses_style_spec.rb
@@ -275,5 +275,43 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::ConsistentParenthesesStyle do
         end
       RUBY
     end
+
+    context 'when create and first argument are on same line' do
+      it 'register an offense' do
+        expect_offense(<<~RUBY)
+          create(:user,
+          ^^^^^^ Prefer method call without parentheses
+            name: 'foo'
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create :user,
+            name: 'foo'
+
+        RUBY
+      end
+    end
+
+    context 'when create and first argument are not on same line' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          create(
+            :user
+          )
+        RUBY
+      end
+    end
+
+    context 'when create and some argument are not on same line' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          create(
+            :user,
+            name: 'foo'
+          )
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix: #1442

This PR is following cases where the method name and the first argument are different line are not considered offense.
```ruby
create(
  :user
)
build(
  :user,
  name: 'foo'
)
```

This is because the absence of parentheses will result in a syntax error.
```ruby
create
  :user

build
  :user,
  name: 'foo'
```

In that case, the following modification would be necessary, and we have chosen not to make it an offense here, since we would have to suppress either offense if there is a length limit in Layout/LineLength, etc.

```ruby
create :user

build :user,
  name: 'foo'
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).