### PR TITLE
Add simplecov to measure test coverage of our code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,18 @@ jobs:
         with:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
-      - run: bundle exec rake ${{ matrix.task }}
+      - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
+
+  coverage:
+    runs-on: ubuntu-latest
+    name: "Test coverage"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - run: bundle exec rake spec
 
   edge-rubocop:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ pkg
 
 .ruby-gemset
 .ruby-version
+
+# simplecov generated
+coverage

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+SimpleCov.start do
+  enable_coverage :branch
+  minimum_coverage line: 99.86, branch: 95.33
+  add_filter '/spec/'
+  add_filter '/vendor/bundle/'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'rake'
 gem 'rspec', '~> 3.11'
 gem 'rubocop-performance', '~> 1.7'
 gem 'rubocop-rake', '~> 0.6'
+gem 'simplecov', '>= 0.19'
 gem 'yard'
 
 local_gemfile = 'Gemfile.local'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@
 require 'rubocop'
 require 'rubocop/rspec/support'
 
+require 'simplecov' unless ENV['NO_COVERAGE']
+
 module SpecHelper
   ROOT = Pathname.new(__dir__).parent.freeze
 end


### PR DESCRIPTION
This PR is add [simplecov](https://github.com/simplecov-ruby/simplecov) to measure test coverage of our code.

- https://github.com/rubocop/rubocop-rspec/discussions/1530

Branch coverage is enabled, but [minimum coverage by file](https://github.com/simplecov-ruby/simplecov#minimum-coverage-by-file) is enabled.

Below the lowest of the current coverage, RSpec will fail as shown below.
This keeps the test coverage of our code high.

<img width="1622" alt="fail" src="https://user-images.githubusercontent.com/13041216/209803687-505b18c1-92b7-4f0b-9201-87b83e147f34.png">


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).