### PR TITLE
CI: Test with JRuby 9.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
           - "3.0"
           - "3.1"
           - ruby-head
-          - jruby
+          - jruby-9.3
         task:
           - internal_investigation
           - spec


### PR DESCRIPTION
[JRuby 9.4 tests seem to be failing](https://github.com/rubocop/rubocop-rspec/actions/runs/3581363029/jobs/6024338728). RuboCop itself is tested only with JRuby 9.3.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
