### PR TITLE
CI against JRuby 9.4 instead of JRuby 9.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           - "3.1"
           - "3.2"
           - ruby-head
-          - jruby-9.3
+          - jruby-9.4
         task:
           - internal_investigation
           - spec


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop/pull/11551

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).