### PR TITLE
Declare autocorrect as unsafe for `RSpec/Capybara/SpecificFinders`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Declare autocorrect as unsafe for `RSpec/Capybara/SpecificFinders`. ([@Tietew])
+
 ## 2.15.0 (2022-11-03)
 
 - Fix a false positive for `RSpec/RepeatedDescription` when different its block expectations are used. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -890,7 +890,9 @@ RSpec/Capybara/SpecificActions:
 RSpec/Capybara/SpecificFinders:
   Description: Checks if there is a more specific finder offered by Capybara.
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '2.13'
+  VersionChanged: '2.16'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/SpecificFinders
 
 RSpec/Capybara/SpecificMatcher:

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -217,9 +217,9 @@ find('div').click_button
 
 ¦ Pending
 ¦ Yes
-¦ Yes
+¦ Yes (Unsafe)
 ¦ 2.13
-¦ -
+¦ 2.16
 |===
 
 Checks if there is a more specific finder offered by Capybara.


### PR DESCRIPTION
Fixes #1468

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged` in `config/default.yml` to the next major version.
