### PR TITLE
Update document for RuboCop 1.41.1

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -673,6 +673,7 @@ end
 
 * https://rspec.rubystyle.guide/#context-descriptions
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
+* http://www.betterspecs.org/#contexts
 
 == RSpec/DescribeClass
 
@@ -809,6 +810,7 @@ end
 === References
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeSymbol
+* https://github.com/rspec/rspec-core/issues/1610
 
 == RSpec/DescribedClass
 
@@ -939,6 +941,7 @@ end
 === References
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClassModuleWrapping
+* https://github.com/rubocop/rubocop-rspec/issues/735
 
 == RSpec/Dialect
 
@@ -1645,6 +1648,7 @@ end
 
 * https://rspec.rubystyle.guide/#should-in-example-docstrings
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
+* http://betterspecs.org/#should
 
 == RSpec/ExcessiveDocstringSpacing
 
@@ -2745,6 +2749,7 @@ end
 
 * https://rspec.rubystyle.guide/#declare-constants
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration
+* https://relishapp.com/rspec/rspec-mocks/docs/mutating-constants
 
 == RSpec/LetBeforeExamples
 
@@ -3158,6 +3163,7 @@ end
 
 * https://rspec.rubystyle.guide/#expectation-per-example
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
+* http://betterspecs.org/#single
 
 == RSpec/MultipleMemoizedHelpers
 
@@ -4778,6 +4784,8 @@ end
 
 * https://rspec.rubystyle.guide/#dont-stub-subject
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
+* https://robots.thoughtbot.com/don-t-stub-the-system-under-test
+* https://penelope.zone/2015/12/27/introducing-rspec-smells-and-where-to-find-them.html#smell-1-stubjec
 
 == RSpec/UnspecifiedException
 
@@ -5037,6 +5045,7 @@ end
 === References
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubleReference
+* https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles
 
 == RSpec/VerifiedDoubles
 
@@ -5090,6 +5099,7 @@ end
 
 * https://rspec.rubystyle.guide/#doubles
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
+* https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles
 
 == RSpec/VoidExpect
 

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -10,7 +10,6 @@ module RuboCop
       # include `if`, `unless`, `for`, `before`, `after`, or `during`.
       # They may consist of multiple words if desired.
       #
-      # @see https://rspec.rubystyle.guide/#context-descriptions
       # @see http://www.betterspecs.org/#contexts
       #
       # @example `Prefixes` configuration

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -12,7 +12,6 @@ module RuboCop
       #
       # @see https://robots.thoughtbot.com/don-t-stub-the-system-under-test
       # @see https://penelope.zone/2015/12/27/introducing-rspec-smells-and-where-to-find-them.html#smell-1-stubjec
-      # @see https://github.com/rubocop-hq/rspec-style-guide#dont-stub-subject
       #
       # @example
       #   # bad


### PR DESCRIPTION
We are updating the documentation as versions are released that include the following
- https://github.com/rubocop/rubocop/pull/11317

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
