### PR TITLE
Change the `rake newcop` task to output `<<next>>` instead of the next minor version for config/default.yml

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -74,14 +74,7 @@ task :new_cop, [:cop] do |_task, args|
   generator.write_source
   generator.write_spec
   generator.inject_require(root_file_path: 'lib/rubocop/cop/rspec_cops.rb')
-  generator.inject_config(config_file_path: 'config/default.yml',
-                          version_added: bump_minor_version)
+  generator.inject_config
 
   puts generator.todo
-end
-
-def bump_minor_version
-  major, minor, _patch = RuboCop::RSpec::Version::STRING.split('.')
-
-  "#{major}.#{minor.succ}.0"
 end


### PR DESCRIPTION
Ref: https://github.com/rubocop/rubocop-rspec/pull/1489#discussion_r1025488243

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
