### PR TITLE
Bump version to v2.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.16.0 (2022-12-13)
+
 - Add new `RSpec/FactoryBot/FactoryNameStyle` cop. ([@ydah])
 - Improved processing speed for `RSpec/Be`, `RSpec/ExpectActual`, `RSpec/ImplicitExpect`, `RSpec/MessageSpies`, `RSpec/PredicateMatcher` and `RSpec/Rails/HaveHttpStatus`. ([@ydah])
 - Fix wrong autocorrection in `n_times` style on `RSpec/FactoryBot/CreateList`. ([@r7kamura])

--- a/config/default.yml
+++ b/config/default.yml
@@ -149,7 +149,7 @@ RSpec/BeEq:
   Enabled: pending
   Safe: false
   VersionAdded: 2.9.0
-  VersionChanged: "<<next>>"
+  VersionChanged: '2.16'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEq
 
 RSpec/BeEql:
@@ -157,7 +157,7 @@ RSpec/BeEql:
   Enabled: true
   Safe: false
   VersionAdded: '1.7'
-  VersionChanged: "<<next>>"
+  VersionChanged: '2.16'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEql
 
 RSpec/BeNil:
@@ -291,7 +291,7 @@ RSpec/Dialect:
 RSpec/DuplicatedMetadata:
   Description: Avoid duplicated metadata.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.16'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DuplicatedMetadata
 
 RSpec/EmptyExampleGroup:
@@ -677,7 +677,7 @@ RSpec/Pending:
 RSpec/PendingWithoutReason:
   Description: Checks for pending or skipped examples without reason.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.16'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PendingWithoutReason
 
 RSpec/PredicateMatcher:
@@ -979,7 +979,7 @@ RSpec/FactoryBot/FactoryClassName:
 RSpec/FactoryBot/FactoryNameStyle:
   Description: Checks for name style for argument of FactoryBot::Syntax::Methods.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.16'
   EnforcedStyle: symbol
   SupportedStyles:
     - symbol

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: ~
+version: '2.16'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -195,7 +195,7 @@ expect(foo).to be(true)
 | No
 | Yes (Unsafe)
 | 2.9.0
-| <<next>>
+| 2.16
 |===
 
 Check for expectations where `be(...)` can replace `eq(...)`.
@@ -236,7 +236,7 @@ expect(foo).to be(nil)
 | No
 | Yes (Unsafe)
 | 1.7
-| <<next>>
+| 2.16
 |===
 
 Check for expectations where `be(...)` can replace `eql(...)`.
@@ -1017,7 +1017,7 @@ end
 | Pending
 | Yes
 | Yes
-| <<next>>
+| 2.16
 | -
 |===
 
@@ -3841,7 +3841,7 @@ end
 | Pending
 | Yes
 | No
-| <<next>>
+| 2.16
 | -
 |===
 

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -243,7 +243,7 @@ end
 | Pending
 | Yes
 | Yes
-| <<next>>
+| 2.16
 | -
 |===
 

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.15.0'
+      STRING = '2.16.0'
     end
   end
 end


### PR DESCRIPTION
It’s been over a month since our last release, and [our (latest) documentation has broken tables](https://github.com/rubocop/rubocop-rspec/pull/1479).
