### PR TITLE
Bump version to v2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.17.0 (2023-01-13)
+
 - Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip is argument of methods. ([@ydah])
 - Add new `RSpec/Capybara/MatchStyle` cop. ([@ydah])
 - Add new `RSpec/Rails/MinitestAssertions` cop. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -890,7 +890,7 @@ RSpec/Capybara/FeatureMethods:
 RSpec/Capybara/MatchStyle:
   Description: Checks for usage of deprecated style methods.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.17'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Capybara/MatchStyle
 
 RSpec/Capybara/NegationMatcher:
@@ -1054,5 +1054,5 @@ RSpec/Rails/InferredSpecType:
 RSpec/Rails/MinitestAssertions:
   Description: Check if using Minitest matchers.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.17'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/MinitestAssertions

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: ~
+version: '2.17'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_capybara.adoc
@@ -120,7 +120,7 @@ end
 | Pending
 | Yes
 | Yes
-| <<next>>
+| 2.17
 | -
 |===
 

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -213,7 +213,7 @@ end
 | Pending
 | Yes
 | Yes
-| <<next>>
+| 2.17
 | -
 |===
 

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.16.0'
+      STRING = '2.17.0'
     end
   end
 end


### PR DESCRIPTION
@pirj You suggested in https://github.com/rubocop/rubocop-rspec/issues/1549#issuecomment-1381360466 that we release a v2.16.1 now, then release the Capybara extraction in a v2.17.0. But seeing that there are new cops in the changelog, I would prefer to release a v2.17.0 now, and then a v2.18.0 with the Capybara extraction. Would that be ok, or does that mess up the version numbers of rubocop-capybara?