### PR TITLE
Fix a false positive for `RSpec/RepeatedDescription` when different its block expectations are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/RepeatedDescription` when different its block expectations are used. ([@ydah])
 - Add `named_only` style to `RSpec/NamedSubject`. ([@kuahyeow])
 - Fix `RSpec/FactoryBot/ConsistentParenthesesStyle` to ignore calls without the first positional argument. ([@pirj])
 

--- a/spec/rubocop/cop/rspec/repeated_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_description_spec.rb
@@ -207,4 +207,33 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
       end
     RUBY
   end
+
+  it 'registers an offense when repeated its are used' do
+    expect_offense(<<-RUBY)
+      describe 'doing x' do
+        its(:x) { is_expected.to be_present }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
+        its(:x) { is_expected.to be_present }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
+      end
+    RUBY
+  end
+
+  it 'does not flag examples when different its arguments are used' do
+    expect_no_offenses(<<-RUBY)
+      describe 'doing x' do
+        its(:x) { is_expected.to be_present }
+        its(:y) { is_expected.to be_present }
+      end
+    RUBY
+  end
+
+  it 'does not flag examples when different its block expectations are used' do
+    expect_no_offenses(<<-RUBY)
+      describe 'doing x' do
+        its(:x) { is_expected.to be_present }
+        its(:x) { is_expected.to be_blank }
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/repeated_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_spec.rb
@@ -45,11 +45,31 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
     RUBY
   end
 
+  it 'registers an offense when repeated its are used' do
+    expect_offense(<<-RUBY)
+      describe 'doing x' do
+        its(:x) { is_expected.to be_present }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat examples within an example group.
+        its(:x) { is_expected.to be_present }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat examples within an example group.
+      end
+    RUBY
+  end
+
   it 'does not flag examples when different its arguments are used' do
     expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         its(:x) { is_expected.to be_present }
         its(:y) { is_expected.to be_present }
+      end
+    RUBY
+  end
+
+  it 'does not flag examples when different its block expectations are used' do
+    expect_no_offenses(<<-RUBY)
+      describe 'doing x' do
+        its(:x) { is_expected.to be_present }
+        its(:x) { is_expected.to be_blank }
       end
     RUBY
   end


### PR DESCRIPTION

Fix: https://github.com/rubocop/rubocop-rspec/issues/1273

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).