### PR TITLE
Bump version to v2.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.18.0 (2023-01-16)
+
 - Extract Capybara cops to a separate repository. ([@pirj])
 
 ## 2.17.1 (2023-01-16)

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: ~
+version: '2.18'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.17.1'
+      STRING = '2.18.0'
     end
   end
 end


### PR DESCRIPTION
There is only one thing in this release: 

- Extract Capybara cops to a separate repository. (#1519)