### PR TITLE
Add a test case for `RSpec/ContextMethod` when context without `.` or `#` at the beginning

### DIFF
--- a/spec/rubocop/cop/rspec/context_method_spec.rb
+++ b/spec/rubocop/cop/rspec/context_method_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextMethod do
 
   it 'ignores context without `.` or `#` at the beginning' do
     expect_no_offenses(<<-RUBY)
-      context '_foo_bar' do
+      context "when it's sunny" do
       end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/context_method_spec.rb
+++ b/spec/rubocop/cop/rspec/context_method_spec.rb
@@ -11,6 +11,13 @@ RSpec.describe RuboCop::Cop::RSpec::ContextMethod do
     RUBY
   end
 
+  it 'ignores context without `.` or `#` at the beginning' do
+    expect_no_offenses(<<-RUBY)
+      context '_foo_bar' do
+      end
+    RUBY
+  end
+
   it 'flags context with `.` at the beginning' do
     expect_offense(<<-RUBY)
       context '.foo_bar' do


### PR DESCRIPTION
This PR is add a test case for `RSpec/ContextMethod` when context without `.` or `#` at the beginning.

The test case was added because there was no case where the following method was false.

https://github.com/rubocop/rubocop-rspec/blob/a1ece2cad9d18fdfe0bdd481f35d7cc471f1e5d4/lib/rubocop/cop/rspec/context_method.rb#L47-L49

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).