### PR TITLE
Check same factory calls in array on `RSpec/FactoryBot/CreateList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`. ([@r7kamura])
 - Fix a false positive for `RSpec/FactoryBot/ConsistentParenthesesStyle` when using `generate` with multiple arguments. ([@ydah])
 - Mark `RSpec/BeEq` as `Safe: false` ([@r7kamura])
+- Check same factory calls in array on `RSpec/FactoryBot/CreateList`. ([@r7kamura])
 
 ## 2.15.0 (2022-11-03)
 

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -146,6 +146,7 @@ This cop can be configured using the `EnforcedStyle` option
 ----
 # bad
 3.times { create :user }
+[create(:user), create(:user), create(:user)]
 
 # good
 create_list :user, 3
@@ -166,6 +167,7 @@ create_list :user, 3
 ----
 # bad
 create_list :user, 3
+[create(:user), create(:user), create(:user)]
 
 # good
 3.times { create :user }

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -189,6 +189,61 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList do
         create_list(:user, 3) { |user| create(:account, user: user) }
       RUBY
     end
+
+    context 'with empty array' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          []
+        RUBY
+      end
+    end
+
+    context 'with different `create` nodes in array' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          [create(:user), create(:user, age: 18)]
+        RUBY
+      end
+    end
+
+    context 'with one `create` node in array' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user)]
+          ^^^^^^^^^^^^^^^ Prefer create_list.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create_list(:user, 1)
+        RUBY
+      end
+    end
+
+    context 'with same `create` nodes in array' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user), create(:user)]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer create_list.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          create_list(:user, 2)
+        RUBY
+      end
+    end
+
+    context 'with same `create` nodes in array with method calls' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user, point: rand), create(:user, point: rand)]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          2.times { create(:user, point: rand) }
+        RUBY
+      end
+    end
   end
 
   context 'when EnforcedStyle is :n_times' do
@@ -259,6 +314,32 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList do
       it 'ignores n.times with numblock' do
         expect_no_offenses(<<~RUBY)
           3.times { create :user, position: _1 }
+        RUBY
+      end
+    end
+
+    context 'with same `create` nodes in array' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user), create(:user)]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          2.times { create(:user) }
+        RUBY
+      end
+    end
+
+    context 'with same `create` nodes in array with method calls' do
+      it 'registers and corrects an offense' do
+        expect_offense(<<~RUBY)
+          [create(:user, point: rand), create(:user, point: rand)]
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer 2.times.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          2.times { create(:user, point: rand) }
         RUBY
       end
     end


### PR DESCRIPTION
It would be nice to have a feature in `RSpec/FactoryBot/CreateList` that does the following correction. What do you think?

```ruby
# bad
[create(:user)]

# good
create_list(:user, 1)

# bad
[create(:user), create(:user)]

# good
create_list(:user, 2)
```

FYI: The real example in my project that makes me feel to add this feature is as follows:

```ruby
RSpec.describe 'GET /categories' do
  let!(:categories) do
    [
      create(:category),
      create(:category)
    ]
  end

  it 'returns categories' do
    get '/categories'
    expect(response).to have_http_status(200)
    expect(response.parsed_body).to match(
      'categories' => categories.map do |category|
        hash_including('id' => category.id)
      end
    )
  end
end
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).