### PR TITLE
Add `RSpec/Rails/ResponseParsedBody` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -144,3 +144,5 @@ RSpec/Rails/HaveHttpStatus:
   Enabled: true
 RSpec/Rails/InferredSpecType:
   Enabled: true
+RSpec/Rails/ResponseParsedBody:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`. ([@r7kamura])
+- Add `RSpec/Rails/ResponseParsedBody` cop. ([@r7kamura])
 
 ## 2.15.0 (2022-11-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1018,3 +1018,13 @@ RSpec/Rails/HttpStatus:
   VersionAdded: '1.23'
   VersionChanged: '2.0'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus
+
+RSpec/Rails/ResponseParsedBody:
+  Description: Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+  Enabled: pending
+  Safe: false
+  Include:
+    - spec/controllers/**/*
+    - spec/requests/**/*
+  VersionAdded: "<<next>>"
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/ResponseParsedBody

--- a/docs/modules/ROOT/pages/cops.adoc
+++ b/docs/modules/ROOT/pages/cops.adoc
@@ -116,5 +116,6 @@
 * xref:cops_rspec_rails.adoc#rspecrails/havehttpstatus[RSpec/Rails/HaveHttpStatus]
 * xref:cops_rspec_rails.adoc#rspecrails/httpstatus[RSpec/Rails/HttpStatus]
 * xref:cops_rspec_rails.adoc#rspecrails/inferredspectype[RSpec/Rails/InferredSpecType]
+* xref:cops_rspec_rails.adoc#rspecrails/responseparsedbody[RSpec/Rails/ResponseParsedBody]
 
 // END_COP_LIST

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -210,3 +210,49 @@ end
 === References
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/InferredSpecType
+
+== RSpec/Rails/ResponseParsedBody
+
+[separator=¦]
+|===
+| Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
+
+¦ Pending
+¦ No
+¦ Yes (Unsafe)
+¦ <<next>>
+¦ -
+|===
+
+Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+
+=== Safety
+
+This cop is unsafe because Content-Type may not be
+`application/json`.
+
+=== Examples
+
+[source,ruby]
+----
+# bad
+JSON.parse(response.body)
+
+# good
+response.parsed_body
+----
+
+=== Configurable attributes
+
+[separator=¦]
+|===
+| Name | Default value | Configurable values
+
+¦ Include
+¦ `+spec/controllers/**/*+`, `+spec/requests/**/*+`
+¦ Array
+|===
+
+=== References
+
+* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/ResponseParsedBody

--- a/lib/rubocop/cop/rspec/rails/response_parsed_body.rb
+++ b/lib/rubocop/cop/rspec/rails/response_parsed_body.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      module Rails
+        # Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+        #
+        # @safety
+        #   This cop is unsafe because Content-Type may not be
+        #   `application/json`.
+        #
+        # @example
+        #   # bad
+        #   JSON.parse(response.body)
+        #
+        #   # good
+        #   response.parsed_body
+        class ResponseParsedBody < Base
+          extend AutoCorrector
+
+          MSG = 'Prefer `response.parsed_body` to `JSON.parse(response.body)`.'
+
+          RESTRICT_ON_SEND = %i[parse].freeze
+
+          # @!method json_parse_response_body?(node)
+          #   @param node [RuboCop::AST::Node]
+          #   @return [Boolean]
+          def_node_matcher :json_parse_response_body?, <<~PATTERN
+            (send
+              (const {nil? cbase} :JSON)
+              :parse
+              (send
+                (send nil? :response)
+                :body
+              )
+            )
+          PATTERN
+
+          # @param node [RuboCop::AST::SendNode]
+          # @return [void]
+          def on_send(node)
+            return unless json_parse_response_body?(node)
+
+            add_offense(node) do |corrector|
+              autocorrect(corrector, node)
+            end
+          end
+
+          private
+
+          # @param corrector [RuboCop::Cop::Corrector]
+          # @param node [RuboCop::AST::SendNode]
+          # @return [void]
+          def autocorrect(corrector, node)
+            corrector.replace(node, 'response.parsed_body')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/rspec_cops.rb
+++ b/lib/rubocop/cop/rspec_cops.rb
@@ -22,6 +22,7 @@ rescue LoadError
   # Rails/HttpStatus cannot be loaded if rack/utils is unavailable.
 end
 require_relative 'rspec/rails/inferred_spec_type'
+require_relative 'rspec/rails/response_parsed_body'
 
 require_relative 'rspec/align_left_let_brace'
 require_relative 'rspec/align_right_let_brace'

--- a/spec/rubocop/cop/rspec/rails/response_parsed_body_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/response_parsed_body_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::Rails::ResponseParsedBody do
+  def inspected_source_filename
+    'spec/requests/example_spec.rb'
+  end
+
+  context 'when `response.parsed_body` is used' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        expect(response.parsed_body).to eq('foo' => 'bar')
+      RUBY
+    end
+  end
+
+  context 'when `JSON.parse(response.body)` is used' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        expect(JSON.parse(response.body)).to eq('foo' => 'bar')
+               ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response.parsed_body).to eq('foo' => 'bar')
+      RUBY
+    end
+  end
+
+  context 'when `::JSON.parse(response.body)` is used' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        expect(::JSON.parse(response.body)).to eq('foo' => 'bar')
+               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `response.parsed_body` to `JSON.parse(response.body)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(response.parsed_body).to eq('foo' => 'bar')
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
Since Rails 5, there is an often overlooked feature: `response.parsed_body`.

- https://github.com/rails/rails/issues/23594

As a typical pattern, many Rails applications have `JSON.parse(response.body)` in their controlelr-specs and request-specs, but most of these could be replaced by `response.parsed_body`. So it would be nice for rubocop-rails to have a Cop that recommends `response.parsed_body`.

I think there are several advantages to using `response.parsed_body`.

1. the fact that Rails provides this by default means that Rails would probably encourage the use of it
2. it avoids direct references to `JSON`
3. shorter code

What do you think?
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] Added the new cop to `config/default.yml`.
- [x] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [x] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [x] The cop documents examples of good and bad code.
- [x] The tests assert both that bad code is reported and that good code is not reported.
- [x] Set `VersionAdded` in `default/config.yml` to the next minor version.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
