### PR TITLE
Use non-RSpec Base cop where possible

### DIFF
--- a/bin/build_config
+++ b/bin/build_config
@@ -20,7 +20,8 @@ rspec_cop_path = File.join('lib', 'rubocop', 'cop', 'rspec', 'base.rb')
 YARD::Tags::Library.define_tag('Cop Safety Information', :safety)
 YARD.parse(Dir[glob].prepend(rspec_cop_path), [])
 
-descriptions = RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all).to_h
+descriptions =
+  RuboCop::RSpec::DescriptionExtractor.new(YARD::Registry.all(:class)).to_h
 current_config = if Psych::VERSION >= '4.0.0' # RUBY_VERSION >= '3.1.0'
                    YAML.unsafe_load_file('config/default.yml')
                  else

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -47,14 +47,14 @@ module RuboCop
           # @!method as_is_matcher(node)
           def_node_matcher :as_is_matcher, <<-PATTERN
             (send
-              #expectation_set_on_current_path $#Runners.all
+              #expectation_set_on_current_path ${:to :to_not :not_to}
               ${(send nil? :eq ...) (send nil? :match (regexp ...))})
           PATTERN
 
           # @!method regexp_str_matcher(node)
           def_node_matcher :regexp_str_matcher, <<-PATTERN
             (send
-              #expectation_set_on_current_path $#Runners.all
+              #expectation_set_on_current_path ${:to :to_not :not_to}
               $(send nil? :match (str $_)))
           PATTERN
 

--- a/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
+++ b/lib/rubocop/cop/rspec/capybara/current_path_expectation.rb
@@ -29,7 +29,7 @@ module RuboCop
         #   # good
         #   expect(page).to have_current_path('/callback')
         #
-        class CurrentPathExpectation < Base
+        class CurrentPathExpectation < ::RuboCop::Cop::Base
           extend AutoCorrector
 
           MSG = 'Do not set an RSpec expectation on `current_path` in ' \

--- a/lib/rubocop/cop/rspec/capybara/negation_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/negation_matcher.rb
@@ -24,7 +24,7 @@ module RuboCop
         #   expect(page).to have_no_selector
         #   expect(page).to have_no_css('a')
         #
-        class NegationMatcher < Base
+        class NegationMatcher < ::RuboCop::Cop::Base
           extend AutoCorrector
           include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/rspec/capybara/specific_actions.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_actions.rb
@@ -20,7 +20,7 @@ module RuboCop
         #   click_link(exact_text: 'foo')
         #   find('div').click_button
         #
-        class SpecificActions < Base
+        class SpecificActions < ::RuboCop::Cop::Base
           MSG = "Prefer `%<good_action>s` over `find('%<selector>s').click`."
           RESTRICT_ON_SEND = %i[click].freeze
           SPECIFIC_ACTION = {

--- a/lib/rubocop/cop/rspec/capybara/specific_finders.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_finders.rb
@@ -15,7 +15,7 @@ module RuboCop
         #   find_by_id('some-id')
         #   find_by_id('some-id', visible: true)
         #
-        class SpecificFinders < Base
+        class SpecificFinders < ::RuboCop::Cop::Base
           extend AutoCorrector
 
           include RangeHelp

--- a/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/specific_matcher.rb
@@ -26,7 +26,7 @@ module RuboCop
         #   expect(page).to have_select
         #   expect(page).to have_field('foo')
         #
-        class SpecificMatcher < Base
+        class SpecificMatcher < ::RuboCop::Cop::Base
           MSG = 'Prefer `%<good_matcher>s` over `%<bad_matcher>s`.'
           RESTRICT_ON_SEND = %i[have_selector have_no_selector have_css
                                 have_no_css].freeze

--- a/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
+++ b/lib/rubocop/cop/rspec/capybara/visibility_matcher.rb
@@ -26,7 +26,7 @@ module RuboCop
         #   expect(page).to have_css('.foo', visible: :all)
         #   expect(page).to have_link('my link', visible: :hidden)
         #
-        class VisibilityMatcher < Base
+        class VisibilityMatcher < ::RuboCop::Cop::Base
           MSG_FALSE = 'Use `:all` or `:hidden` instead of `false`.'
           MSG_TRUE = 'Use `:visible` instead of `true`.'
           CAPYBARA_MATCHER_METHODS = %w[

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -25,7 +25,7 @@ module RuboCop
         #   # good
         #   count { 1 }
         #
-        class AttributeDefinedStatically < Base
+        class AttributeDefinedStatically < ::RuboCop::Cop::Base
           extend AutoCorrector
 
           MSG = 'Use a block to declare attribute values.'

--- a/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
@@ -40,7 +40,7 @@ module RuboCop
         #     name: 'foo'
         #   )
         #
-        class ConsistentParenthesesStyle < Base
+        class ConsistentParenthesesStyle < ::RuboCop::Cop::Base
           extend AutoCorrector
           include ConfigurableEnforcedStyle
           include RuboCop::RSpec::FactoryBot::Language

--- a/lib/rubocop/cop/rspec/factory_bot/create_list.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/create_list.rb
@@ -31,7 +31,7 @@ module RuboCop
         #   # good
         #   3.times { create :user }
         #
-        class CreateList < Base
+        class CreateList < ::RuboCop::Cop::Base
           extend AutoCorrector
           include ConfigurableEnforcedStyle
           include RuboCop::RSpec::FactoryBot::Language

--- a/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/factory_class_name.rb
@@ -20,7 +20,7 @@ module RuboCop
         #   factory :foo, class: 'Foo' do
         #   end
         #
-        class FactoryClassName < Base
+        class FactoryClassName < ::RuboCop::Cop::Base
           extend AutoCorrector
 
           MSG = "Pass '%<class_name>s' string instead of `%<class_name>s` " \

--- a/lib/rubocop/cop/rspec/factory_bot/factory_name_style.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/factory_name_style.rb
@@ -24,7 +24,7 @@ module RuboCop
         #   create('user')
         #   build "user", username: "NAME"
         #
-        class FactoryNameStyle < Base
+        class FactoryNameStyle < ::RuboCop::Cop::Base
           extend AutoCorrector
           include ConfigurableEnforcedStyle
           include RuboCop::RSpec::FactoryBot::Language

--- a/lib/rubocop/cop/rspec/rails/have_http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/have_http_status.rb
@@ -20,7 +20,8 @@ module RuboCop
             'Prefer `expect(response).%<to>s have_http_status(%<status>i)` ' \
             'over `expect(response.status).%<to>s %<match>s`.'
 
-          RESTRICT_ON_SEND = Runners.all
+          RUNNERS = %i[to to_not not_to].to_set
+          RESTRICT_ON_SEND = RUNNERS
 
           # @!method match_status(node)
           def_node_matcher :match_status, <<-PATTERN
@@ -28,7 +29,7 @@ module RuboCop
               (send nil? :expect
                 $(send (send nil? :response) :status)
               )
-              $#Runners.all
+              $RUNNERS
               $(send nil? {:be :eq :eql :equal} (int $_))
             )
           PATTERN

--- a/lib/rubocop/cop/rspec/rails/have_http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/have_http_status.rb
@@ -13,7 +13,7 @@ module RuboCop
         #   # good
         #   expect(response).to have_http_status(200)
         #
-        class HaveHttpStatus < Base
+        class HaveHttpStatus < ::RuboCop::Cop::Base
           extend AutoCorrector
 
           MSG =

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -9,7 +9,7 @@ module RuboCop
       EXTENSION_ROOT_DEPARTMENT = %r{^(RSpec/)}.freeze
       SUBDEPARTMENTS = %(RSpec/Capybara RSpec/FactoryBot RSpec/Rails)
       AMENDMENTS = %(Metrics/BlockLength)
-      COP_DOC_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/'
+      COP_DOC_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/'
 
       def initialize(config, descriptions)
         @config       = config
@@ -47,7 +47,7 @@ module RuboCop
       end
 
       def reference(cop)
-        COP_DOC_BASE_URL + cop.sub('RSpec/', '')
+        COP_DOC_BASE_URL + cop
       end
 
       attr_reader :config, :descriptions

--- a/lib/rubocop/rspec/description_extractor.rb
+++ b/lib/rubocop/rspec/description_extractor.rb
@@ -21,7 +21,8 @@ module RuboCop
 
       # Decorator of a YARD code object for working with documented rspec cops
       class CodeObject
-        COP_CLASS_NAME = 'RuboCop::Cop::RSpec::Base'
+        RSPEC_COP_CLASS_NAME = 'RuboCop::Cop::RSpec::Base'
+        RUBOCOP_COP_CLASS_NAME = 'RuboCop::Cop::Base'
         RSPEC_NAMESPACE = 'RuboCop::Cop::RSpec'
 
         def initialize(yardoc)
@@ -32,10 +33,7 @@ module RuboCop
         #
         # @return [Boolean]
         def rspec_cop?
-          class_documentation? &&
-            rspec_cop_namespace? &&
-            cop_subclass? &&
-            !abstract?
+          cop_subclass? && !abstract? && rspec_cop_namespace?
         end
 
         # Configuration for the documented cop that would live in default.yml
@@ -55,10 +53,6 @@ module RuboCop
           yardoc.docstring.split("\n\n").first.to_s
         end
 
-        def class_documentation?
-          yardoc.type.equal?(:class)
-        end
-
         def rspec_cop_namespace?
           documented_constant.start_with?(RSPEC_NAMESPACE)
         end
@@ -68,7 +62,8 @@ module RuboCop
         end
 
         def cop_subclass?
-          yardoc.superclass.path == COP_CLASS_NAME
+          yardoc.superclass.path == RSPEC_COP_CLASS_NAME ||
+            yardoc.superclass.path == RUBOCOP_COP_CLASS_NAME
         end
 
         def abstract?

--- a/spec/rubocop/cop/rspec/factory_bot/factory_name_style_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/factory_name_style_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryNameStyle,
-               :config do
+RSpec.describe RuboCop::Cop::RSpec::FactoryBot::FactoryNameStyle, :config do
   let(:cop_config) do
     { 'EnforcedStyle' => enforced_style }
   end

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::RSpec::DescriptionExtractor do
       end
     RUBY
 
-    YARD::Registry.all
+    YARD::Registry.all(:class)
   end
 
   let(:temp_class) do


### PR DESCRIPTION
This is the first, non-breaking, step towards #1440, extraction of Capybara, Rails and FactoryBot cops to their own departments, outside RSpec/.

This change is extracted from a more radical, breaking proof of concept, #1476.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).