### PR TITLE
FIx a false positive for `RSpec/PendingWithoutReason` when pending/skip is argument of methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip is argument of methods. ([@ydah])
 - Add new `RSpec/Capybara/MatchStyle` cop. ([@ydah])
 - Add new `RSpec/Rails/MinitestAssertions` cop. ([@ydah])
 - Fix a false positive for `RSpec/PendingWithoutReason` when not inside example. ([@ydah])

--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -97,7 +97,7 @@ module RuboCop
             add_offense(node, message: 'Give the reason for pending.')
           elsif skipped_without_reason?(node)
             add_offense(node, message: 'Give the reason for skip.')
-          elsif without_reason?(node) && inside_example?(node)
+          elsif without_reason?(node) && example?(node.parent)
             add_offense(node,
                         message: "Give the reason for #{node.method_name}.")
           end
@@ -114,10 +114,6 @@ module RuboCop
           skipped_by_example_group_method?(node.block_node) ||
             skipped_by_example_method?(node.block_node) ||
             skipped_by_metadata_without_reason?(node)
-        end
-
-        def inside_example?(node)
-          node.ancestors.find { |parent| example?(parent) }
         end
       end
     end

--- a/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
@@ -85,6 +85,43 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason do
     end
   end
 
+  context 'when pending is argument of methods' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        it 'does something' do
+          expect('foo').to eq pending
+          foo(bar, pending)
+          foo(bar, pending: pending)
+          is_expected.to match_array [foo, pending, bar]
+        end
+      RUBY
+    end
+  end
+
+  context 'when skip is argument of methods' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        it 'does something' do
+          expect('foo').to eq skip
+          foo(bar, skip)
+          foo(bar, skip: skip)
+          is_expected.to match_array [foo, skip, bar]
+        end
+      RUBY
+    end
+  end
+
+  context 'when pending/skip is argument of methods' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        it 'does something' do
+          list = [skip, pending]
+          foo(list)
+        end
+      RUBY
+    end
+  end
+
   context 'when pending by example method' do
     it 'registers offense' do
       expect_offense(<<~RUBY)
@@ -131,6 +168,19 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason do
         it 'does something' do
           pending
           ^^^^^^^ Give the reason for pending.
+        end
+      RUBY
+    end
+  end
+
+  context 'when pending/skip inside conditional' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        it 'does something' do
+          pending if RUBY_VERSION < '3.0'
+          if RUBY_VERSION < '3.0'
+            skip
+          end
         end
       RUBY
     end


### PR DESCRIPTION
This PR is fix a false positive for `RSpec/PendingWithoutReason` when pending/skip is argument of methods. 
The following cases:
```ruby
it 'does something' do
  foo pending
  foo(bar, skip)
  foo(bar, pending: pending)
  is_expected.to match_array [foo, pending, skip, bar]
end
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
