### PR TITLE
Lock rubocop-capybara dependency to < 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.18.1 (2023-01-19)
+
 - Add `rubocop-capybara` version constraint to prevent sudden cop enabling when it hits 3.0. ([@pirj])
 
 ## 2.18.0 (2023-01-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Master (Unreleased)
 
+- Add `rubocop-capybara` version constraint to prevent sudden cop enabling when it hits 3.0. ([@pirj])
+
 ## 2.18.0 (2023-01-16)
 
-- Extract Capybara cops to a separate repository. ([@pirj])
+- Extract Capybara cops to a separate repository, [`rubocop-capybara`](https://github.com/rubocop/rubocop-capybara). The `rubocop-capybara` repository is a dependency of `rubocop-rspec` and the Capybara cops are aliased (`RSpec/Capybara/Foo` == `Capybara/Foo`) until v3.0 is released, so the change will be invisible to users until then. ([@pirj])
 
 ## 2.17.1 (2023-01-16)
 

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.18.0'
+      STRING = '2.18.1'
     end
   end
 end

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency 'rubocop', '~> 1.33'
-  spec.add_runtime_dependency 'rubocop-capybara'
+  spec.add_runtime_dependency 'rubocop-capybara', '~> 2.17'
 end


### PR DESCRIPTION
We've noticed that if we don't lock it, a release of rubocop-capybara 3.0 would still install along with rubocop-rspec 2.18.0.
Also, Bundler may prefer installing an older rubocop-rspec version (2.18.0) and rubocop-capybara 3.0 instead of a newer 2.18+ rubocop-rspec with rubocop-capybara 2.x.

See https://github.com/rubocop/rubocop-rspec/commit/eed7439be0c90c7d79e264240f91ad0a924d5a80#r96342863 for details.

In a while after this is released, we plan to yank the release 2.18.0 to prevent suddenly enabling Capybara cops from rubocop-capybara 3.0.

We acknowledge that yanking may cause CI of projects that locked (via Gemfile.lock) their rubocop-rspec dependency to 2.18.0 would break on the `bundle install` stage.
To mitigate that, we give some time to update to an even newer 2.18+ version before yanking 2.18.0

Kudos to @AlexWayfer for bringing this up to our attention.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).