### PR TITLE
Use rubocop/rubocop-rspec instead of rubocop-hq/rubocop-rspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/rubocop-rspec/Lobby](https://badges.gitter.im/rubocop-rspec/Lobby.svg)](https://gitter.im/rubocop-rspec/Lobby)
 [![Gem Version](https://badge.fury.io/rb/rubocop-rspec.svg)](https://rubygems.org/gems/rubocop-rspec)
-![CI](https://github.com/rubocop-hq/rubocop-rspec/workflows/CI/badge.svg)
+![CI](https://github.com/rubocop/rubocop-rspec/workflows/CI/badge.svg)
 
 RSpec-specific analysis for your projects, as an extension to
 [RuboCop](https://github.com/rubocop/rubocop).


### PR DESCRIPTION
This PR is use rubocop/rubocop-rspec instead of rubocop-hq/rubocop-rspec in README

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
