### PR TITLE
Workaround issue with CI failing with jruby-9.4.0.0

### DIFF
--- a/lib/rubocop/rspec/align_let_brace.rb
+++ b/lib/rubocop/rspec/align_let_brace.rb
@@ -33,21 +33,25 @@ module RuboCop
       end
 
       def let_group_for(let)
-        adjacent_let_chunks.detect do |chunk|
+        chunked_let_array.detect do |chunk|
           chunk.any? do |member|
             member == let && same_line?(member, let)
           end
         end
       end
 
-      def adjacent_let_chunks
+      def chunked_let_array
+        chunked_let.map { |_, array| array }
+      end
+
+      def chunked_let
         last_line = nil
 
         single_line_lets.chunk do |node|
-          line      = node.loc.line
+          line = node.loc.line
           last_line = (line if last_line.nil? || last_line + 1 == line)
           last_line.nil?
-        end.map(&:last)
+        end
       end
 
       def single_line_lets


### PR DESCRIPTION
This PR is workaround issue with CI failing with jruby-9.4.0.0

The following CI failed:
https://github.com/rubocop/rubocop-rspec/actions/runs/3537497262/jobs/5937517666#logs

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).