### PR TITLE
Add spec for `RSpec/AlignLeftLetBrace` and `RSpec/AlignRightLetBrace`with `Layout/ExtraSpacing`

### DIFF
--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -48,4 +48,46 @@ RSpec.describe 'RuboCop::CLI --autocorrect' do # rubocop:disable RSpec/DescribeC
       RUBY
     end
   end
+
+  context 'when corrects `RSpec/AlignLeftLetBrace` and ' \
+          '`RSpec/AlignRightLetBrace` with `Layout/ExtraSpacing`' do
+    before do
+      RuboCop::ConfigLoader
+        .default_configuration
+        .for_all_cops['SuggestExtensions'] = false
+
+      create_file('.rubocop.yml', <<~YAML)
+        RSpec/AlignLeftLetBrace:
+          Enabled: true
+        RSpec/AlignRightLetBrace:
+          Enabled: true
+      YAML
+
+      create_file('spec/example.rb', <<~RUBY)
+        let(:foobar) { blahblah }
+        let(:baz) { bar }
+        let(:a) { b }
+      RUBY
+    end
+
+    it 'rubocop terminates with a success' do
+      expect(cli.run(['-A', '--only',
+                      'RSpec/AlignLeftLetBrace,' \
+                      'RSpec/AlignRightLetBrace,' \
+                      'Layout/ExtraSpacing'])).to eq(0)
+    end
+
+    it 'autocorrects be compatible with each other' do
+      cli.run(['-A', '--only',
+               'RSpec/AlignLeftLetBrace,' \
+               'RSpec/AlignRightLetBrace,' \
+               'Layout/ExtraSpacing'])
+
+      expect(File.read('spec/example.rb')).to eq(<<~RUBY)
+        let(:foobar) { blahblah }
+        let(:baz)    { bar      }
+        let(:a)      { b        }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR is add spec for `RSpec/AlignLeftLetBrace` and `RSpec/AlignRightLetBrace` with `Layout/ExtraSpacing`

I found this while looking at the coverage of the test code generated by simplecov.

Before
<img width="500" alt="Before" src="https://user-images.githubusercontent.com/13041216/209558477-52c791f3-6f92-48fd-9b7d-c76e8f215b2d.png">

After
<img width="500" alt="After" src="https://user-images.githubusercontent.com/13041216/209558491-3bb40e5e-da12-4bdb-aebc-36c9059bd51d.png">


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).