### PR TITLE
Remove cops we don't use

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,19 +128,3 @@ RSpec/SubjectDeclaration:
   Enabled: true
 RSpec/VerifiedDoubleReference:
   Enabled: true
-RSpec/Capybara/NegationMatcher:
-  Enabled: true
-RSpec/Capybara/SpecificActions:
-  Enabled: true
-RSpec/Capybara/SpecificFinders:
-  Enabled: true
-RSpec/Capybara/SpecificMatcher:
-  Enabled: true
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: true
-RSpec/Rails/AvoidSetupHook:
-  Enabled: true
-RSpec/Rails/HaveHttpStatus:
-  Enabled: true
-RSpec/Rails/InferredSpecType:
-  Enabled: true


### PR DESCRIPTION
Even though it would be fair to use our own pending cops, but they don't seem to be inspecting much, as we use no Capybara/FactoryBot in our code.
Compared to checking changes/new cops against a set of large repos, it's an approach that may inspire false confidence in those cops' stability and correctness.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).