### PR TITLE
Fix a false positive for `RSpec/PredicateMatcher` when multiple arguments and not replaceable method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix a false positive for `RSpec/ContextMethod` when multi-line context with `#` at the beginning. ([@ydah])
 - Extract Capybara cops to a separate repository. ([@pirj])
 - Fix an incorrect autocorrect for `RSpec/PredicateMatcher` when multiline expect and predicate method with heredoc. ([@ydah])
+- Fix a false positive for `RSpec/PredicateMatcher` when `include` with multiple argument. ([@ydah])
 
 ## 2.17.0 (2023-01-13)
 

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -149,11 +149,22 @@ module RuboCop
           return if part_of_ignored_node?(node)
 
           predicate_matcher?(node) do |actual, matcher|
+            next unless replaceable_matcher?(matcher)
+
             add_offense(node, message: message_explicit(matcher)) do |corrector|
               next if uncorrectable_matcher?(node, matcher)
 
               corrector_explicit(corrector, node, actual, matcher, matcher)
             end
+          end
+        end
+
+        def replaceable_matcher?(matcher)
+          case matcher.method_name.to_s
+          when 'include'
+            matcher.arguments.one?
+          else
+            true
           end
         end
 

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -95,14 +95,14 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
 
       it 'registers an offense for a predicate method with heredoc' do
         expect_offense(<<~RUBY)
-          expect(foo.include?(<<~TEXT)).to be_truthy
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `include` matcher over `include?`.
+          expect(foo.something?(<<~TEXT)).to be_truthy
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `be_something` matcher over `something?`.
             bar
           TEXT
         RUBY
 
         expect_correction(<<~RUBY)
-          expect(foo).to include(<<~TEXT)
+          expect(foo).to be_something(<<~TEXT)
             bar
           TEXT
         RUBY
@@ -346,14 +346,14 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
          'heredoc and multiline expect' do
         expect_offense(<<~RUBY)
           expect(foo)
-          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
-            .to include(<<~TEXT)
+          ^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
+            .to be_something(<<~TEXT)
               bar
             TEXT
 
           expect(foo)
-          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
-            .to include(bar, <<~TEXT, 'baz')
+          ^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
+            .to be_something(bar, <<~TEXT, 'baz')
               bar
             TEXT
         RUBY
@@ -365,14 +365,14 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
          'heredoc include #{} and multiline expect' do
         expect_offense(<<~'RUBY')
           expect(foo)
-          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
-            .to include(<<~TEXT)
+          ^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
+            .to be_something(<<~TEXT)
               #{bar}
             TEXT
 
           expect(foo)
-          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
-            .to include(bar, <<~TEXT, 'baz')
+          ^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
+            .to be_something(bar, <<~TEXT, 'baz')
               #{bar}
             TEXT
         RUBY
@@ -384,19 +384,33 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
          'heredoc surrounded by back ticks and multiline expect' do
         expect_offense(<<~'RUBY')
           expect(foo)
-          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
-            .to include(<<~`COMMAND`)
+          ^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
+            .to be_something(<<~`COMMAND`)
               pwd
             COMMAND
 
           expect(foo)
-          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
-            .to include(bar, <<~COMMAND, 'baz')
+          ^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
+            .to be_something(bar, <<~COMMAND, 'baz')
               pwd
             COMMAND
         RUBY
 
         expect_no_corrections
+      end
+
+      it 'does not register an offense for a `include` ' \
+         'with no argument' do
+        expect_no_offenses(<<~RUBY)
+          expect(foo).to include
+        RUBY
+      end
+
+      it 'does not register an offense for a `include` ' \
+         'with multiple arguments' do
+        expect_no_offenses(<<~RUBY)
+          expect(foo).to include(foo, bar)
+        RUBY
       end
 
       it 'registers an offense for a predicate method with a block' do


### PR DESCRIPTION
This PR is fix a false positive for `RSpec/PredicateMatcher` when multiple arguments and not replaceable method.

following code:
```ruby
expect(foo).to include(foo, bar)
```

`RSpec/PredicateMatcher` autocorrects it as follows:
```ruby
expect(foo.include?(foo, bar)).to be(true)
```

However, this is a SyntaxError.
```
ArgumentError:
       wrong number of arguments (given 2, expected 1)
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).