### PR TITLE
Use concurrency for GitHub Actions workflow

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,9 @@
 name: CodeSpell
 on:
   - pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   codespell:
     name: CodeSpell

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,9 @@
 name: Linting
 on:
   - pull_request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   yamllint:
     name: Yamllint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   confirm_config_and_documentation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR ensures that only the last execution per branch always works, even when pushed multiple times in a row, for example. The older one is canceled.

I tried it on this branch and sure enough, all but the most recent workflow is cancelled.
https://github.com/rubocop/rubocop-rspec/actions/runs/3848207691
https://github.com/rubocop/rubocop-rspec/actions/runs/3848207692
https://github.com/rubocop/rubocop-rspec/actions/runs/3848207694

Refs:
https://docs.github.com/en/actions/using-jobs/using-concurrency https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
