### PR TITLE
Fix a false positive for `RSpec/StubbedMock` when stubbed message expectation with a block and block parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add new `RSpec/Rails/MinitestAssertions` cop. ([@ydah])
 - Fix a false positive for `RSpec/PendingWithoutReason` when not inside example. ([@ydah])
 - Fix a false negative for `RSpec/PredicateMatcher` when using `include` and `respond_to`. ([@ydah])
+- Fix a false positive for `RSpec/StubbedMock` when stubbed message expectation with a block and block parameter. ([@ydah])
 
 ## 2.16.0 (2022-12-13)
 

--- a/lib/rubocop/cop/rspec/stubbed_mock.rb
+++ b/lib/rubocop/cop/rspec/stubbed_mock.rb
@@ -91,7 +91,7 @@ module RuboCop
         #   @param node [RuboCop::AST::Node]
         #   @yield [RuboCop::AST::Node] matcher
         def_node_matcher :matcher_with_return_block, <<~PATTERN
-          (block #message_expectation? args _)  # receive(:foo) { 'bar' }
+          (block #message_expectation? (args) _)  # receive(:foo) { 'bar' }
         PATTERN
 
         # @!method matcher_with_hash(node)

--- a/spec/rubocop/cop/rspec/stubbed_mock_spec.rb
+++ b/spec/rubocop/cop/rspec/stubbed_mock_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe RuboCop::Cop::RSpec::StubbedMock do
     RUBY
   end
 
+  it 'ignores stubbed message expectation with a block and block parameter' do
+    expect_no_offenses(<<-RUBY)
+      expect(foo).to receive(:bar) { |x| bar }
+    RUBY
+  end
+
   it 'flags stubbed message expectation with argument matching' do
     expect_offense(<<-RUBY)
       expect(foo).to receive(:bar).with(42).and_return('hello world')


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1518

For the context, we don't want to conside `expect.to receive(:foo) { |arg, arg2| ... }` an offence, since most likely the block contains expectations on arguments.
If it's an `allow`, those argument expectations might be missed of `foo` is not called.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
