### PR TITLE
Fix a false positive for `RSpec/ContextWording` when context is interpolated string literal or execute string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/ContextWording` when context is interpolated string literal or execute string. ([@ydah])
+
 ## 2.18.1 (2023-01-19)
 
 - Add `rubocop-capybara` version constraint to prevent sudden cop enabling when it hits 3.0. ([@pirj])

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -20,6 +20,23 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
     RUBY
   end
 
+  it 'finds context without `when` at the beginning and contains `#{}`' do
+    expect_offense(<<-'RUBY')
+      context "the #{display} name not present" do
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
+      end
+    RUBY
+  end
+
+  it 'finds context without `when` at the beginning ' \
+     'and command surrounded by back ticks' do
+    expect_offense(<<-'RUBY')
+      context `pwd` do
+              ^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
+      end
+    RUBY
+  end
+
   it 'finds shared_context without `when` at the beginning' do
     expect_offense(<<-'RUBY')
       shared_context 'the display name not present' do


### PR DESCRIPTION
This PR is fix a false positive for `RSpec/ContextWording` when context is interpolated string literal or execute string.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
