### PR TITLE
Fix a false positive for `RSpec/DescribeMethod` when multi-line describe without `#` or `.` at the beginning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `RSpec/ContextWording` when context is interpolated string literal or execute string. ([@ydah])
+- Fix a false positive for `RSpec/DescribeMethod` when multi-line describe without `#` and `.` at the beginning. ([@ydah])
 
 ## 2.18.1 (2023-01-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `RSpec/ContextWording` when context is interpolated string literal or execute string. ([@ydah])
-- Fix a false positive for `RSpec/DescribeMethod` when multi-line describe without `#` and `.` at the beginning. ([@ydah])
+- Fix a false positive for `RSpec/DescribeMethod` when multi-line describe without `#` and `.` at the beginning. ([@ydah], [@pirj])
 
 ## 2.18.1 (2023-01-19)
 

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -23,27 +23,27 @@ module RuboCop
         MSG = 'The second argument to describe should be the method ' \
               "being tested. '#instance' or '.class'."
 
-        # @!method second_argument(node)
-        def_node_matcher :second_argument, <<~PATTERN
+        # @!method second_string_literal_argument(node)
+        def_node_matcher :second_string_literal_argument, <<~PATTERN
           (block
-            (send #rspec? :describe _first_argument $_ ...)
+            (send #rspec? :describe _first_argument ${str dstr} ...)
           ...)
         PATTERN
 
-        # @!method not_method_name?(node)
-        def_node_matcher :not_method_name?, <<~PATTERN
-          {(str !#method_name?) (dstr (str !#method_name?) ...)}
+        # @!method method_name?(node)
+        def_node_matcher :method_name?, <<~PATTERN
+          {(str #method_name_prefix?) (dstr (str #method_name_prefix?) ...)}
         PATTERN
 
         def on_top_level_group(node)
-          second_argument(node) do |argument|
-            add_offense(argument) if not_method_name?(argument)
+          second_string_literal_argument(node) do |argument|
+            add_offense(argument) unless method_name?(argument)
           end
         end
 
         private
 
-        def method_name?(description)
+        def method_name_prefix?(description)
           description.start_with?('.', '#')
         end
       end

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -13,12 +13,33 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
     RUBY
   end
 
+  it 'enforces non-method names with multi-line describe' do
+    expect_offense(<<-'RUBY')
+      describe Some::Class, "foo" \
+                            ^^^^^^^ The second argument to describe should be the method being tested. '#instance' or '.class'.
+        "bar" do
+      end
+    RUBY
+  end
+
   it 'skips methods starting with a . or #' do
     expect_no_offenses(<<-RUBY)
       describe Some::Class, '.asdf' do
       end
 
       describe Some::Class, '#fdsa' do
+      end
+    RUBY
+  end
+
+  it 'skips methods starting with a . or # with multi-line describe' do
+    expect_no_offenses(<<-'RUBY')
+      describe Some::Class, ".foo" \
+        "bar" do
+      end
+
+      describe Some::Class, "#foo" \
+        "bar" do
       end
     RUBY
   end


### PR DESCRIPTION
This PR is fix a false positive for `RSpec/DescribeMethod` when multi-line describe without `#` and `.` at the beginning.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
