### PR TITLE
Revert duplicate `RESTRICT_ON_SEND`

### DIFF
--- a/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
@@ -54,7 +54,6 @@ module RuboCop
           MSG_OMIT_PARENS = 'Prefer method call without parentheses'
 
           FACTORY_CALLS = RuboCop::RSpec::FactoryBot::Language::METHODS
-          RESTRICT_ON_SEND = FACTORY_CALLS
 
           RESTRICT_ON_SEND = FACTORY_CALLS
 


### PR DESCRIPTION
Sorry, I had created https://github.com/rubocop/rubocop-rspec/pull/1461 from a slightly older branch and added `RESTRICT_ON_SEND` as a duplicate. We will revert that.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).