### PR TITLE
Fix an incorrect autocorrect for `RSpec/PredicateMatcher` when multiline expect and predicate method with heredoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix a false positive for `RSpec/NoExpectationExample` when using skipped in metadata is multiline string. ([@ydah])
 - Fix a false positive for `RSpec/ContextMethod` when multi-line context with `#` at the beginning. ([@ydah])
 - Extract Capybara cops to a separate repository. ([@pirj])
+- Fix an incorrect autocorrect for `RSpec/PredicateMatcher` when multiline expect and predicate method with heredoc. ([@ydah])
 
 ## 2.17.0 (2023-01-13)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3968,6 +3968,17 @@ expect(foo).to be_something
 
 # good - the above code is rewritten to it by this cop
 expect(foo.something?).to be(true)
+
+# bad - no autocorrect
+expect(foo)
+  .to be_something(<<~TEXT)
+    bar
+  TEXT
+
+# good
+expect(foo.something?(<<~TEXT)).to be(true)
+  bar
+TEXT
 ----
 
 ==== Strict: false, EnforcedStyle: explicit

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -93,6 +93,21 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
         RUBY
       end
 
+      it 'registers an offense for a predicate method with heredoc' do
+        expect_offense(<<~RUBY)
+          expect(foo.include?(<<~TEXT)).to be_truthy
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `include` matcher over `include?`.
+            bar
+          TEXT
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect(foo).to include(<<~TEXT)
+            bar
+          TEXT
+        RUBY
+      end
+
       it 'registers an offense for a predicate method with a block' do
         expect_offense(<<~RUBY)
           expect(foo.all?(&:present?)).to be_truthy
@@ -310,6 +325,78 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           expect(foo.something?(1, 2)).to #{matcher_true}
           expect(foo.something? 1, 2).to #{matcher_true}
         RUBY
+      end
+
+      it 'registers an offense for a predicate method with heredoc' do
+        expect_offense(<<~RUBY)
+          expect(foo).to include(<<~TEXT)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
+            bar
+          TEXT
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect(foo.include?(<<~TEXT)).to #{matcher_true}
+            bar
+          TEXT
+        RUBY
+      end
+
+      it 'registers an offense for a predicate method with ' \
+         'heredoc and multiline expect' do
+        expect_offense(<<~RUBY)
+          expect(foo)
+          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
+            .to include(<<~TEXT)
+              bar
+            TEXT
+
+          expect(foo)
+          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
+            .to include(bar, <<~TEXT, 'baz')
+              bar
+            TEXT
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for a predicate method with ' \
+         'heredoc include #{} and multiline expect' do
+        expect_offense(<<~'RUBY')
+          expect(foo)
+          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
+            .to include(<<~TEXT)
+              #{bar}
+            TEXT
+
+          expect(foo)
+          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
+            .to include(bar, <<~TEXT, 'baz')
+              #{bar}
+            TEXT
+        RUBY
+
+        expect_no_corrections
+      end
+
+      it 'registers an offense for a predicate method with ' \
+         'heredoc surrounded by back ticks and multiline expect' do
+        expect_offense(<<~'RUBY')
+          expect(foo)
+          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
+            .to include(<<~`COMMAND`)
+              pwd
+            COMMAND
+
+          expect(foo)
+          ^^^^^^^^^^^ Prefer using `include?` over `include` matcher.
+            .to include(bar, <<~COMMAND, 'baz')
+              pwd
+            COMMAND
+        RUBY
+
+        expect_no_corrections
       end
 
       it 'registers an offense for a predicate method with a block' do


### PR DESCRIPTION
This PR is fix an incorrect autocorrect for `RSpec/PredicateMatcher` when multiline expect and predicate method with heredoc.

The following code:
```ruby
expect(foo)
  .to be_something(<<~TEXT)
    bar
  TEXT
```

This would be corrected as follows:
```ruby
expect(foo.something?(<<~TEXT))
  .to be(true) <<----------- this would be included in heredoc
    bar
TEXT
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).