### PR TITLE
Enable some new cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -116,6 +116,8 @@ Style/EmptyHeredoc:
   Enabled: true
 Style/RedundantHeredocDelimiterQuotes:
   Enabled: true
+Style/RedundantStringEscape:
+  Enabled: true
 
 # Enable our own pending cops.
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,6 +114,8 @@ Layout/LineEndStringConcatenationIndentation:
   Enabled: true
 Style/EmptyHeredoc:
   Enabled: true
+Style/RedundantHeredocDelimiterQuotes:
+  Enabled: true
 
 # Enable our own pending cops.
 

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'ignores heredocs' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<-RUBY)
       it <<~DESC do
           ^^^^^ Do not use should when describing your tests.
         should not start with this word
@@ -189,7 +189,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'flags an unclear description' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<-RUBY)
       it "works" do
           ^^^^^ Your example description is insufficient.
       end
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'flags an unclear description despite extra spaces' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<-RUBY)
       it "  works    " do
           ^^^^^^^^^^^ Your example description is insufficient.
       end
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'flags an unclear description despite uppercase and lowercase strings' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<-RUBY)
       it "WOrKs " do
           ^^^^^^ Your example description is insufficient.
       end
@@ -233,7 +233,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     end
 
     it 'flags an unclear description' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<-RUBY)
         it "workz" do
             ^^^^^ Your example description is insufficient.
         end
@@ -241,7 +241,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     end
 
     it 'flags an unclear description despite uppercase and lowercase strings' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<-RUBY)
         it "WOrKz " do
             ^^^^^^ Your example description is insufficient.
         end

--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -386,13 +386,13 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
     end
 
     it 'handles one-word descriptions' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<-RUBY)
         it "tests  " do
             ^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<-RUBY)
         it "tests" do
         end
       RUBY
@@ -519,13 +519,13 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
   context 'when using other common example groups' do
     it 'supports `xcontext`' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<-RUBY)
         xcontext "when testing  " do
                   ^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<-RUBY)
         xcontext "when testing" do
         end
       RUBY
@@ -545,12 +545,12 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
     end
 
     it 'supports `its`' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<-RUBY)
         its("  length  ") { should eq(1) }
              ^^^^^^^^^^ Excessive whitespace.
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<-RUBY)
         its("length") { should eq(1) }
       RUBY
     end
@@ -563,7 +563,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<-RUBY)
         skip 'this please and thank you !' do
         end
       RUBY
@@ -576,7 +576,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
             '  and thank you  !'
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<-RUBY)
         skip 'this please and thank you !'
       RUBY
     end
@@ -598,7 +598,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
   end
 
   it 'ignores heredocs' do
-    expect_no_offenses(<<-'RUBY')
+    expect_no_offenses(<<-RUBY)
       it <<~DESC do
         does not remove
           another comments reports,

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -382,7 +382,7 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
 
       it 'registers an offense for a predicate method with ' \
          'heredoc surrounded by back ticks and multiline expect' do
-        expect_offense(<<~'RUBY')
+        expect_offense(<<~RUBY)
           expect(foo)
           ^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
             .to be_something(<<~`COMMAND`)


### PR DESCRIPTION
I would like to enable these cop following https://github.com/rubocop/rubocop-rspec/pull/1410 .
One cop is correcting offenses and it looks good. What do you think?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).