### PR TITLE
Add autocorrect support for `RSpec/ScatteredSetup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Mark `RSpec/BeEq` as `Safe: false` ([@r7kamura])
 - Add `RSpec/DuplicatedMetadata` cop. ([@r7kamura])
 - Mark `RSpec/BeEql` as `Safe: false`. ([@r7kamura])
+- Add autocorrect support for `RSpec/ScatteredSetup`. ([@r7kamura])
 
 ## 2.15.0 (2022-11-03)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -751,7 +751,9 @@ RSpec/ScatteredLet:
 RSpec/ScatteredSetup:
   Description: Checks for setup scattered across multiple hooks in an example group.
   Enabled: true
+  SafeAutoCorrect: false
   VersionAdded: '1.10'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredSetup
 
 RSpec/SharedContext:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4375,14 +4375,23 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes (Unsafe)
 | 1.10
-| -
+| <<next>>
 |===
 
 Checks for setup scattered across multiple hooks in an example group.
 
 Unify `before`, `after`, and `around` hooks when possible.
+
+Autocorrection is not supported when `around` is used because it can
+be difficult to unify them.
+
+=== Safety
+
+This cop's autocorrection is unsafe because it could change the order
+of processing if there is another hook between them.
+(e.g. `let!` between `before`s)
 
 === Examples
 

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -2,42 +2,65 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   it 'flags multiple hooks in the same example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         before { bar }
-        ^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 3).
         before { baz }
         ^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        before { bar
+
+      baz }
       end
     RUBY
   end
 
   it 'flags multiple hooks of the same scope with different symbols' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         after { bar }
-        ^^^^^^^^^^^^^ Do not define multiple `after` hooks in the same example group (also defined on lines 3, 4).
         after(:each) { baz }
-        ^^^^^^^^^^^^^^^^^^^^ Do not define multiple `after` hooks in the same example group (also defined on lines 2, 4).
+        ^^^^^^^^^^^^^^^^^^^^ Do not define multiple `after` hooks in the same example group (also defined on line 2).
         after(:example) { baz }
-        ^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `after` hooks in the same example group (also defined on lines 2, 3).
+        ^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `after` hooks in the same example group (also defined on line 2).
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        after { bar
+
+      baz
+
+      baz }
       end
     RUBY
   end
 
   it 'flags multiple before(:all) hooks in the same example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         before(:all) { bar }
-        ^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 3).
         before(:all) { baz }
         ^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        before(:all) { bar
+
+      baz }
       end
     RUBY
   end
 
   it 'ignores different hooks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before { bar }
         after { baz }
@@ -47,7 +70,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores different hook types' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before { bar }
         before(:all) { baz }
@@ -57,7 +80,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores hooks in different example groups' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before { bar }
 
@@ -69,7 +92,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores hooks in different shared contexts' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         shared_context 'one' do
           before { bar }
@@ -83,7 +106,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores similar method names inside of examples' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before { bar }
 
@@ -95,7 +118,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores hooks with different metadata' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before(:example) { foo }
         before(:example, :special_case) { bar }
@@ -104,18 +127,75 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'flags hooks with similar metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         before(:each, :special_case) { foo }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on lines 3, 4, 5).
         before(:example, :special_case) { bar }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on lines 2, 4, 5).
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
         before(:example, special_case: true) { bar }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on lines 2, 3, 5).
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
         before(special_case: true) { bar }
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on lines 2, 3, 4).
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
         before(:example, special_case: false) { bar }
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        before(:each, :special_case) { foo
+
+      bar
+
+      bar
+
+      bar }
+        before(:example, special_case: false) { bar }
+      end
+    RUBY
+  end
+
+  context 'with multiple `around`' do
+    it 'registers offense without autocorrection' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          around do |example|
+            a
+            example.run
+            b
+          end
+
+          around do |example|
+          ^^^^^^^^^^^^^^^^^^^ Do not define multiple `around` hooks in the same example group (also defined on line 2).
+            c
+            example.run
+            d
+          end
+        end
+      RUBY
+
+      expect_no_corrections
+    end
+  end
+
+  context 'with `let!` between multiple `before`' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          before { a }
+          let!(:b) { 1 }
+          before { c }
+          ^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        describe Foo do
+          before { a
+
+        c }
+          let!(:b) { 1 }
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
I think autocorrection on this cop could be achieved by merging the contents of the two `before` (or `after`) with a blank line.

```ruby
# bad
describe Foo do
  before { setup1 }
  before { setup2 }
end

# good
describe Foo do
  before do
    setup1
    setup2
  end
end
```

Since this Cop often reports offenses when introducing rubocop-rspec, it would be nice to support autocorrection on this cop, even though it is unsafe.

Note that in supporting autocorrection, I have also made changes to the way offenses are reported. When multiple same hooks are written, all of them used to be considered as offenses. However, when implementing autocorrection this was inconvenient, so only the second and later defined hooks are now considered offenses. Given the way other similar Cop offenses are reported, I believe this is an acceptable change.

```ruby
# before
before { bar }
^^^^^^^^^^^^^^ Do not define...
before { baz }
^^^^^^^^^^^^^^ Do not define...
```

```ruby
# after
before { bar }
before { baz }
^^^^^^^^^^^^^^ Do not define...
```

This autocorrection gives little consideration to line breaks and spaces because it's not this cop's business, but I believe that this will not be a problem since they will be autocorrected at the same time by other Layout cops.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
