### PR TITLE
Fix wrong cop name in example code on `RSpec/Rails/InferredSpecType`

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -171,7 +171,7 @@ end
 [source,ruby]
 ----
 # .rubocop.yml
-# RSpec/InferredSpecType:
+# RSpec/Rails/InferredSpecType:
 #   Inferences:
 #     services: service
 

--- a/lib/rubocop/cop/rspec/rails/inferred_spec_type.rb
+++ b/lib/rubocop/cop/rspec/rails/inferred_spec_type.rb
@@ -33,7 +33,7 @@ module RuboCop
         #
         # @example `Inferences` configuration
         #   # .rubocop.yml
-        #   # RSpec/InferredSpecType:
+        #   # RSpec/Rails/InferredSpecType:
         #   #   Inferences:
         #   #     services: service
         #


### PR DESCRIPTION
Cop name in the example code was incorrect by mistake.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
