### PR TITLE
Fix 'sorts configuration keys alphabetically' spec

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -366,12 +366,6 @@ RSpec/ExampleWithoutDescription:
   VersionAdded: '1.22'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWithoutDescription
 
-RSpec/ExcessiveDocstringSpacing:
-  Description: Checks for excessive whitespace in example descriptions.
-  Enabled: pending
-  VersionAdded: '2.5'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExcessiveDocstringSpacing
-
 RSpec/ExampleWording:
   Description: Checks for common mistakes in example descriptions.
   Enabled: true
@@ -387,6 +381,12 @@ RSpec/ExampleWording:
   VersionChanged: '2.13'
   StyleGuide: https://rspec.rubystyle.guide/#should-in-example-docstrings
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
+
+RSpec/ExcessiveDocstringSpacing:
+  Description: Checks for excessive whitespace in example descriptions.
+  Enabled: pending
+  VersionAdded: '2.5'
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExcessiveDocstringSpacing
 
 RSpec/ExpectActual:
   Description: Checks for `expect(...)` calls containing literal values.
@@ -1005,6 +1005,17 @@ RSpec/Rails/HaveHttpStatus:
   VersionAdded: '2.12'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HaveHttpStatus
 
+RSpec/Rails/HttpStatus:
+  Description: Enforces use of symbolic or numeric value to describe HTTP status.
+  Enabled: true
+  EnforcedStyle: symbolic
+  SupportedStyles:
+    - numeric
+    - symbolic
+  VersionAdded: '1.23'
+  VersionChanged: '2.0'
+  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus
+
 RSpec/Rails/InferredSpecType:
   Description: Identifies redundant spec type.
   Enabled: pending
@@ -1027,14 +1038,3 @@ RSpec/Rails/InferredSpecType:
     routing: routing
     system: system
     views: view
-
-RSpec/Rails/HttpStatus:
-  Description: Enforces use of symbolic or numeric value to describe HTTP status.
-  Enabled: true
-  EnforcedStyle: symbolic
-  SupportedStyles:
-    - numeric
-    - symbolic
-  VersionAdded: '1.23'
-  VersionChanged: '2.0'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/HttpStatus

--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'config/default.yml' do
   end
 
   let(:config_keys) do
-    cop_names + %w[RSpec RSpec/Capybara RSpec/FactoryBot RSpec/Rails]
+    cop_names + namespaces.values
   end
 
   def cop_configuration(config_key)
@@ -47,13 +47,19 @@ RSpec.describe 'config/default.yml' do
       .to match_array([*config_keys, 'Metrics/BlockLength'])
   end
 
-  it 'sorts configuration keys alphabetically', :pending do
-    namespaces.each do |_path, prefix|
-      expected = config_keys.select { |key| key.start_with?(prefix) }.sort
-      actual = default_config.keys.select { |key| key.start_with?(prefix) }
-      actual.each_with_index do |key, idx|
-        expect(key).to eq expected[idx]
-      end
+  it 'sorts configuration keys alphabetically with nested namespaces last' do
+    rspec_keys = default_config.keys.select { |key| key.start_with?('RSpec') }
+    namespaced_rspec_keys = rspec_keys.select do |key|
+      key.start_with?(*(namespaces.values - ['RSpec']))
+    end
+
+    expected = rspec_keys.sort_by do |key|
+      namespaced = namespaced_rspec_keys.include?(key) ? 1 : 0
+      "#{namespaced} #{key}"
+    end
+
+    rspec_keys.each_with_index do |key, idx|
+      expect(key).to eq expected[idx]
     end
   end
 


### PR DESCRIPTION
The spec now checks that our config file 'sorts configuration keys alphabetically with nested namespaces last'.