### PR TITLE
Fix a false positive for `RSpec/ContextMethod` when multi-line context with `#` at the beginning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a false negative for `RSpec/Pending` when using skipped in metadata is multiline string. ([@ydah])
 - Fix a false positive for `RSpec/NoExpectationExample` when using skipped in metadata is multiline string. ([@ydah])
+- Fix a false positive for `RSpec/ContextMethod` when multi-line context with `#` at the beginning. ([@ydah])
 
 ## 2.17.0 (2023-01-13)
 

--- a/lib/rubocop/cop/rspec/context_method.rb
+++ b/lib/rubocop/cop/rspec/context_method.rb
@@ -31,7 +31,11 @@ module RuboCop
 
         # @!method context_method(node)
         def_node_matcher :context_method, <<-PATTERN
-          (block (send #rspec? :context $(str #method_name?) ...) ...)
+          (block
+            (send #rspec? :context
+              ${(str #method_name?) (dstr (str #method_name?) ...)}
+            ...)
+          ...)
         PATTERN
 
         def on_block(node)  # rubocop:disable InternalAffairs/NumblockHandler

--- a/spec/rubocop/cop/rspec/context_method_spec.rb
+++ b/spec/rubocop/cop/rspec/context_method_spec.rb
@@ -43,4 +43,19 @@ RSpec.describe RuboCop::Cop::RSpec::ContextMethod do
       end
     RUBY
   end
+
+  it 'flags multi-line context with `#` at the beginning' do
+    expect_offense(<<-'RUBY')
+      context '#foo_bar' \
+              ^^^^^^^^^^^^ Use `describe` for testing methods.
+              '.baz'do
+      end
+    RUBY
+
+    expect_correction(<<-'RUBY')
+      describe '#foo_bar' \
+              '.baz'do
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
This PR is fix a false positive for `RSpec/ContextMethod` when multi-line context with `#` at the beginning.

```ruby
# no offense
context '#foo_bar' \
  '.baz'do
end
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
