### PR TITLE
Fix a false positive and incorrect autocorrect for `RSpec/Capybara/SpecificActions`, `RSpec/Capybara/SpecificFinders` and `RSpec/Capybara/SpecificMatcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add new `RSpec/Rails/MinitestAssertions` cop. ([@ydah])
 - Fix a false positive for `RSpec/PendingWithoutReason` when not inside example. ([@ydah])
 - Fix a false negative for `RSpec/PredicateMatcher` when using `include` and `respond_to`. ([@ydah])
+- Fix a false positive and incorrect autocorrect for `RSpec/Capybara/SpecificActions`, `RSpec/Capybara/SpecificFinders` and `RSpec/Capybara/SpecificMatcher`. ([@ydah])
 
 ## 2.16.0 (2022-12-13)
 

--- a/lib/rubocop/cop/rspec/capybara/specific_actions.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_actions.rb
@@ -42,9 +42,7 @@ module RuboCop
               # which the last selector points.
               next unless (selector = last_selector(arg))
               next unless (action = specific_action(selector))
-              next unless CapybaraHelp.specific_option?(node.receiver, arg,
-                                                        action)
-              next unless CapybaraHelp.specific_pseudo_classes?(arg)
+              next unless replaceable?(node, arg, action)
 
               range = offense_range(node, node.receiver)
               add_offense(range, message: message(action, selector))
@@ -55,6 +53,18 @@ module RuboCop
 
           def specific_action(selector)
             SPECIFIC_ACTION[last_selector(selector)]
+          end
+
+          def replaceable?(node, arg, action)
+            replaceable_attributes?(arg) &&
+              CapybaraHelp.replaceable_option?(node.receiver, arg, action) &&
+              CapybaraHelp.replaceable_pseudo_classes?(arg)
+          end
+
+          def replaceable_attributes?(selector)
+            CapybaraHelp.replaceable_attributes?(
+              CssSelector.attributes(selector)
+            )
           end
 
           def supported_selector?(selector)

--- a/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
@@ -47,8 +47,7 @@ module RuboCop
             first_argument(node) do |arg|
               next unless (matcher = specific_matcher(arg))
               next if CssSelector.multiple_selectors?(arg)
-              next unless CapybaraHelp.specific_option?(node, arg, matcher)
-              next unless CapybaraHelp.specific_pseudo_classes?(arg)
+              next unless replaceable?(node, arg, matcher)
 
               add_offense(node, message: message(node, matcher))
             end
@@ -59,6 +58,18 @@ module RuboCop
           def specific_matcher(arg)
             splitted_arg = arg[/^\w+/, 0]
             SPECIFIC_MATCHER[splitted_arg]
+          end
+
+          def replaceable?(node, arg, matcher)
+            replaceable_attributes?(arg) &&
+              CapybaraHelp.replaceable_option?(node, arg, matcher) &&
+              CapybaraHelp.replaceable_pseudo_classes?(arg)
+          end
+
+          def replaceable_attributes?(selector)
+            CapybaraHelp.replaceable_attributes?(
+              CssSelector.attributes(selector)
+            )
           end
 
           def message(node, matcher)

--- a/lib/rubocop/cop/rspec/mixin/css_selector.rb
+++ b/lib/rubocop/cop/rspec/mixin/css_selector.rb
@@ -5,59 +5,18 @@ module RuboCop
     module RSpec
       # Helps parsing css selector.
       module CssSelector
-        COMMON_OPTIONS = %w[
-          above below left_of right_of near count minimum maximum between text
-          id class style visible obscured exact exact_text normalize_ws match
-          wait filter_set focused
-        ].freeze
-        SPECIFIC_OPTIONS = {
-          'button' => (
-            COMMON_OPTIONS + %w[disabled name value title type]
-          ).freeze,
-          'link' => (
-            COMMON_OPTIONS + %w[href alt title download]
-          ).freeze,
-          'table' => (
-            COMMON_OPTIONS + %w[
-              caption with_cols cols with_rows rows
-            ]
-          ).freeze,
-          'select' => (
-            COMMON_OPTIONS + %w[
-              disabled name placeholder options enabled_options
-              disabled_options selected with_selected multiple with_options
-            ]
-          ).freeze,
-          'field' => (
-            COMMON_OPTIONS + %w[
-              checked unchecked disabled valid name placeholder
-              validation_message readonly with type multiple
-            ]
-          ).freeze
-        }.freeze
-        SPECIFIC_PSEUDO_CLASSES = %w[
-          not() disabled enabled checked unchecked
-        ].freeze
-
         module_function
 
-        # @param element [String]
-        # @param attribute [String]
-        # @return [Boolean]
+        # @param selector [String]
+        # @return [String]
         # @example
-        #   specific_pesudo_classes?('button', 'name') # => true
-        #   specific_pesudo_classes?('link', 'invalid') # => false
-        def specific_options?(element, attribute)
-          SPECIFIC_OPTIONS.fetch(element, []).include?(attribute)
-        end
+        #   id('#some-id') # => some-id
+        #   id('.some-class') # => nil
+        #   id('#some-id.cls') # => some-id
+        def id(selector)
+          return unless id?(selector)
 
-        # @param pseudo_class [String]
-        # @return [Boolean]
-        # @example
-        #   specific_pesudo_classes?('disabled') # => true
-        #   specific_pesudo_classes?('first-of-type') # => false
-        def specific_pesudo_classes?(pseudo_class)
-          SPECIFIC_PSEUDO_CLASSES.include?(pseudo_class)
+          selector.gsub(selector.scan(/[^\\]([>,+~.].*)/).join, '')
         end
 
         # @param selector [String]
@@ -67,6 +26,17 @@ module RuboCop
         #   id?('.some-class') # => false
         def id?(selector)
           selector.start_with?('#')
+        end
+
+        # @param selector [String]
+        # @return [Array<String>]
+        # @example
+        #   classes('#some-id') # => []
+        #   classes('.some-class') # => ['some-class']
+        #   classes('#some-id.some-class') # => ['some-class']
+        #   classes('#some-id.cls1.cls2') # => ['cls1', 'cls2']
+        def classes(selector)
+          selector.scan(/.([\w-]*)/).flatten
         end
 
         # @param selector [String]
@@ -87,19 +57,9 @@ module RuboCop
         def attributes(selector)
           selector.scan(/\[(.*?)\]/).flatten.to_h do |attr|
             key, value = attr.split('=')
+            value << ']' if value&.include?('[')
             [key, normalize_value(value)]
           end
-        end
-
-        # @param selector [String]
-        # @return [Boolean]
-        # @example
-        #   common_attributes?('a[focused]') # => true
-        #   common_attributes?('button[focused][visible]') # => true
-        #   common_attributes?('table[id=some-id]') # => true
-        #   common_attributes?('h1[invalid]') # => false
-        def common_attributes?(selector)
-          attributes(selector).keys.difference(COMMON_OPTIONS).none?
         end
 
         # @param selector [String]
@@ -122,7 +82,8 @@ module RuboCop
         #   multiple_selectors?('a.cls b#id') # => true
         #   multiple_selectors?('a.cls') # => false
         def multiple_selectors?(selector)
-          selector.match?(/[ >,+~]/)
+          normalize = selector.gsub(/(\\[>,+~]|\(.*\))/, '')
+          normalize.match?(/[ >,+~]/)
         end
 
         # @param value [String]
@@ -130,14 +91,14 @@ module RuboCop
         # @example
         #   normalize_value('true') # => true
         #   normalize_value('false') # => false
-        #   normalize_value(nil) # => false
+        #   normalize_value(nil) # => nil
         #   normalize_value("foo") # => "'foo'"
         def normalize_value(value)
           case value
           when 'true' then true
           when 'false' then false
-          when nil then true
-          else "'#{value}'"
+          when nil then nil
+          else "'#{value.gsub(/["']/, '')}'"
           end
         end
       end

--- a/spec/rubocop/cop/rspec/capybara/specific_finders_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_finders_spec.rb
@@ -23,6 +23,87 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
     RUBY
   end
 
+  it 'registers an offense when using `find` with id and class' do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: 'some-cls')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with id include `\.`' do
+    expect_offense(<<~RUBY)
+      find('#some-id\\.some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('#some-id\\>some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('#some-id\\,some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('#some-id\\+some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('#some-id\\~some-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id.some-cls')
+      find_by_id('some-id>some-cls')
+      find_by_id('some-id,some-cls')
+      find_by_id('some-id+some-cls')
+      find_by_id('some-id~some-cls')
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with multiple classes' do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls.other-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: ["some-cls", "other-cls"])
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with multiple classes ' \
+     "and class: 'other-cls'" do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls', class: 'other-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: ["some-cls", "other-cls"])
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with multiple classes ' \
+     "and class: ['other-cls1', 'other-cls2']" do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls', class: ['other-cls1', 'other-cls2'])
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', class: ["some-cls", "other-cls1", "other-cls2"])
+    RUBY
+  end
+
+  it 'registers an offense when using `find` with multiple classes ' \
+     "and exact_text: 'foo', class: 'other-cls'" do
+    expect_offense(<<~RUBY)
+      find('#some-id.some-cls', exact_text: 'foo', class: 'other-cls')
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('some-id', exact_text: 'foo', class: ["some-cls", "other-cls"])
+    RUBY
+  end
+
   it 'registers an offense when using `find` and other args' do
     expect_offense(<<~RUBY)
       find('#some-id', exact_text: 'foo')
@@ -64,24 +145,42 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
     expect_offense(<<~RUBY)
       find('[id=some-id]')
       ^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
-      find('[visible][id=some-id]')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
-      find('[id=some-id][class=some-cls][focused]')
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
     RUBY
 
     expect_correction(<<~RUBY)
       find_by_id('some-id')
-      find_by_id('some-id', visible: true)
-      find_by_id('some-id', class: 'some-cls', focused: true)
+    RUBY
+  end
+
+  it 'registers an offense when using `find ' \
+     'with argument is attribute specified id surrounded by quotation' do
+    expect_offense(<<~RUBY)
+      find('[id="foo"]')
+      ^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+      find('[id="foo[bar]"]')
+      ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `find_by` over `find`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      find_by_id('foo')
+      find_by_id('foo[bar]')
     RUBY
   end
 
   it 'does not register an offense when using `find ' \
      'with argument is attribute not specified id' do
     expect_no_offenses(<<~RUBY)
-      find('[visible]')
-      find('[class=some-cls][visible]')
+      find('[id]')
+      find('[disabled=true]')
+      find('[class=some-cls][disabled]')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find ' \
+     'with argument is attribute specified id and class' do
+    expect_no_offenses(<<~RUBY)
+      find('[class=some-cls][id=some-id]')
+      find('[id=some-id][disabled][class=some-cls]')
     RUBY
   end
 
@@ -120,6 +219,23 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificFinders, :config do
       find('#some-id>h1')
       find('#some-id,h2')
       find('#some-id+option')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find` ' \
+     'with id and attribute' do
+    expect_no_offenses(<<~RUBY)
+      find('#foo[hidden]')
+      find('#foo[class="some-cls"]')
+    RUBY
+  end
+
+  it 'does not register an offense when using `find` ' \
+     'with id and pseudo class' do
+    expect_no_offenses(<<~RUBY)
+      find('#foo:enabled')
+      find('#foo:not(:disabled)')
+      find('#foo:is(:enabled,:checked)')
     RUBY
   end
 end

--- a/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/specific_matcher_spec.rb
@@ -78,25 +78,18 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
     RUBY
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set focused disabled name value
-     title type].each do |attr|
+  %i[id class style disabled name value title type].each do |attr|
     it 'registers an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_button`' do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("button[#{attr}=foo]")
                         ^^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_button` over `have_css`.
-        expect(page).to have_css("button[#{attr}]")
-                        ^^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_button` over `have_css`.
       RUBY
     end
   end
 
-  %i[above below left_of right_of near count minimum maximum between text id
-     class style visible obscured exact exact_text normalize_ws match wait
-     filter_set focused alt title download].each do |attr|
+  %i[id class style alt title download].each do |attr|
     it 'does not register an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_link` without `href`' do
@@ -111,10 +104,8 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_link` with attribute `href`' do
       expect_offense(<<-RUBY, attr: attr)
-        expect(page).to have_css("a[#{attr}=foo][href]")
-                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
-        expect(page).to have_css("a[#{attr}][href='http://example.com']")
-                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+        expect(page).to have_css("a[#{attr}=foo][href='http://example.com']")
+                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
       RUBY
     end
 
@@ -124,8 +115,8 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("a[#{attr}=foo]", href: 'http://example.com')
                         ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
-        expect(page).to have_css("a[#{attr}]", text: 'foo', href: 'http://example.com')
-                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
+        expect(page).to have_css("a[#{attr}=foo]", text: 'foo', href: 'http://example.com')
+                        ^^^^^^^^^^^^^{attr}^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
       RUBY
     end
   end
@@ -134,58 +125,40 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
      'first argument is element with replaceable attributes href ' \
      'for `have_link`' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css("a[href]")
-                      ^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
       expect(page).to have_css("a[href='http://example.com']")
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_link` over `have_css`.
     RUBY
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set focused caption with_cols cols with_rows
-     rows].each do |attr|
+  %i[id class style cols rows].each do |attr|
     it 'registers an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_table`' do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("table[#{attr}=foo]")
                         ^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_table` over `have_css`.
-        expect(page).to have_css("table[#{attr}]")
-                        ^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_table` over `have_css`.
       RUBY
     end
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set focused disabled name placeholder options
-     enabled_options disabled_options selected with_selected
-     multiple with_options].each do |attr|
+  %i[id class style disabled name placeholder selected multiple].each do |attr|
     it 'registers an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_select`' do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("select[#{attr}=foo]")
                         ^^^^^^^^^^^^^^^^^^{attr}^^^^^^^ Prefer `have_select` over `have_css`.
-        expect(page).to have_css("select[#{attr}]")
-                        ^^^^^^^^^^^^^^^^^^{attr}^^^ Prefer `have_select` over `have_css`.
       RUBY
     end
   end
 
-  %i[above below left_of right_of near count minimum maximum between
-     text id class style visible obscured exact exact_text normalize_ws
-     match wait filter_set checked unchecked disabled valid name
-     placeholder validation_message ].each do |attr|
+  %i[id class style checked disabled name placeholder].each do |attr|
     it 'registers an offense for abstract matcher when ' \
        "first argument is element with replaceable attributes #{attr} " \
        'for `have_field`' do
       expect_offense(<<-RUBY, attr: attr)
         expect(page).to have_css("input[#{attr}=foo]")
                         ^^^^^^^^^^^^^^^^^^{attr}^^^^^^ Prefer `have_field` over `have_css`.
-        expect(page).to have_css("input[#{attr}]")
-                        ^^^^^^^^^^^^^^^^^^{attr}^^ Prefer `have_field` over `have_css`.
       RUBY
     end
   end
@@ -193,43 +166,41 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   it 'registers an offense when using abstract matcher with ' \
      'first argument is element with multiple replaceable attributes' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('button[disabled][name="foo"]', exact_text: 'foo')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button[disabled=true][name="foo"]', exact_text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher with state' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('button[disabled]', exact_text: 'foo')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button[disabled=true]', exact_text: 'foo')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher with ' \
      'first argument is element with replaceable pseudo-classes' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('button:not([disabled])', exact_text: 'bar')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
-      expect(page).to have_css('button:not([disabled][visible])')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([disabled=true])', exact_text: 'bar')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
     RUBY
   end
 
   it 'registers an offense when using abstract matcher with ' \
      'first argument is element with multiple replaceable pseudo-classes' do
     expect_offense(<<-RUBY)
-      expect(page).to have_css('button:not([disabled]):enabled')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('button:not([disabled=true]):enabled')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
       expect(page).to have_css('button:not([disabled=false]):disabled')
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
-      expect(page).to have_css('button:not([disabled]):not([disabled])')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
-      expect(page).to have_css('input:not([unchecked]):checked')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
-      expect(page).to have_css('input:not([unchecked=false]):unchecked')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
-      expect(page).to have_css('input:not([unchecked]):not([unchecked])')
-                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+      expect(page).to have_css('button:not([disabled=true]):not([disabled=true])')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_button` over `have_css`.
+      expect(page).to have_css('input:not([checked=false]):checked')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+      expect(page).to have_css('input:not([checked=false]):unchecked')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
+      expect(page).to have_css('input:not([checked=true]):not([checked=true])')
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `have_field` over `have_css`.
     RUBY
   end
 
@@ -251,6 +222,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   it 'does not register an offense for abstract matcher when ' \
      'first argument is element with nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
+      expect(page).to have_css('button[disabled]')
       expect(page).to have_css('button[data-disabled]')
       expect(page).to have_css('button[foo=bar]')
       expect(page).to have_css('button[foo-bar=baz]', exact_text: 'foo')
@@ -260,10 +232,10 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::SpecificMatcher do
   it 'does not register an offense for abstract matcher when ' \
      'first argument is element with multiple nonreplaceable attributes' do
     expect_no_offenses(<<-RUBY)
-      expect(page).to have_css('button[disabled][foo]')
-      expect(page).to have_css('button[foo][disabled]')
-      expect(page).to have_css('button[foo][disabled][bar]')
-      expect(page).to have_css('button[disabled][foo=bar]')
+      expect(page).to have_css('button[disabled=true][foo]')
+      expect(page).to have_css('button[foo][disabled=true]')
+      expect(page).to have_css('button[foo][disabled=true][bar]')
+      expect(page).to have_css('button[disabled=true][foo=bar]')
       expect(page).to have_css('button[disabled=foo][bar]', exact_text: 'foo')
     RUBY
   end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-capybara/issues/4

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
