### PR TITLE
Mark `RSpec/BeEql` as `Safe: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix a false positive for `RSpec/FactoryBot/ConsistentParenthesesStyle` when using `generate` with multiple arguments. ([@ydah])
 - Mark `RSpec/BeEq` as `Safe: false` ([@r7kamura])
 - Add `RSpec/DuplicatedMetadata` cop. ([@r7kamura])
+- Mark `RSpec/BeEql` as `Safe: false`. ([@r7kamura])
 
 ## 2.15.0 (2022-11-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -155,7 +155,9 @@ RSpec/BeEq:
 RSpec/BeEql:
   Description: Check for expectations where `be(...)` can replace `eql(...)`.
   Enabled: true
+  Safe: false
   VersionAdded: '1.7'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEql
 
 RSpec/BeNil:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -233,10 +233,10 @@ expect(foo).to be(nil)
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
 | Enabled
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 1.7
-| -
+| <<next>>
 |===
 
 Check for expectations where `be(...)` can replace `eql(...)`.
@@ -252,6 +252,10 @@ than `!equal?`. We also do not try to flag `eq` because if
 `a == b`, and `b` is comparable by identity, `a` is still not
 necessarily the same type as `b` since the `#==` operator can
 coerce objects for comparison.
+
+=== Safety
+
+This cop is unsafe because it changes how values are compared.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -10,6 +10,9 @@ module RuboCop
       # can be compared by identity and therefore the `be` matcher is
       # preferable as it is a more strict test.
       #
+      # @safety
+      #   This cop is unsafe because it changes how values are compared.
+      #
       # @example
       #   # bad
       #   expect(foo).to eql(1)


### PR DESCRIPTION
I believe `RSpec/BeEql` should be marked as `Safe: false` for the same reason as `RSpec/Be`.

- https://github.com/rubocop/rubocop-rspec/pull/1490
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
