### PR TITLE
Fix a false negative for `RSpec/PredicateMatcher` when using `include` and `respond_to`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add new `RSpec/Capybara/MatchStyle` cop. ([@ydah])
 - Add new `RSpec/Rails/MinitestAssertions` cop. ([@ydah])
 - Fix a false positive for `RSpec/PendingWithoutReason` when not inside example. ([@ydah])
+- Fix a false negative for `RSpec/PredicateMatcher` when using `include` and `respond_to`. ([@ydah])
 
 ## 2.16.0 (2022-12-13)
 

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -179,7 +179,8 @@ module RuboCop
 
           return false if allowed_explicit_matchers.include?(name)
 
-          name.start_with?('be_', 'have_') && !name.end_with?('?')
+          name.start_with?('be_', 'have_') && !name.end_with?('?') ||
+            %w[include respond_to].include?(name)
         end
 
         def message_explicit(matcher)

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -275,6 +275,10 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `is_a?` over `be_a` matcher.
           expect(foo).to be_instance_of(Array)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `instance_of?` over `be_instance_of` matcher.
+          expect(foo).to include('bar')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
+          expect(foo).to respond_to(:method)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `respond_to?` over `respond_to` matcher.
           expect(foo).to be_something()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
         RUBY
@@ -285,6 +289,8 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           expect(foo.has_something?).to #{matcher_true}
           expect(foo.is_a?(Array)).to #{matcher_true}
           expect(foo.instance_of?(Array)).to #{matcher_true}
+          expect(foo.include?('bar')).to #{matcher_true}
+          expect(foo.respond_to?(:method)).to #{matcher_true}
           expect(foo.something?()).to #{matcher_true}
         RUBY
       end


### PR DESCRIPTION
This PR is fixed false negative in the following code:

```ruby
expect(foo).to include('bar')
expect(foo).to respond_to(:method)
```

I noticed this when I was looking at the coverage of the test code generated by simplecov.

Before
<img width="500" alt="before" src="https://user-images.githubusercontent.com/13041216/209555792-2aa5a3f8-96f8-4493-b75e-b02d43883b21.png">


After
<img width="500" alt="after" src="https://user-images.githubusercontent.com/13041216/209555831-d8797f93-ea6e-4a0e-af78-6ba12239d904.png">

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
