### PR TITLE
Improved processing speed for `RSpec/Be`, `RSpec/ExpectActual`, `RSpec/ImplicitExpect`, `RSpec/MessageSpies`, `RSpec/PredicateMatcher`, `RSpec/StubbedMock` and `RSpec/Rails/HaveHttpStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add new `RSpec/FactoryBot/FactoryNameStyle` cop. ([@ydah])
+- Improved processing speed for `RSpec/Be`, `RSpec/ExpectActual`, `RSpec/ImplicitExpect`, `RSpec/MessageSpies`, `RSpec/PredicateMatcher` and `RSpec/Rails/HaveHttpStatus`. ([@ydah])
 - Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`. ([@r7kamura])
 
 ## 2.15.0 (2022-11-03)

--- a/lib/rubocop/cop/rspec/be.rb
+++ b/lib/rubocop/cop/rspec/be.rb
@@ -21,6 +21,8 @@ module RuboCop
       class Be < Base
         MSG = "Don't use `be` without an argument."
 
+        RESTRICT_ON_SEND = Runners.all
+
         # @!method be_without_args(node)
         def_node_matcher :be_without_args, <<-PATTERN
           (send _ #Runners.all $(send nil? :be))

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -26,6 +26,8 @@ module RuboCop
 
         MSG = 'Provide the actual you are testing to `expect(...)`.'
 
+        RESTRICT_ON_SEND = Runners.all
+
         SIMPLE_LITERALS = %i[
           true
           false

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -28,6 +28,8 @@ module RuboCop
 
         MSG = 'Prefer `%<good>s` over `%<bad>s`.'
 
+        RESTRICT_ON_SEND = Runners.all + %i[should should_not]
+
         # @!method implicit_expect(node)
         def_node_matcher :implicit_expect, <<-PATTERN
           {

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -41,6 +41,8 @@ module RuboCop
 
         SUPPORTED_STYLES = %w[have_received receive].freeze
 
+        RESTRICT_ON_SEND = Runners.all
+
         # @!method message_expectation(node)
         def_node_matcher :message_expectation, %(
           (send (send nil? :expect $_) #Runners.all ...)

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -283,6 +283,8 @@ module RuboCop
         include InflectedHelper
         include ExplicitHelper
 
+        RESTRICT_ON_SEND = Runners.all
+
         def on_send(node)
           case style
           when :inflected

--- a/lib/rubocop/cop/rspec/rails/have_http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/have_http_status.rb
@@ -20,6 +20,8 @@ module RuboCop
             'Prefer `expect(response).%<to>s have_http_status(%<status>i)` ' \
             'over `expect(response.status).%<to>s %<match>s`.'
 
+          RESTRICT_ON_SEND = Runners.all
+
           # @!method match_status(node)
           def_node_matcher :match_status, <<-PATTERN
             (send

--- a/lib/rubocop/cop/rspec/stubbed_mock.rb
+++ b/lib/rubocop/cop/rspec/stubbed_mock.rb
@@ -133,6 +133,8 @@ module RuboCop
           }
         PATTERN
 
+        RESTRICT_ON_SEND = %i[to].freeze
+
         def on_send(node)
           expectation(node, &method(:on_expectation))
         end

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -160,8 +160,12 @@ module RuboCop
 
       module Runners # :nodoc:
         ALL = %i[to to_not not_to].freeze
-        def self.all(element)
-          ALL.include?(element)
+        class << self
+          def all(element = nil)
+            return ALL if element.nil?
+
+            ALL.include?(element)
+          end
         end
       end
 


### PR DESCRIPTION
Defined `RESTRICT_ON_SEND` for cop where `on_send` is defined but `RESTRICT_ON_SEND` is not defined.
For those not defined, the following Custom Cop was used to check.

- https://github.com/ydah/workitcop/blob/main/lib/rubocop/cop/workit/restrict_on_send.rb

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).