### PR TITLE
Fix a false positive for `RSpec/DescribedClassModuleWrapping` when RSpec.describe numblock is nested within a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add support `be_status` style for `RSpec/Rails/HttpStatus`. ([@ydah])
+- Fix a false positive for `RSpec/DescribedClassModuleWrapping` when RSpec.describe numblock is nested within a module. ([@ydah])
 - Add new `RSpec/IndexedLet` cop. ([@dmitrytsepelev])
 - Fix order of expected and actual in correction for `RSpec/Rails/MinitestAssertions` ([@mvz])
 - Fix a false positive for `RSpec/FactoryBot/ConsistentParenthesesStyle` inside `&&`, `||` and `:?` when `omit_parentheses` is on ([@dmitrytsepelev])

--- a/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
+++ b/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
@@ -22,15 +22,15 @@ module RuboCop
       class DescribedClassModuleWrapping < Base
         MSG = 'Avoid opening modules and defining specs within them.'
 
-        # @!method find_rspec_blocks(node)
-        def_node_search :find_rspec_blocks, <<~PATTERN
-          (block (send #explicit_rspec? #ExampleGroups.all ...) ...)
+        # @!method include_rspec_blocks?(node)
+        def_node_search :include_rspec_blocks?, <<~PATTERN
+          ({block numblock} (send #explicit_rspec? #ExampleGroups.all ...) ...)
         PATTERN
 
         def on_module(node)
-          find_rspec_blocks(node) do
-            add_offense(node)
-          end
+          return unless include_rspec_blocks?(node)
+
+          add_offense(node)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/described_class_module_wrapping_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_module_wrapping_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping do
+RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping, :ruby27 do
   it 'allows a describe block in the outermost scope' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe MyClass do
@@ -9,7 +9,8 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping do
     RUBY
   end
 
-  it 'registers an offense when RSpec.describe is nested within a module' do
+  it 'registers an offense when RSpec.describe block is nested ' \
+     'within a module' do
     expect_offense(<<-RUBY)
       module MyModule
       ^^^^^^^^^^^^^^^ Avoid opening modules and defining specs within them.
@@ -21,7 +22,21 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping do
     RUBY
   end
 
-  it 'registers an offense when RSpec.describe is nested within two modules' do
+  it 'registers an offense when RSpec.describe numblock is nested ' \
+     'within a module' do
+    expect_offense(<<-RUBY)
+      module MyModule
+      ^^^^^^^^^^^^^^^ Avoid opening modules and defining specs within them.
+        RSpec.describe MyClass do
+          _1
+          subject { "MyClass" }
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense when RSpec.describe block is nested ' \
+     'within two modules' do
     expect_offense(<<-RUBY)
       module MyFirstModule
       ^^^^^^^^^^^^^^^^^^^^ Avoid opening modules and defining specs within them.
@@ -36,7 +51,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping do
     RUBY
   end
 
-  it 'allows a module that does not contain RSpec.describe' do
+  it 'allows a module that does not contain RSpec.describe block' do
     expect_no_offenses(<<-RUBY)
       module MyModule
         def some_method


### PR DESCRIPTION
This PR is fix a false positive for `RSpec/DescribedClassModuleWrapping` when RSpec.describe numblock is nested within a module.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
