### PR TITLE
Remove unnecessary `only: true`

### DIFF
--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing, only: true do
+RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
   it 'ignores non-example blocks' do
     expect_no_offenses('foo "should do something" do; end')
   end


### PR DESCRIPTION
Perhaps this `only: true` is unnecessary and has just got mixed in, so removed it.

- https://github.com/rubocop/rubocop-rspec/pull/1497#pullrequestreview-1192132522

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
