### PR TITLE
Fix a false positive for `RSpec/FactoryBot/ConsistentParenthesesStyle` when using `generate` with multiple arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add new `RSpec/FactoryBot/FactoryNameStyle` cop. ([@ydah])
 - Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`. ([@r7kamura])
+- Fix a false positive for `RSpec/FactoryBot/ConsistentParenthesesStyle` when using `generate` with multiple arguments. ([@ydah])
 
 ## 2.15.0 (2022-11-03)
 

--- a/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
@@ -69,6 +69,8 @@ module RuboCop
             return if ambiguous_without_parentheses?(node)
 
             factory_call(node) do
+              return if node.method?(:generate) && node.arguments.count > 1
+
               if node.parenthesized?
                 process_with_parentheses(node)
               else

--- a/spec/rubocop/cop/rspec/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/consistent_parentheses_style_spec.rb
@@ -148,6 +148,14 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::ConsistentParenthesesStyle do
         create foo: :bar
       RUBY
     end
+
+    it 'dose not register an offense when using `generate` ' \
+       'with not a one argument' do
+      expect_no_offenses(<<~RUBY)
+        generate
+        generate :foo, :bar
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is :omit_parentheses' do
@@ -364,6 +372,14 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::ConsistentParenthesesStyle do
       expect_no_offenses(<<~RUBY)
         create()
         create(foo: :bar)
+      RUBY
+    end
+
+    it 'dose not register an offense when using `generate` ' \
+       'with not a one argument' do
+      expect_no_offenses(<<~RUBY)
+        generate()
+        generate(:foo, :bar)
       RUBY
     end
   end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1480

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).