### PR TITLE
Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`. ([@r7kamura])
+
 ## 2.15.0 (2022-11-03)
 
 - Fix a false positive for `RSpec/RepeatedDescription` when different its block expectations are used. ([@ydah])

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -143,7 +143,7 @@ module RuboCop
 
             def call(corrector)
               replacement = generate_n_times_block(node)
-              corrector.replace(node, replacement)
+              corrector.replace(node.block_node || node, replacement)
             end
 
             private
@@ -159,7 +159,14 @@ module RuboCop
 
               replacement = format_receiver(node.receiver)
               replacement += format_method_call(node, 'create', arguments)
+              replacement += " #{factory_call_block_source}" if node.block_node
               "#{count.source}.times { #{replacement} }"
+            end
+
+            def factory_call_block_source
+              node.block_node.location.begin.with(
+                end_pos: node.block_node.location.end.end_pos
+              ).source
             end
           end
 

--- a/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/create_list_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::CreateList do
       RUBY
 
       expect_correction(<<~RUBY)
-        3.times { FactoryGirl.create(:user) } { |user| user.points = rand(1000) }
+        3.times { FactoryGirl.create(:user) { |user| user.points = rand(1000) } }
       RUBY
     end
 


### PR DESCRIPTION
I have fixed the problem pointed out in the following comment:

- https://github.com/rubocop/rubocop-rspec/pull/1469#discussion_r1016896121

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).