### PR TITLE
Make hook scopes and runners non-configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix `RSpec/FactoryBot/ConsistentParenthesesStyle` to ignore calls without the first positional argument. ([@pirj])
 - Fix `RSpec/FactoryBot/ConsistentParenthesesStyle` to ignore calls inside a Hash or an Array. ([@pirj])
 - Fix `RSpec/NestedGroups` to correctly use `AllowedGroups` config. ([@samrjenkins])
+- Remove `Runners` and `HookScopes` RSpec DSL elements from configuration. ([@pirj])
 
 ## 2.14.2 (2022-10-25)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -12,8 +12,6 @@ RSpec:
         - Expectations
         - Helpers
         - Hooks
-        - HookScopes
-        - Runners
         - Subjects
     ExampleGroups:
       inherit_mode:
@@ -81,12 +79,6 @@ RSpec:
       - prepend_after
       - after
       - append_after
-    HookScopes:
-      - each
-      - example
-      - context
-      - all
-      - suite
     Includes:
       inherit_mode:
         merge:
@@ -98,10 +90,6 @@ RSpec:
         - include_examples
       Context:
         - include_context
-    Runners:
-      - to
-      - to_not
-      - not_to
     SharedGroups:
       inherit_mode:
         merge:

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -135,8 +135,9 @@ module RuboCop
       end
 
       module HookScopes # :nodoc:
+        ALL = %i[each example context all suite].freeze
         def self.all(element)
-          Language.config['HookScopes'].include?(element.to_s)
+          ALL.include?(element)
         end
       end
 
@@ -158,8 +159,9 @@ module RuboCop
       end
 
       module Runners # :nodoc:
+        ALL = %i[to to_not not_to].freeze
         def self.all(element)
-          Language.config['Runners'].include?(element.to_s)
+          ALL.include?(element)
         end
       end
 


### PR DESCRIPTION
Unlike other RSpec DSL elements, there is no obvious way of configuring aliases for runners, and there's no point (I know of) and no straightforward way for adding more hook scopes.

It doesn't make sense to expose them in the configuration file, as those won't ever be configured by users.

[Originated from](https://github.com/rubocop/rubocop-rspec/discussions/1440#discussioncomment-4041788)
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).