### PR TITLE
Mark `RSpec/BeEq` as `Safe: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new `RSpec/FactoryBot/FactoryNameStyle` cop. ([@ydah])
 - Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`. ([@r7kamura])
 - Fix a false positive for `RSpec/FactoryBot/ConsistentParenthesesStyle` when using `generate` with multiple arguments. ([@ydah])
+- Mark `RSpec/BeEq` as `Safe: false` ([@r7kamura])
 
 ## 2.15.0 (2022-11-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -147,7 +147,9 @@ RSpec/Be:
 RSpec/BeEq:
   Description: Check for expectations where `be(...)` can replace `eq(...)`.
   Enabled: pending
+  Safe: false
   VersionAdded: 2.9.0
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEq
 
 RSpec/BeEql:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -192,10 +192,10 @@ expect(foo).to be(true)
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
 | Pending
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 2.9.0
-| -
+| <<next>>
 |===
 
 Check for expectations where `be(...)` can replace `eq(...)`.
@@ -203,6 +203,10 @@ Check for expectations where `be(...)` can replace `eq(...)`.
 The `be` matcher compares by identity while the `eq` matcher compares
 using `==`. Booleans and nil can be compared by identity and therefore
 the `be` matcher is preferable as it is a more strict test.
+
+=== Safety
+
+This cop is unsafe because it changes how values are compared.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/be_eq.rb
+++ b/lib/rubocop/cop/rspec/be_eq.rb
@@ -9,6 +9,9 @@ module RuboCop
       # using `==`. Booleans and nil can be compared by identity and therefore
       # the `be` matcher is preferable as it is a more strict test.
       #
+      # @safety
+      #   This cop is unsafe because it changes how values are compared.
+      #
       # @example
       #   # bad
       #   expect(foo).to eq(true)


### PR DESCRIPTION
I tried autocorrecting `expect(value).to eq true` to `expect(value).to be true` in my Rails app and the tests result in failure. When I looked into the cause of this, I noticed that this `Value#==` has a slightly special implementation.

~~So I think it is better to mark this as an unsafe autocorrection, since it could change the test result.~~
After discussion, I thought that it is appropriate to set `Safe: false`.

What do you think?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

- [x] Set `VersionChanged` in `config/default.yml` to the next major version.
    - wait... I certainly changed the existing cop's configuration, but should I really set this to the next major version?
