### PR TITLE
Change the start label of a heredocument to be enclosed in single quotes

### DIFF
--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
   end
 
   it 'finds context without `when` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<-'RUBY')
       context 'the display name not present' do
-              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
       end
     RUBY
   end
 
   it 'finds shared_context without `when` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<-'RUBY')
       shared_context 'the display name not present' do
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
       end
     RUBY
   end
@@ -43,18 +43,18 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
   end
 
   it 'finds context without separate `when` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<-'RUBY')
       context 'whenever you do' do
-              ^^^^^^^^^^^^^^^^^ Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.
+              ^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
       end
     RUBY
   end
 
   context 'with metadata hash' do
     it 'finds context without separate `when` at the beginning' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<-'RUBY')
         context 'whenever you do', legend: true do
-                ^^^^^^^^^^^^^^^^^ Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.
+                ^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
         end
       RUBY
     end
@@ -62,9 +62,9 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
   context 'with symbol metadata' do
     it 'finds context without separate `when` at the beginning' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<-'RUBY')
         context 'whenever you do', :legend do
-                ^^^^^^^^^^^^^^^^^ Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.
+                ^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
         end
       RUBY
     end
@@ -72,9 +72,9 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
   context 'with mixed metadata' do
     it 'finds context without separate `when` at the beginning' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<-'RUBY')
         context 'whenever you do', :legend, myth: true do
-                ^^^^^^^^^^^^^^^^^ Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.
+                ^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
         end
       RUBY
     end
@@ -84,9 +84,9 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
     let(:cop_config) { { 'Prefixes' => %w[if], 'AllowedPatterns' => [] } }
 
     it 'finds context without allowed prefixes at the beginning' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<-'RUBY')
         context 'when display name is present' do
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^if\\b/.
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^if\b/.
         end
       RUBY
     end
@@ -115,16 +115,16 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       let(:cop_config) { { 'Prefixes' => ['a$b\d'], 'AllowedPatterns' => [] } }
 
       it 'matches the full prefix' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<-'RUBY')
           context 'a' do
-                  ^^^ Context description should match /^a\\$b\\\\d\\b/.
+                  ^^^ Context description should match /^a\$b\\d\b/.
           end
         RUBY
       end
 
       it 'matches special characters' do
-        expect_no_offenses(<<-RUBY)
-          context 'a$b\\d something' do
+        expect_no_offenses(<<-'RUBY')
+          context 'a$b\d something' do
           end
         RUBY
       end
@@ -166,18 +166,18 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
       it 'finds context without `when` at the beginning and not included ' \
          '`/patterns/`' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<-'RUBY')
           context 'this is an incorrect context' do
-                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /patterns/, or /^when\\b/.
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /patterns/, or /^when\b/.
           end
         RUBY
       end
 
       it 'finds shared_context without `when` at the beginning and ' \
          'not included `/patterns/`' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<-'RUBY')
           shared_context 'this is an incorrect context' do
-                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /patterns/, or /^when\\b/.
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /patterns/, or /^when\b/.
           end
         RUBY
       end

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -151,8 +151,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'flags \-separated multiline strings' do
-    expect_offense(<<-RUBY)
-      it 'should do something ' \\
+    expect_offense(<<-'RUBY')
+      it 'should do something ' \
           ^^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
           'and correctly fix' do
       end

--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -120,8 +120,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'skips \-separated multiline strings whose trailing whitespace ' \
        'makes sense' do
-      expect_no_offenses(<<-RUBY)
-        describe '#mymethod ' \\
+      expect_no_offenses(<<-'RUBY')
+        describe '#mymethod ' \
             '(is cool)' do
         end
       RUBY
@@ -129,8 +129,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline strings whose trailing whitespace ' \
        'does not make sense' do
-      expect_offense(<<-RUBY)
-        describe '#mymethod   ' \\
+      expect_offense(<<-'RUBY')
+        describe '#mymethod   ' \
                   ^^^^^^^^^^^^^^^ Excessive whitespace.
             '(is cool)' do
         end
@@ -287,8 +287,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'skips \-separated multiline strings whose trailing whitespace ' \
        'makes sense' do
-      expect_no_offenses(<<-RUBY)
-        context 'when doing something ' \\
+      expect_no_offenses(<<-'RUBY')
+        context 'when doing something ' \
             'like this' do
         end
       RUBY
@@ -296,8 +296,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline strings whose trailing whitespace ' \
        'does not make sense' do
-      expect_offense(<<-RUBY)
-        context 'when doing something   ' \\
+      expect_offense(<<-'RUBY')
+        context 'when doing something   ' \
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             'like this' do
         end
@@ -479,8 +479,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'skips \-separated multiline strings whose trailing whitespace ' \
        'makes sense' do
-      expect_no_offenses(<<-RUBY)
-        it 'should do something ' \\
+      expect_no_offenses(<<-'RUBY')
+        it 'should do something ' \
             'and correctly fix' do
         end
       RUBY
@@ -488,8 +488,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline strings whose trailing whitespace ' \
        'does not make sense' do
-      expect_offense(<<-RUBY)
-        it 'does something   ' \\
+      expect_offense(<<-'RUBY')
+        it 'does something   ' \
             ^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             'and correctly fix' do
         end
@@ -556,8 +556,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
     end
 
     it 'supports `skip` (with a block)' do
-      expect_offense(<<-RUBY)
-        skip '  this   please   ' \\
+      expect_offense(<<-'RUBY')
+        skip '  this   please   ' \
               ^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             '  and thank you  !' do
         end
@@ -570,8 +570,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
     end
 
     it 'supports `skip` (without a block)' do
-      expect_offense(<<-RUBY)
-        skip '  this   please   ' \\
+      expect_offense(<<-'RUBY')
+        skip '  this   please   ' \
               ^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             '  and thank you  !'
       RUBY

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -272,14 +272,14 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds concatenated strings with no variables' do
-      expect_offense(<<-RUBY)
-        allow(Foo).to receive(:bar).and_return('You called ' \\
+      expect_offense(<<-'RUBY')
+        allow(Foo).to receive(:bar).and_return('You called ' \
                                     ^^^^^^^^^^ Use block for static values.
           'me')
       RUBY
 
-      expect_correction(<<-RUBY)
-        allow(Foo).to receive(:bar) { 'You called ' \\
+      expect_correction(<<-'RUBY')
+        allow(Foo).to receive(:bar) { 'You called ' \
           'me' }
       RUBY
     end


### PR DESCRIPTION
This PR is change as follows

```ruby
# bad - This would require escaping inside heredoc. 
expect_offense(<<-RUBY)
  it 'should do something ' \\ <---here
  ^^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
    'and correctly fix' do
  end
RUBY

# good - This makes the heredoc readable with no need for escaping inside it.
expect_offense(<<-'RUBY')
  it 'should do something ' \
  ^^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
    'and correctly fix' do
  end
RUBY
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
