### PR TITLE
Use `line_with_comment?` instead of bad API

### DIFF
--- a/lib/rubocop/cop/rspec/mixin/empty_line_separation.rb
+++ b/lib/rubocop/cop/rspec/mixin/empty_line_separation.rb
@@ -25,8 +25,7 @@ module RuboCop
 
         def missing_separating_line(node)
           line = final_end_line = final_end_location(node).line
-
-          while comment_line?(processed_source[line])
+          while processed_source.line_with_comment?(line + 1)
             line += 1
             comment = processed_source.comment_at_line(line)
             if DirectiveComment.new(comment).enabled?


### PR DESCRIPTION
`RuboCop::Cop::Util#comment_line?` is flagged by https://github.com/rubocop/rubocop/pull/8405 as a bad API. So I propose to fix not use this method.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
