### PR TITLE
Add `RESTRICT_ON_SEND` for `RSpec/FactoryBot/ConsistentParenthesesStyle`

### DIFF
--- a/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
@@ -54,6 +54,7 @@ module RuboCop
           MSG_OMIT_PARENS = 'Prefer method call without parentheses'
 
           FACTORY_CALLS = RuboCop::RSpec::FactoryBot::Language::METHODS
+          RESTRICT_ON_SEND = FACTORY_CALLS
 
           # @!method factory_call(node)
           def_node_matcher :factory_call, <<-PATTERN


### PR DESCRIPTION
In this PR, add `RESTRICT_ON_SEND` for `RSpec/FactoryBot/ConsistentParenthesesStyle`
This prevents on_send from being called more than necessary.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).