### PR TITLE
Fix test failure on rubocop 1.40.0

### DIFF
--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -232,6 +232,8 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
   end
 
   it 'does not register offense for absolute file path' do
+    # RuboCop's Commissioner is calling it, too
+    allow(File).to receive(:expand_path).and_call_original
     allow(File).to receive(:expand_path).with('my_class_spec.rb').and_return(
       '/home/foo/spec/very/long/namespace/my_class_spec.rb'
     )


### PR DESCRIPTION
Perhaps the following change is the cause.

- https://github.com/rubocop/rubocop/pull/11247

I ran into this failure at the following Pull Request:

- https://github.com/rubocop/rubocop-rspec/pull/1509
- https://github.com/rubocop/rubocop-rspec/actions/runs/3652710709/jobs/6171400421
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
