### PR TITLE
Remove coverage measurement for `Edge RuboCop` and `RSpec 4` jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           ruby-version: "3.2"
           bundler-cache: true
-      - run: bundle exec rake ${{ matrix.task }}
+      - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
   rspec4:
     runs-on: ubuntu-latest
@@ -91,4 +91,4 @@ jobs:
         with:
           ruby-version: "3.2"
           bundler-cache: true
-      - run: bundle exec rake spec
+      - run: NO_COVERAGE=true bundle exec rake spec


### PR DESCRIPTION
This PR is remove coverage measurement for `Edge RuboCop` and `RSpec 4` jobs.
Coverage measurements are performed only in Test coverage job, so unnecessary measurements are stopped.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).