### PR TITLE
Explain to use `<<next>>` in the Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,8 +18,8 @@ If you have created a new cop:
 - [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
 - [ ] The cop documents examples of good and bad code.
 - [ ] The tests assert both that bad code is reported and that good code is not reported.
-- [ ] Set `VersionAdded` in `default/config.yml` to the next minor version.
+- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.
 
 If you have modified an existing cop's configuration options:
 
-- [ ] Set `VersionChanged` in `config/default.yml` to the next major version.
+- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.


### PR DESCRIPTION
In response to the following review comment that `<<next>>` should be used, I thought it would be better to explain it in the Pull Request template.

- https://github.com/rubocop/rubocop-rspec/pull/1365#discussion_r992795329

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
