### PR TITLE
Fix a false negative for `RSpec/Pending` and false positive for `RSpec/NoExpectationExample` when using skipped in metadata is multiline string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Fix a false positive for `RSpec/PendingWithoutReason` when not inside example. ([@ydah])
 - Fix a false negative for `RSpec/PredicateMatcher` when using `include` and `respond_to`. ([@ydah])
 - Fix a false positive for `RSpec/StubbedMock` when stubbed message expectation with a block and block parameter. ([@ydah])
+- Fix a false negative for `RSpec/Pending` when using skipped in metadata is multiline string. ([@ydah])
+- Fix a false positive for `RSpec/NoExpectationExample` when using skipped in metadata is multiline string. ([@ydah])
 
 ## 2.16.0 (2022-12-13)
 

--- a/lib/rubocop/cop/rspec/mixin/skip_or_pending.rb
+++ b/lib/rubocop/cop/rspec/mixin/skip_or_pending.rb
@@ -11,7 +11,7 @@ module RuboCop
         def_node_matcher :skipped_in_metadata?, <<-PATTERN
           {
             (send _ _ <#skip_or_pending? ...>)
-            (send _ _ ... (hash <(pair #skip_or_pending? { true str }) ...>))
+            (send _ _ ... (hash <(pair #skip_or_pending? { true str dstr }) ...>))
           }
         PATTERN
 

--- a/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
+++ b/spec/rubocop/cop/rspec/no_expectation_example_spec.rb
@@ -145,10 +145,24 @@ RSpec.describe RuboCop::Cop::RSpec::NoExpectationExample do
       it 'is skipped', skip: true do
         foo
       end
+      it 'is skipped', skip: "test" do
+        foo
+      end
+      it 'is skipped', skip: "test" \\
+                             "foo" do
+        foo
+      end
       it 'is pending', :pending do
         foo
       end
       it 'is pending', pending: true do
+        foo
+      end
+      it 'is pending', pending: "test" do
+        foo
+      end
+      it 'is pending', pending: "test" \\
+                                "foo" do
         foo
       end
     RUBY

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -98,6 +98,34 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
     RUBY
   end
 
+  it 'flags blocks with pending: string metadata and line break by `\`' do
+    expect_offense(<<-'RUBY')
+      it "test", pending: 'test' \
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
+                          'foo' do
+      end
+    RUBY
+  end
+
+  it 'flags blocks with pending: string metadata and line break by `,`' do
+    expect_offense(<<-RUBY)
+      it "test", pending: 'test ,
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
+                          foo' do
+      end
+    RUBY
+  end
+
+  it 'flags blocks with pending: surrounded by `%()` stringg metadata ' \
+     'and line break' do
+    expect_offense(<<-RUBY)
+      it "test", pending: %(test ,
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
+                          foo) do
+      end
+    RUBY
+  end
+
   it 'flags blocks with skip: true metadata' do
     expect_offense(<<-RUBY)
       it 'test', skip: true do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1540
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).