### PR TITLE
Fix a docs rendering of the tables is broken

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2,15 +2,14 @@
 
 == RSpec/AlignLeftLetBrace
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Disabled
-¦ Yes
-¦ Yes
-¦ 1.16
-¦ -
+| Disabled
+| Yes
+| Yes
+| 1.16
+| -
 |===
 
 Checks that left braces for adjacent single line lets are aligned.
@@ -36,15 +35,14 @@ let(:a)      { b }
 
 == RSpec/AlignRightLetBrace
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Disabled
-¦ Yes
-¦ Yes
-¦ 1.16
-¦ -
+| Disabled
+| Yes
+| Yes
+| 1.16
+| -
 |===
 
 Checks that right braces for adjacent single line lets are aligned.
@@ -70,15 +68,14 @@ let(:a)      { b        }
 
 == RSpec/AnyInstance
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.4
-¦ -
+| Enabled
+| Yes
+| No
+| 1.4
+| -
 |===
 
 Check that instances are not being stubbed globally.
@@ -112,15 +109,14 @@ end
 
 == RSpec/AroundBlock
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.11
-¦ -
+| Enabled
+| Yes
+| No
+| 1.11
+| -
 |===
 
 Checks that around blocks actually run the test.
@@ -156,15 +152,14 @@ end
 
 == RSpec/Be
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.25
-¦ -
+| Enabled
+| Yes
+| No
+| 1.25
+| -
 |===
 
 Check for expectations where `be` is used without argument.
@@ -193,15 +188,14 @@ expect(foo).to be(true)
 
 == RSpec/BeEq
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.9.0
-¦ -
+| Pending
+| Yes
+| Yes
+| 2.9.0
+| -
 |===
 
 Check for expectations where `be(...)` can replace `eq(...)`.
@@ -231,15 +225,14 @@ expect(foo).to be(nil)
 
 == RSpec/BeEql
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.7
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.7
+| -
 |===
 
 Check for expectations where `be(...)` can replace `eql(...)`.
@@ -283,15 +276,14 @@ expect(foo).to be(nil)
 
 == RSpec/BeNil
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.9.0
-¦ 2.10.0
+| Pending
+| Yes
+| Yes
+| 2.9.0
+| 2.10.0
 |===
 
 Ensures a consistent style is used when matching `nil`.
@@ -327,13 +319,12 @@ expect(foo).to be(nil)
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `be_nil`
-¦ `be`, `be_nil`
+| EnforcedStyle
+| `be_nil`
+| `be`, `be_nil`
 |===
 
 === References
@@ -342,15 +333,14 @@ expect(foo).to be(nil)
 
 == RSpec/BeforeAfterAll
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.12
-¦ -
+| Enabled
+| Yes
+| No
+| 1.12
+| -
 |===
 
 Check that before/after(:all) isn't being used.
@@ -380,13 +370,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Exclude
-¦ `spec/spec_helper.rb`, `spec/rails_helper.rb`, `+spec/support/**/*.rb+`
-¦ Array
+| Exclude
+| `spec/spec_helper.rb`, `spec/rails_helper.rb`, `+spec/support/**/*.rb+`
+| Array
 |===
 
 === References
@@ -396,15 +385,14 @@ end
 
 == RSpec/ChangeByZero
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.11
-¦ 2.14
+| Pending
+| Yes
+| Yes
+| 2.11
+| 2.14
 |===
 
 Prefer negated matchers over `to change.by(0)`.
@@ -473,13 +461,12 @@ expect { run }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ NegatedMatcher
-¦ `<none>`
-¦ 
+| NegatedMatcher
+| `<none>`
+| 
 |===
 
 === References
@@ -488,15 +475,14 @@ expect { run }
 
 == RSpec/ClassCheck
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.13
-¦ -
+| Pending
+| Yes
+| Yes
+| 2.13
+| -
 |===
 
 Enforces consistent use of `be_a` or `be_kind_of`.
@@ -531,13 +517,12 @@ expect(object).to be_a_kind_of(String)
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `be_a`
-¦ `be_a`, `be_kind_of`
+| EnforcedStyle
+| `be_a`
+| `be_a`, `be_kind_of`
 |===
 
 === References
@@ -547,15 +532,14 @@ expect(object).to be_a_kind_of(String)
 
 == RSpec/ContextMethod
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.36
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.36
+| -
 |===
 
 `context` should not be used for specifying methods.
@@ -590,15 +574,14 @@ end
 
 == RSpec/ContextWording
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.20
-¦ 2.13
+| Enabled
+| Yes
+| No
+| 1.20
+| 2.13
 |===
 
 Checks that `context` docstring starts with an allowed prefix.
@@ -666,17 +649,16 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Prefixes
-¦ `when`, `with`, `without`
-¦ Array
+| Prefixes
+| `when`, `with`, `without`
+| Array
 
-¦ AllowedPatterns
-¦ `[]`
-¦ Array
+| AllowedPatterns
+| `[]`
+| Array
 |===
 
 === References
@@ -686,15 +668,14 @@ end
 
 == RSpec/DescribeClass
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.0
-¦ 2.7
+| Enabled
+| Yes
+| No
+| 1.0
+| 2.7
 |===
 
 Check that the first argument to the top-level describe is a constant.
@@ -738,17 +719,16 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Exclude
-¦ `+**/spec/features/**/*+`, `+**/spec/requests/**/*+`, `+**/spec/routing/**/*+`, `+**/spec/system/**/*+`, `+**/spec/views/**/*+`
-¦ Array
+| Exclude
+| `+**/spec/features/**/*+`, `+**/spec/requests/**/*+`, `+**/spec/routing/**/*+`, `+**/spec/system/**/*+`, `+**/spec/views/**/*+`
+| Array
 
-¦ IgnoredMetadata
-¦ `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox", "aruba", "task"]}`
-¦ 
+| IgnoredMetadata
+| `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox", "aruba", "task"]}`
+| 
 |===
 
 === References
@@ -757,15 +737,14 @@ end
 
 == RSpec/DescribeMethod
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.0
-¦ -
+| Enabled
+| Yes
+| No
+| 1.0
+| -
 |===
 
 Checks that the second argument to `describe` specifies a method.
@@ -792,15 +771,14 @@ end
 
 == RSpec/DescribeSymbol
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.15
-¦ -
+| Enabled
+| Yes
+| No
+| 1.15
+| -
 |===
 
 Avoid describing symbols.
@@ -826,15 +804,14 @@ end
 
 == RSpec/DescribedClass
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes (Unsafe)
-¦ 1.0
-¦ 1.11
+| Enabled
+| Yes
+| Yes (Unsafe)
+| 1.0
+| 1.11
 |===
 
 Checks that tests use `described_class`.
@@ -904,17 +881,16 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ SkipBlocks
-¦ `false`
-¦ Boolean
+| SkipBlocks
+| `false`
+| Boolean
 
-¦ EnforcedStyle
-¦ `described_class`
-¦ `described_class`, `explicit`
+| EnforcedStyle
+| `described_class`
+| `described_class`, `explicit`
 |===
 
 === References
@@ -923,15 +899,14 @@ end
 
 == RSpec/DescribedClassModuleWrapping
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Disabled
-¦ Yes
-¦ No
-¦ 1.37
-¦ -
+| Disabled
+| Yes
+| No
+| 1.37
+| -
 |===
 
 Avoid opening modules and defining specs within them.
@@ -959,15 +934,14 @@ end
 
 == RSpec/Dialect
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Disabled
-¦ Yes
-¦ Yes
-¦ 1.33
-¦ -
+| Disabled
+| Yes
+| Yes
+| 1.33
+| -
 |===
 
 Enforces custom RSpec dialects.
@@ -1015,13 +989,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ PreferredMethods
-¦ `{}`
-¦ 
+| PreferredMethods
+| `{}`
+| 
 |===
 
 === References
@@ -1030,15 +1003,14 @@ end
 
 == RSpec/EmptyExampleGroup
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes (Unsafe)
-¦ 1.7
-¦ 2.13
+| Enabled
+| Yes
+| Yes (Unsafe)
+| 1.7
+| 2.13
 |===
 
 Checks if an example group does not include any tests.
@@ -1085,15 +1057,14 @@ end
 
 == RSpec/EmptyHook
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.39
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.39
+| -
 |===
 
 Checks for empty before and after hooks.
@@ -1126,15 +1097,14 @@ after(:all) { cleanup_feed }
 
 == RSpec/EmptyLineAfterExample
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.36
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.36
+| -
 |===
 
 Checks if there is an empty line after example blocks.
@@ -1184,13 +1154,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ AllowConsecutiveOneLiners
-¦ `true`
-¦ Boolean
+| AllowConsecutiveOneLiners
+| `true`
+| Boolean
 |===
 
 === References
@@ -1200,15 +1169,14 @@ end
 
 == RSpec/EmptyLineAfterExampleGroup
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.27
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.27
+| -
 |===
 
 Checks if there is an empty line after example group blocks.
@@ -1242,15 +1210,14 @@ end
 
 == RSpec/EmptyLineAfterFinalLet
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.14
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.14
+| -
 |===
 
 Checks if there is an empty line after the last let block.
@@ -1278,15 +1245,14 @@ it { does_something }
 
 == RSpec/EmptyLineAfterHook
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.27
-¦ 2.13
+| Enabled
+| Yes
+| Yes
+| 1.27
+| 2.13
 |===
 
 Checks if there is an empty line after hook blocks.
@@ -1346,13 +1312,12 @@ it { does_something }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ AllowConsecutiveOneLiners
-¦ `true`
-¦ Boolean
+| AllowConsecutiveOneLiners
+| `true`
+| Boolean
 |===
 
 === References
@@ -1362,15 +1327,14 @@ it { does_something }
 
 == RSpec/EmptyLineAfterSubject
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.14
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.14
+| -
 |===
 
 Checks if there is an empty line after subject block.
@@ -1396,15 +1360,14 @@ let(:foo) { bar }
 
 == RSpec/ExampleLength
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.5
-¦ 2.3
+| Enabled
+| Yes
+| No
+| 1.5
+| 2.3
 |===
 
 Checks for long examples.
@@ -1461,17 +1424,16 @@ end                 # 5 points
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Max
-¦ `5`
-¦ Integer
+| Max
+| `5`
+| Integer
 
-¦ CountAsOne
-¦ `[]`
-¦ Array
+| CountAsOne
+| `[]`
+| Array
 |===
 
 === References
@@ -1480,15 +1442,14 @@ end                 # 5 points
 
 == RSpec/ExampleWithoutDescription
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.22
-¦ -
+| Enabled
+| Yes
+| No
+| 1.22
+| -
 |===
 
 Checks for examples without a description.
@@ -1552,13 +1513,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `always_allow`
-¦ `always_allow`, `single_line_only`, `disallow`
+| EnforcedStyle
+| `always_allow`
+| `always_allow`, `single_line_only`, `disallow`
 |===
 
 === References
@@ -1567,15 +1527,14 @@ end
 
 == RSpec/ExampleWording
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.0
-¦ 2.13
+| Enabled
+| Yes
+| Yes
+| 1.0
+| 2.13
 |===
 
 Checks for common mistakes in example descriptions.
@@ -1629,21 +1588,20 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ CustomTransform
-¦ `{"be"=>"is", "BE"=>"IS", "have"=>"has", "HAVE"=>"HAS"}`
-¦ 
+| CustomTransform
+| `{"be"=>"is", "BE"=>"IS", "have"=>"has", "HAVE"=>"HAS"}`
+| 
 
-¦ IgnoredWords
-¦ `[]`
-¦ Array
+| IgnoredWords
+| `[]`
+| Array
 
-¦ DisallowedExamples
-¦ `works`
-¦ Array
+| DisallowedExamples
+| `works`
+| Array
 |===
 
 === References
@@ -1653,15 +1611,14 @@ end
 
 == RSpec/ExcessiveDocstringSpacing
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.5
-¦ -
+| Pending
+| Yes
+| Yes
+| 2.5
+| -
 |===
 
 Checks for excessive whitespace in example descriptions.
@@ -1696,15 +1653,14 @@ end
 
 == RSpec/ExpectActual
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.7
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.7
+| -
 |===
 
 Checks for `expect(...)` calls containing literal values.
@@ -1731,13 +1687,12 @@ expect(false).to eq(true)
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Exclude
-¦ `+spec/routing/**/*+`
-¦ Array
+| Exclude
+| `+spec/routing/**/*+`
+| Array
 |===
 
 === References
@@ -1746,15 +1701,14 @@ expect(false).to eq(true)
 
 == RSpec/ExpectChange
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes (Unsafe)
-¦ 1.22
-¦ 2.5
+| Enabled
+| Yes
+| Yes (Unsafe)
+| 1.22
+| 2.5
 |===
 
 Checks for consistent style of change matcher.
@@ -1795,13 +1749,12 @@ expect { run }.to change { Foo.bar }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `method_call`
-¦ `method_call`, `block`
+| EnforcedStyle
+| `method_call`
+| `method_call`, `block`
 |===
 
 === References
@@ -1810,15 +1763,14 @@ expect { run }.to change { Foo.bar }
 
 == RSpec/ExpectInHook
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.16
-¦ -
+| Enabled
+| Yes
+| No
+| 1.16
+| -
 |===
 
 Do not use `expect` in hooks such as `before`.
@@ -1849,15 +1801,14 @@ end
 
 == RSpec/ExpectOutput
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.10
-¦ -
+| Enabled
+| Yes
+| No
+| 1.10
+| -
 |===
 
 Checks for opportunities to use `expect { ... }.to output`.
@@ -1882,15 +1833,14 @@ expect { my_app.print_report }.to output('Hello World').to_stdout
 
 == RSpec/FilePath
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.2
-¦ 1.40
+| Enabled
+| Yes
+| No
+| 1.2
+| 1.40
 |===
 
 Checks that spec file paths are consistent and well-formed.
@@ -1960,25 +1910,24 @@ my_class_spec.rb         # describe MyClass, '#method'
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Include
-¦ `+**/*_spec*rb*+`, `+**/spec/**/*+`
-¦ Array
+| Include
+| `+**/*_spec*rb*+`, `+**/spec/**/*+`
+| Array
 
-¦ CustomTransform
-¦ `{"RuboCop"=>"rubocop", "RSpec"=>"rspec"}`
-¦ 
+| CustomTransform
+| `{"RuboCop"=>"rubocop", "RSpec"=>"rspec"}`
+| 
 
-¦ IgnoreMethods
-¦ `false`
-¦ Boolean
+| IgnoreMethods
+| `false`
+| Boolean
 
-¦ SpecSuffixOnly
-¦ `false`
-¦ Boolean
+| SpecSuffixOnly
+| `false`
+| Boolean
 |===
 
 === References
@@ -1987,15 +1936,14 @@ my_class_spec.rb         # describe MyClass, '#method'
 
 == RSpec/Focus
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.5
-¦ 2.1
+| Enabled
+| Yes
+| Yes
+| 1.5
+| 2.1
 |===
 
 Checks if examples are focused.
@@ -2042,15 +1990,14 @@ focus 'test' do; end
 
 == RSpec/HookArgument
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.7
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.7
+| -
 |===
 
 Checks the arguments passed to `before`, `around`, and `after`.
@@ -2124,13 +2071,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `implicit`
-¦ `implicit`, `each`, `example`
+| EnforcedStyle
+| `implicit`
+| `implicit`, `each`, `example`
 |===
 
 === References
@@ -2140,15 +2086,14 @@ end
 
 == RSpec/HooksBeforeExamples
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.29
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.29
+| -
 |===
 
 Checks for before/around/after hooks that come after an example.
@@ -2180,15 +2125,14 @@ end
 
 == RSpec/IdenticalEqualityAssertion
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ No
-¦ 2.4
-¦ -
+| Pending
+| Yes
+| No
+| 2.4
+| -
 |===
 
 Checks for equality assertions with identical expressions on both sides.
@@ -2212,15 +2156,14 @@ expect(foo.bar).to eql(2)
 
 == RSpec/ImplicitBlockExpectation
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.35
-¦ -
+| Enabled
+| Yes
+| No
+| 1.35
+| -
 |===
 
 Check that implicit block expectation syntax is not used.
@@ -2248,15 +2191,14 @@ end
 
 == RSpec/ImplicitExpect
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.8
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.8
+| -
 |===
 
 Check that a consistent implicit expectation style is used.
@@ -2290,13 +2232,12 @@ it { should be_truthy }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `is_expected`
-¦ `is_expected`, `should`
+| EnforcedStyle
+| `is_expected`
+| `is_expected`, `should`
 |===
 
 === References
@@ -2306,15 +2247,14 @@ it { should be_truthy }
 
 == RSpec/ImplicitSubject
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.29
-¦ 2.13
+| Enabled
+| Yes
+| Yes
+| 1.29
+| 2.13
 |===
 
 Checks for usage of implicit subject (`is_expected` / `should`).
@@ -2396,13 +2336,12 @@ it { expect(named_subject).to be_truthy }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `single_line_only`
-¦ `single_line_only`, `single_statement_only`, `disallow`, `require_implicit`
+| EnforcedStyle
+| `single_line_only`
+| `single_line_only`, `single_statement_only`, `disallow`, `require_implicit`
 |===
 
 === References
@@ -2411,15 +2350,14 @@ it { expect(named_subject).to be_truthy }
 
 == RSpec/InstanceSpy
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.12
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.12
+| -
 |===
 
 Checks for `instance_double` used with `have_received`.
@@ -2447,15 +2385,14 @@ end
 
 == RSpec/InstanceVariable
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.0
-¦ 1.7
+| Enabled
+| Yes
+| No
+| 1.0
+| 1.7
 |===
 
 Checks for instance variable usage in specs.
@@ -2510,13 +2447,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ AssignmentOnly
-¦ `false`
-¦ Boolean
+| AssignmentOnly
+| `false`
+| Boolean
 |===
 
 === References
@@ -2526,15 +2462,14 @@ end
 
 == RSpec/ItBehavesLike
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.13
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.13
+| -
 |===
 
 Checks that only one `it_behaves_like` style is used.
@@ -2565,13 +2500,12 @@ it_should_behave_like 'a foo'
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `it_behaves_like`
-¦ `it_behaves_like`, `it_should_behave_like`
+| EnforcedStyle
+| `it_behaves_like`
+| `it_behaves_like`, `it_should_behave_like`
 |===
 
 === References
@@ -2580,15 +2514,14 @@ it_should_behave_like 'a foo'
 
 == RSpec/IteratedExpectation
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.14
-¦ -
+| Enabled
+| Yes
+| No
+| 1.14
+| -
 |===
 
 Check that `all` matcher is used instead of iterating over an array.
@@ -2614,15 +2547,14 @@ end
 
 == RSpec/LeadingSubject
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.7
-¦ 1.14
+| Enabled
+| Yes
+| Yes
+| 1.7
+| 1.14
 |===
 
 Enforce that subject is the first definition in the test.
@@ -2663,15 +2595,14 @@ it { expect_something_else }
 
 == RSpec/LeakyConstantDeclaration
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.35
-¦ -
+| Enabled
+| Yes
+| No
+| 1.35
+| -
 |===
 
 Checks that no class, module, or constant is declared.
@@ -2780,15 +2711,14 @@ end
 
 == RSpec/LetBeforeExamples
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.16
-¦ 1.22
+| Enabled
+| Yes
+| Yes
+| 1.16
+| 1.22
 |===
 
 Checks for `let` definitions that come after an example.
@@ -2829,15 +2759,14 @@ end
 
 == RSpec/LetSetup
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.7
-¦ -
+| Enabled
+| Yes
+| No
+| 1.7
+| -
 |===
 
 Checks unreferenced `let!` calls being used for test setup.
@@ -2873,15 +2802,14 @@ end
 
 == RSpec/MessageChain
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.7
-¦ -
+| Enabled
+| Yes
+| No
+| 1.7
+| -
 |===
 
 Check that chains of messages are not being stubbed.
@@ -2904,15 +2832,14 @@ allow(foo).to receive(:bar).and_return(thing)
 
 == RSpec/MessageExpectation
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Disabled
-¦ Yes
-¦ No
-¦ 1.7
-¦ 1.8
+| Disabled
+| Yes
+| No
+| 1.7
+| 1.8
 |===
 
 Checks for consistent message expectation style.
@@ -2946,13 +2873,12 @@ expect(foo).to receive(:bar)
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `allow`
-¦ `allow`, `expect`
+| EnforcedStyle
+| `allow`
+| `allow`, `expect`
 |===
 
 === References
@@ -2961,15 +2887,14 @@ expect(foo).to receive(:bar)
 
 == RSpec/MessageSpies
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.9
-¦ -
+| Enabled
+| Yes
+| No
+| 1.9
+| -
 |===
 
 Checks that message expectations are set using spies.
@@ -3009,13 +2934,12 @@ do_something
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `have_received`
-¦ `have_received`, `receive`
+| EnforcedStyle
+| `have_received`
+| `have_received`, `receive`
 |===
 
 === References
@@ -3024,15 +2948,14 @@ do_something
 
 == RSpec/MissingExampleGroupArgument
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.28
-¦ -
+| Enabled
+| Yes
+| No
+| 1.28
+| -
 |===
 
 Checks that the first argument to an example group is not empty.
@@ -3062,15 +2985,14 @@ end
 
 == RSpec/MultipleDescribes
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.0
-¦ -
+| Enabled
+| Yes
+| No
+| 1.0
+| -
 |===
 
 Checks for multiple top-level example groups.
@@ -3103,15 +3025,14 @@ end
 
 == RSpec/MultipleExpectations
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.7
-¦ 1.21
+| Enabled
+| Yes
+| No
+| 1.7
+| 1.21
 |===
 
 Checks if examples contain too many `expect` calls.
@@ -3188,13 +3109,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Max
-¦ `1`
-¦ Integer
+| Max
+| `1`
+| Integer
 |===
 
 === References
@@ -3204,15 +3124,14 @@ end
 
 == RSpec/MultipleMemoizedHelpers
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.43
-¦ -
+| Enabled
+| Yes
+| No
+| 1.43
+| -
 |===
 
 Checks if example groups contain too many `let` and `subject` calls.
@@ -3307,17 +3226,16 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ AllowSubject
-¦ `true`
-¦ Boolean
+| AllowSubject
+| `true`
+| Boolean
 
-¦ Max
-¦ `5`
-¦ Integer
+| Max
+| `5`
+| Integer
 |===
 
 === References
@@ -3327,15 +3245,14 @@ end
 
 == RSpec/MultipleSubjects
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.16
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.16
+| -
 |===
 
 Checks if an example group defines `subject` multiple times.
@@ -3393,15 +3310,14 @@ end
 
 == RSpec/NamedSubject
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.5.3
-¦ 2.15
+| Enabled
+| Yes
+| No
+| 1.5.3
+| 2.15
 |===
 
 Checks for explicitly referenced test subjects.
@@ -3490,17 +3406,16 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `always`
-¦ `always`, `named_only`
+| EnforcedStyle
+| `always`
+| `always`, `named_only`
 
-¦ IgnoreSharedExamples
-¦ `true`
-¦ Boolean
+| IgnoreSharedExamples
+| `true`
+| Boolean
 |===
 
 === References
@@ -3510,15 +3425,14 @@ end
 
 == RSpec/NestedGroups
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.7
-¦ 2.13
+| Enabled
+| Yes
+| No
+| 1.7
+| 2.13
 |===
 
 Checks for nested example groups.
@@ -3631,17 +3545,16 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Max
-¦ `3`
-¦ Integer
+| Max
+| `3`
+| Integer
 
-¦ AllowedGroups
-¦ `[]`
-¦ Array
+| AllowedGroups
+| `[]`
+| Array
 |===
 
 === References
@@ -3650,15 +3563,14 @@ end
 
 == RSpec/NoExpectationExample
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ No
-¦ No
-¦ 2.13
-¦ 2.14
+| Pending
+| No
+| No
+| 2.13
+| 2.14
 |===
 
 Checks if an example contains any expectation.
@@ -3724,13 +3636,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ AllowedPatterns
-¦ `^expect_`, `^assert_`
-¦ Array
+| AllowedPatterns
+| `^expect_`, `^assert_`
+| Array
 |===
 
 === References
@@ -3739,15 +3650,14 @@ end
 
 == RSpec/NotToNot
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.4
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.4
+| -
 |===
 
 Checks for consistent method usage for negating expectations.
@@ -3786,13 +3696,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `not_to`
-¦ `not_to`, `to_not`
+| EnforcedStyle
+| `not_to`
+| `not_to`, `to_not`
 |===
 
 === References
@@ -3801,15 +3710,14 @@ end
 
 == RSpec/OverwritingSetup
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.14
-¦ -
+| Enabled
+| Yes
+| No
+| 1.14
+| -
 |===
 
 Checks if there is a let/subject that overwrites an existing one.
@@ -3841,15 +3749,14 @@ let!(:other) { other }
 
 == RSpec/Pending
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Disabled
-¦ Yes
-¦ No
-¦ 1.25
-¦ -
+| Disabled
+| Yes
+| No
+| 1.25
+| -
 |===
 
 Checks for any pending or skipped examples.
@@ -3891,15 +3798,14 @@ end
 
 == RSpec/PredicateMatcher
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes (Unsafe)
-¦ 1.16
-¦ -
+| Enabled
+| Yes
+| Yes (Unsafe)
+| 1.16
+| -
 |===
 
 Prefer using predicate matcher over using predicate method directly.
@@ -3960,21 +3866,20 @@ expect(foo.something?).to be_truthy
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Strict
-¦ `true`
-¦ Boolean
+| Strict
+| `true`
+| Boolean
 
-¦ EnforcedStyle
-¦ `inflected`
-¦ `inflected`, `explicit`
+| EnforcedStyle
+| `inflected`
+| `inflected`, `explicit`
 
-¦ AllowedExplicitMatchers
-¦ `[]`
-¦ Array
+| AllowedExplicitMatchers
+| `[]`
+| Array
 |===
 
 === References
@@ -3984,15 +3889,14 @@ expect(foo.something?).to be_truthy
 
 == RSpec/ReceiveCounts
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.26
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.26
+| -
 |===
 
 Check for `once` and `twice` receive counts matchers usage.
@@ -4024,15 +3928,14 @@ expect(foo).to receive(:bar).at_most(:twice).times
 
 == RSpec/ReceiveNever
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.28
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.28
+| -
 |===
 
 Prefer `not_to receive(...)` over `receive(...).never`.
@@ -4054,15 +3957,14 @@ expect(foo).not_to receive(:bar)
 
 == RSpec/RepeatedDescription
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.9
-¦ -
+| Enabled
+| Yes
+| No
+| 1.9
+| -
 |===
 
 Check for repeated description strings in example groups.
@@ -4111,15 +4013,14 @@ end
 
 == RSpec/RepeatedExample
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.10
-¦ -
+| Enabled
+| Yes
+| No
+| 1.10
+| -
 |===
 
 Check for repeated examples within example groups.
@@ -4143,15 +4044,14 @@ end
 
 == RSpec/RepeatedExampleGroupBody
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.38
-¦ -
+| Enabled
+| Yes
+| No
+| 1.38
+| -
 |===
 
 Check for repeated describe and context block body.
@@ -4203,15 +4103,14 @@ end
 
 == RSpec/RepeatedExampleGroupDescription
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.38
-¦ -
+| Enabled
+| Yes
+| No
+| 1.38
+| -
 |===
 
 Check for repeated example group descriptions.
@@ -4263,15 +4162,14 @@ end
 
 == RSpec/RepeatedIncludeExample
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.44
-¦ -
+| Enabled
+| Yes
+| No
+| 1.44
+| -
 |===
 
 Check for repeated include of shared examples.
@@ -4326,15 +4224,14 @@ end
 
 == RSpec/ReturnFromStub
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.16
-¦ 1.22
+| Enabled
+| Yes
+| Yes
+| 1.16
+| 1.22
 |===
 
 Checks for consistent style of stub's return setting.
@@ -4379,13 +4276,12 @@ allow(Foo).to receive(:bar).and_return(bar.baz)
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `and_return`
-¦ `and_return`, `block`
+| EnforcedStyle
+| `and_return`
+| `and_return`, `block`
 |===
 
 === References
@@ -4394,15 +4290,14 @@ allow(Foo).to receive(:bar).and_return(bar.baz)
 
 == RSpec/ScatteredLet
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.14
-¦ 1.39
+| Enabled
+| Yes
+| Yes
+| 1.14
+| 1.39
 |===
 
 Checks for let scattered across the example group.
@@ -4438,15 +4333,14 @@ end
 
 == RSpec/ScatteredSetup
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.10
-¦ -
+| Enabled
+| Yes
+| No
+| 1.10
+| -
 |===
 
 Checks for setup scattered across multiple hooks in an example group.
@@ -4478,15 +4372,14 @@ end
 
 == RSpec/SharedContext
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.13
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.13
+| -
 |===
 
 Checks for proper shared_context and shared_examples usage.
@@ -4548,15 +4441,14 @@ end
 
 == RSpec/SharedExamples
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.25
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.25
+| -
 |===
 
 Enforces use of string to titleize shared examples.
@@ -4586,15 +4478,14 @@ include_examples 'foo bar baz'
 
 == RSpec/SingleArgumentMessageChain
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.9
-¦ 1.10
+| Enabled
+| Yes
+| Yes
+| 1.9
+| 1.10
 |===
 
 Checks that chains of messages contain more than one element.
@@ -4620,15 +4511,14 @@ allow(foo).to receive("bar.baz")
 
 == RSpec/SortMetadata
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.14
-¦ -
+| Pending
+| Yes
+| Yes
+| 2.14
+| -
 |===
 
 Sort RSpec metadata alphabetically.
@@ -4654,15 +4544,14 @@ it 'works', :a, :b, baz: true, foo: 'bar'
 
 == RSpec/StubbedMock
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.44
-¦ -
+| Enabled
+| Yes
+| No
+| 1.44
+| -
 |===
 
 Checks that message expectations do not have a configured response.
@@ -4685,15 +4574,14 @@ expect(foo).to receive(:bar).with(42)
 
 == RSpec/SubjectDeclaration
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ No
-¦ 2.5
-¦ -
+| Pending
+| Yes
+| No
+| 2.5
+| -
 |===
 
 Ensure that subject is defined using subject helper.
@@ -4722,15 +4610,14 @@ subject(:test_subject) { foo }
 
 == RSpec/SubjectStub
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.7
-¦ 2.8
+| Enabled
+| Yes
+| No
+| 1.7
+| 2.8
 |===
 
 Checks for stubbed test subjects.
@@ -4783,15 +4670,14 @@ end
 
 == RSpec/UnspecifiedException
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.30
-¦ -
+| Enabled
+| Yes
+| No
+| 1.30
+| -
 |===
 
 Checks for a specified error in checking raised errors.
@@ -4831,15 +4717,14 @@ expect { do_something }.not_to raise_error
 
 == RSpec/VariableDefinition
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.40
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.40
+| -
 |===
 
 Checks that memoized helpers names are symbols or strings.
@@ -4874,13 +4759,12 @@ let('user_name') { 'Adam' }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `symbols`
-¦ `symbols`, `strings`
+| EnforcedStyle
+| `symbols`
+| `symbols`, `strings`
 |===
 
 === References
@@ -4889,15 +4773,14 @@ let('user_name') { 'Adam' }
 
 == RSpec/VariableName
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.40
-¦ 2.13
+| Enabled
+| Yes
+| No
+| 1.40
+| 2.13
 |===
 
 Checks that memoized helper names use the configured style.
@@ -4953,17 +4836,16 @@ let(:userFood_2) { 'fettuccine' }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `snake_case`
-¦ `snake_case`, `camelCase`
+| EnforcedStyle
+| `snake_case`
+| `snake_case`, `camelCase`
 
-¦ AllowedPatterns
-¦ `[]`
-¦ Array
+| AllowedPatterns
+| `[]`
+| Array
 |===
 
 === References
@@ -4972,15 +4854,14 @@ let(:userFood_2) { 'fettuccine' }
 
 == RSpec/VerifiedDoubleReference
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes (Unsafe)
-¦ 2.10.0
-¦ 2.12
+| Pending
+| Yes
+| Yes (Unsafe)
+| 2.10.0
+| 2.12
 |===
 
 Checks for consistent verified double reference style.
@@ -5034,13 +4915,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `constant`
-¦ `constant`, `string`
+| EnforcedStyle
+| `constant`
+| `constant`, `string`
 |===
 
 === References
@@ -5049,15 +4929,14 @@ end
 
 == RSpec/VerifiedDoubles
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.2.1
-¦ 1.5
+| Enabled
+| Yes
+| No
+| 1.2.1
+| 1.5
 |===
 
 Prefer using verifying doubles over normal doubles.
@@ -5084,17 +4963,16 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ IgnoreNameless
-¦ `true`
-¦ Boolean
+| IgnoreNameless
+| `true`
+| Boolean
 
-¦ IgnoreSymbolicNames
-¦ `false`
-¦ Boolean
+| IgnoreSymbolicNames
+| `false`
+| Boolean
 |===
 
 === References
@@ -5104,15 +4982,14 @@ end
 
 == RSpec/VoidExpect
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.16
-¦ -
+| Enabled
+| Yes
+| No
+| 1.16
+| -
 |===
 
 Checks void `expect()`.
@@ -5134,15 +5011,14 @@ expect(something).to be(1)
 
 == RSpec/Yield
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.32
-¦ -
+| Enabled
+| Yes
+| Yes
+| 1.32
+| -
 |===
 
 Checks for calling a block within a stub.

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -2,15 +2,14 @@
 
 == RSpec/Capybara/CurrentPathExpectation
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.18
-¦ 2.0
+| Enabled
+| Yes
+| Yes
+| 1.18
+| 2.0
 |===
 
 Checks that no expectations are set on Capybara's `current_path`.
@@ -48,15 +47,14 @@ expect(page).to have_current_path('/callback')
 
 == RSpec/Capybara/FeatureMethods
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.17
-¦ 2.0
+| Enabled
+| Yes
+| Yes
+| 1.17
+| 2.0
 |===
 
 Checks for consistent method usage in feature specs.
@@ -102,13 +100,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnabledMethods
-¦ `[]`
-¦ Array
+| EnabledMethods
+| `[]`
+| Array
 |===
 
 === References
@@ -117,15 +114,14 @@ end
 
 == RSpec/Capybara/NegationMatcher
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.14
-¦ -
+| Pending
+| Yes
+| Yes
+| 2.14
+| -
 |===
 
 Enforces use of `have_no_*` or `not_to` for negated expectations.
@@ -160,13 +156,12 @@ expect(page).to have_no_css('a')
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `not_to`
-¦ `have_no`, `not_to`
+| EnforcedStyle
+| `not_to`
+| `have_no`, `not_to`
 |===
 
 === References
@@ -175,15 +170,14 @@ expect(page).to have_no_css('a')
 
 == RSpec/Capybara/SpecificActions
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ No
-¦ 2.14
-¦ -
+| Pending
+| Yes
+| No
+| 2.14
+| -
 |===
 
 Checks for there is a more specific actions offered by Capybara.
@@ -211,15 +205,14 @@ find('div').click_button
 
 == RSpec/Capybara/SpecificFinders
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.13
-¦ -
+| Pending
+| Yes
+| Yes
+| 2.13
+| -
 |===
 
 Checks if there is a more specific finder offered by Capybara.
@@ -243,15 +236,14 @@ find_by_id('some-id', visible: true)
 
 == RSpec/Capybara/SpecificMatcher
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ No
-¦ 2.12
-¦ -
+| Pending
+| Yes
+| No
+| 2.12
+| -
 |===
 
 Checks for there is a more specific matcher offered by Capybara.
@@ -285,15 +277,14 @@ expect(page).to have_field('foo')
 
 == RSpec/Capybara/VisibilityMatcher
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ No
-¦ 1.39
-¦ 2.0
+| Enabled
+| Yes
+| No
+| 1.39
+| 2.0
 |===
 
 Checks for boolean visibility in Capybara finders.

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -2,15 +2,14 @@
 
 == RSpec/FactoryBot/AttributeDefinedStatically
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.28
-¦ 2.0
+| Enabled
+| Yes
+| Yes
+| 1.28
+| 2.0
 |===
 
 Always declare attribute values as blocks.
@@ -40,13 +39,12 @@ count { 1 }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Include
-¦ `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
-¦ Array
+| Include
+| `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
+| Array
 |===
 
 === References
@@ -55,15 +53,14 @@ count { 1 }
 
 == RSpec/FactoryBot/ConsistentParenthesesStyle
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.14
-¦ -
+| Pending
+| Yes
+| Yes
+| 2.14
+| -
 |===
 
 Use a consistent style for parentheses in factory bot calls.
@@ -113,13 +110,12 @@ build(
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `require_parentheses`
-¦ `require_parentheses`, `omit_parentheses`
+| EnforcedStyle
+| `require_parentheses`
+| `require_parentheses`, `omit_parentheses`
 |===
 
 === References
@@ -128,15 +124,14 @@ build(
 
 == RSpec/FactoryBot/CreateList
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.25
-¦ 2.0
+| Enabled
+| Yes
+| Yes
+| 1.25
+| 2.0
 |===
 
 Checks for create_list usage.
@@ -178,17 +173,16 @@ create_list :user, 3
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Include
-¦ `+**/*_spec.rb+`, `+**/spec/**/*+`, `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
-¦ Array
+| Include
+| `+**/*_spec.rb+`, `+**/spec/**/*+`, `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
+| Array
 
-¦ EnforcedStyle
-¦ `create_list`
-¦ `create_list`, `n_times`
+| EnforcedStyle
+| `create_list`
+| `create_list`, `n_times`
 |===
 
 === References
@@ -197,15 +191,14 @@ create_list :user, 3
 
 == RSpec/FactoryBot/FactoryClassName
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.37
-¦ 2.0
+| Enabled
+| Yes
+| Yes
+| 1.37
+| 2.0
 |===
 
 Use string value when setting the class attribute explicitly.
@@ -230,13 +223,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Include
-¦ `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
-¦ Array
+| Include
+| `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
+| Array
 |===
 
 === References
@@ -245,15 +237,14 @@ end
 
 == RSpec/FactoryBot/FactoryNameStyle
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ <<next>>
-¦ -
+| Pending
+| Yes
+| Yes
+| <<next>>
+| -
 |===
 
 Checks for name style for argument of FactoryBot::Syntax::Methods.
@@ -288,13 +279,12 @@ build "user", username: "NAME"
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `symbol`
-¦ `symbol`, `string`
+| EnforcedStyle
+| `symbol`
+| `symbol`, `string`
 |===
 
 === References
@@ -303,15 +293,14 @@ build "user", username: "NAME"
 
 == RSpec/FactoryBot/SyntaxMethods
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes (Unsafe)
-¦ 2.7
-¦ -
+| Pending
+| Yes
+| Yes (Unsafe)
+| 2.7
+| -
 |===
 
 Use shorthands from `FactoryBot::Syntax::Methods` in your specs.

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -2,15 +2,14 @@
 
 == RSpec/Rails/AvoidSetupHook
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes
-¦ 2.4
-¦ -
+| Pending
+| Yes
+| Yes
+| 2.4
+| -
 |===
 
 Checks that tests use RSpec `before` hook over Rails `setup` method.
@@ -36,15 +35,14 @@ end
 
 == RSpec/Rails/HaveHttpStatus
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ Yes
-¦ Yes (Unsafe)
-¦ 2.12
-¦ -
+| Pending
+| Yes
+| Yes (Unsafe)
+| 2.12
+| -
 |===
 
 Checks that tests use `have_http_status` instead of equality matchers.
@@ -66,15 +64,14 @@ expect(response).to have_http_status(200)
 
 == RSpec/Rails/HttpStatus
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Enabled
-¦ Yes
-¦ Yes
-¦ 1.23
-¦ 2.0
+| Enabled
+| Yes
+| Yes
+| 1.23
+| 2.0
 |===
 
 Enforces use of symbolic or numeric value to describe HTTP status.
@@ -113,13 +110,12 @@ it { is_expected.to have_http_status :error }
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ EnforcedStyle
-¦ `symbolic`
-¦ `numeric`, `symbolic`
+| EnforcedStyle
+| `symbolic`
+| `numeric`, `symbolic`
 |===
 
 === References
@@ -128,15 +124,14 @@ it { is_expected.to have_http_status :error }
 
 == RSpec/Rails/InferredSpecType
 
-[separator=¦]
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-¦ Pending
-¦ No
-¦ Yes (Unsafe)
-¦ 2.14
-¦ -
+| Pending
+| No
+| Yes (Unsafe)
+| 2.14
+| -
 |===
 
 Identifies redundant spec type.
@@ -198,13 +193,12 @@ end
 
 === Configurable attributes
 
-[separator=¦]
 |===
 | Name | Default value | Configurable values
 
-¦ Inferences
-¦ `{"channels"=>"channel", "controllers"=>"controller", "features"=>"feature", "generator"=>"generator", "helpers"=>"helper", "jobs"=>"job", "mailboxes"=>"mailbox", "mailers"=>"mailer", "models"=>"model", "requests"=>"request", "integration"=>"request", "api"=>"request", "routing"=>"routing", "system"=>"system", "views"=>"view"}`
-¦ 
+| Inferences
+| `{"channels"=>"channel", "controllers"=>"controller", "features"=>"feature", "generator"=>"generator", "helpers"=>"helper", "jobs"=>"job", "mailboxes"=>"mailbox", "mailers"=>"mailer", "models"=>"model", "requests"=>"request", "integration"=>"request", "api"=>"request", "routing"=>"routing", "system"=>"system", "views"=>"view"}`
+| 
 |===
 
 === References


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop/pull/11136

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
