### PR TITLE
Remove obsolete check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -70,16 +70,7 @@ task :new_cop, [:cop] do |_task, args|
     exit!
   end
 
-  # FIXME: Remove the condition when requiring RuboCop 1.22 or higher.
-  #        See: https://github.com/rubocop/rubocop/pull/10109
-  if RuboCop::Version::STRING >= '1.22.0'
-    generator = RuboCop::Cop::Generator.new(cop_name)
-  else
-    github_user = `git config github.user`.chop
-    github_user = 'your_id' if github_user.empty?
-    generator = RuboCop::Cop::Generator.new(cop_name, github_user)
-  end
-
+  generator = RuboCop::Cop::Generator.new(cop_name)
   generator.write_source
   generator.write_spec
   generator.inject_require(root_file_path: 'lib/rubocop/cop/rspec_cops.rb')


### PR DESCRIPTION
We depend on rubocop 1.33+

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).