### PR TITLE
Fix false positive ExampleLength offense when skipping/pending a group example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/ExampleLength` when using `pending` and `skip` on example group. ([@morissetcl])
 - Add new `RSpec/FactoryBot/FactoryNameStyle` cop. ([@ydah])
 - Improved processing speed for `RSpec/Be`, `RSpec/ExpectActual`, `RSpec/ImplicitExpect`, `RSpec/MessageSpies`, `RSpec/PredicateMatcher` and `RSpec/Rails/HaveHttpStatus`. ([@ydah])
 - Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`. ([@r7kamura])

--- a/config/default.yml
+++ b/config/default.yml
@@ -19,6 +19,7 @@ RSpec:
           - Regular
           - Skipped
           - Focused
+          - Pending
       Regular:
         - describe
         - context
@@ -28,10 +29,13 @@ RSpec:
         - xdescribe
         - xcontext
         - xfeature
+        - skip
       Focused:
         - fdescribe
         - fcontext
         - ffeature
+      Pending:
+        - pending
     Examples:
       inherit_mode:
         merge:

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -54,8 +54,7 @@ module RuboCop
         LABEL = 'Example'
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless example?(node)
-
+          return unless example?(node) && !example_group?(node)
           check_code_length(node)
         end
 

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -72,7 +72,8 @@ module RuboCop
           def all(element)
             regular(element) ||
               skipped(element) ||
-              focused(element)
+              focused(element) ||
+              pending(element)
           end
 
           def regular(element)
@@ -85,6 +86,10 @@ module RuboCop
 
           def skipped(element)
             Language.config['ExampleGroups']['Skipped'].include?(element.to_s)
+          end
+
+          def pending(element)
+            Language.config['ExampleGroups']['Pending'].include?(element.to_s)
           end
         end
       end

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -56,6 +56,36 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
     end
   end
 
+  context 'given skipped nested examples' do
+    it 'does not flag the example' do
+      expect_no_offenses(<<-RUBY)
+        skip do
+          line 1
+          it do
+            line 1
+            line 2
+            line 3
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'given pending nested examples' do
+    it 'does not flag the example' do
+      expect_no_offenses(<<-RUBY)
+        pending do
+          line 1
+          it do
+            line 1
+            line 2
+            line 3
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'with CountComments enabled' do
     let(:cop_config) do
       { 'Max' => 3, 'CountComments' => true }


### PR DESCRIPTION
The `ExampleLength` raise a false positive offense when using `pending` or `skip` on example group.

Example:

```
# Cop config => { "Max": 4 }

pending "#total_count" do
  let(:store) { create(:parkstoreing) }

  it "returns the number of eligible car" do
    create(:car, :qualified)
    create(:car, :disqualified)
    create(:car, :test)
    expect(subject.total_count).to eq(1)
  end
 end
 
 => RSpec/ExampleLength: Example has too many lines. [7/4]
  pending "#total_count" do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^
```

Whereas using regular example group (eg: `describe`) does not raise an offense.

This PR is a proposal to fix this behaviour by excluding node example group from the `check_code_length` method.

Let me know!
Thanks.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [X] Added tests.
- [x] Updated documentation.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
