### PR TITLE
Sunset *_pattern node pattern helpers

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,7 +2,7 @@
 
 SimpleCov.start do
   enable_coverage :branch
-  minimum_coverage line: 99.86, branch: 95.33
+  minimum_coverage line: 99.83, branch: 95.33
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
 end

--- a/.simplecov
+++ b/.simplecov
@@ -2,7 +2,7 @@
 
 SimpleCov.start do
   enable_coverage :branch
-  minimum_coverage line: 99.83, branch: 95.33
+  minimum_coverage line: 99.60, branch: 95.32
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix a false positive for `RSpec/PendingWithoutReason` when not inside example and pending/skip with block. ([@ydah], [@pirj])
 - Fix a false positive for `RSpec/PendingWithoutReason` when `skip` is passed a block inside example. ([@ydah], [@pirj])
 - Rename `RSpec/PendingBlockInsideExample` cop to `RSpec/SkipBlockInsideExample`. ([@pirj])
+- Deprecate `send_pattern`/`block_pattern`/`numblock_pattern` helpers in favour of using node pattern explicitly. ([@pirj], [@ydah])
 
 ## 2.18.1 (2023-01-19)
 

--- a/docs/modules/ROOT/pages/upgrade_to_version_2.adoc
+++ b/docs/modules/ROOT/pages/upgrade_to_version_2.adoc
@@ -162,7 +162,7 @@ def_node_matcher :shared_context,
 
 # After
 def_node_matcher :shared_context,
-                 block_pattern('#SharedGroups.context')
+                 '(block (send #rspec? #SharedGroups.context ...) ...)'
 ----
 
 [source,ruby]
@@ -173,7 +173,7 @@ def_node_search :examples?,
 
 # After
 def_node_search :examples?,
-                send_pattern('{#Includes.examples #Examples.all}')
+                '(send nil? {#Includes.examples #Examples.all} ...)'
 ----
 
 [source,ruby]
@@ -184,7 +184,7 @@ def_node_search :find_rspec_blocks,
 
 # After
 def_node_search :find_rspec_blocks,
-                block_pattern('#ExampleGroups.all')
+                '(block (send #rspec? #ExampleGroups.all ...) ...)'
 ----
 
 If you were calling Language elements directly, you have to make the same adjustments:

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -68,7 +68,8 @@ module RuboCop
         PATTERN
 
         # @!method rspec_block?(node)
-        def_node_matcher :rspec_block?, block_pattern('#ALL.all')
+        def_node_matcher :rspec_block?,
+                         '({block numblock} (send #rspec? #ALL.all ...) ...)'
 
         # @!method scope_changing_syntax?(node)
         def_node_matcher :scope_changing_syntax?, '{def class module}'

--- a/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
+++ b/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
@@ -23,7 +23,9 @@ module RuboCop
         MSG = 'Avoid opening modules and defining specs within them.'
 
         # @!method find_rspec_blocks(node)
-        def_node_search :find_rspec_blocks, block_pattern('#ExampleGroups.all')
+        def_node_search :find_rspec_blocks, <<~PATTERN
+          (block (send #explicit_rspec? #ExampleGroups.all ...) ...)
+        PATTERN
 
         def on_module(node)
           find_rspec_blocks(node) do

--- a/lib/rubocop/cop/rspec/dialect.rb
+++ b/lib/rubocop/cop/rspec/dialect.rb
@@ -49,7 +49,7 @@ module RuboCop
         MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
 
         # @!method rspec_method?(node)
-        def_node_matcher :rspec_method?, send_pattern('#ALL.all')
+        def_node_matcher :rspec_method?, '(send #rspec? #ALL.all ...)'
 
         def on_send(node)
           return unless rspec_method?(node)

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -53,7 +53,7 @@ module RuboCop
         #   @param node [RuboCop::AST::Node]
         #   @yield [RuboCop::AST::Node] example group body
         def_node_matcher :example_group_body, <<~PATTERN
-          (block #{send_pattern('#ExampleGroups.all')} args $_)
+          (block (send #rspec? #ExampleGroups.all ...) args $_)
         PATTERN
 
         # @!method example_or_group_or_include?(node)
@@ -72,10 +72,10 @@ module RuboCop
         #   @return [Array<RuboCop::AST::Node>] matching nodes
         def_node_matcher :example_or_group_or_include?, <<~PATTERN
           {
-            #{block_pattern(
-              '{#Examples.all #ExampleGroups.all #Includes.all}'
-            )}
-            #{send_pattern('{#Examples.all #Includes.all}')}
+            (block
+              (send #rspec? {#Examples.all #ExampleGroups.all #Includes.all} ...)
+            ...)
+            (send nil? {#Examples.all #Includes.all} ...)
           }
         PATTERN
 
@@ -95,7 +95,7 @@ module RuboCop
         #   @param node [RuboCop::AST::Node]
         #   @return [Array<RuboCop::AST::Node>] matching nodes
         def_node_matcher :examples_inside_block?, <<~PATTERN
-          (block !#{send_pattern('#Hooks.all')} _ #examples?)
+          (block !(send nil? #Hooks.all ...) _ #examples?)
         PATTERN
 
         # @!method examples_directly_or_in_block?(node)

--- a/lib/rubocop/cop/rspec/empty_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_hook.rb
@@ -31,7 +31,7 @@ module RuboCop
 
         # @!method empty_hook?(node)
         def_node_matcher :empty_hook?, <<~PATTERN
-          (block $#{send_pattern('#Hooks.all')} _ nil?)
+          (block $(send nil? #Hooks.all ...) _ nil?)
         PATTERN
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -25,7 +25,7 @@ module RuboCop
         MSG = 'Do not use `%<expect>s` in `%<hook>s` hook'
 
         # @!method expectation(node)
-        def_node_search :expectation, send_pattern('#Expectations.all')
+        def_node_search :expectation, '(send nil? #Expectations.all ...)'
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless hook?(node)

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -61,10 +61,9 @@ module RuboCop
         PATTERN
 
         # @!method focused_block?(node)
-        def_node_matcher :focused_block?,
-                         send_pattern(<<~PATTERN)
-                           {#ExampleGroups.focused #Examples.focused}
-                         PATTERN
+        def_node_matcher :focused_block?, <<~PATTERN
+          (send #rspec? {#ExampleGroups.focused #Examples.focused} ...)
+        PATTERN
 
         def on_send(node)
           focus_metadata(node) do |focus|

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -30,8 +30,11 @@ module RuboCop
         # @!method example_or_group?(node)
         def_node_matcher :example_or_group?, <<-PATTERN
           {
-            #{block_or_numblock_pattern('{#ExampleGroups.all #Examples.all}')}
-            #{send_pattern('#Includes.examples')}
+            ({block numblock} {
+              (send #rspec? #ExampleGroups.all ...)
+              (send nil? #Examples.all ...)
+            } ...)
+            (send nil? #Includes.examples ...)
           }
         PATTERN
 

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -38,16 +38,16 @@ module RuboCop
         # @!method example_or_group?(node)
         def_node_matcher :example_or_group?, <<-PATTERN
           {
-            #{block_pattern('{#ExampleGroups.all #Examples.all}')}
-            #{send_pattern('#Includes.examples')}
+            (block (send nil? {#ExampleGroups.all #Examples.all} ...) ...)
+            (send nil? #Includes.examples ...)
           }
         PATTERN
 
         # @!method include_examples?(node)
         def_node_matcher :include_examples?, <<~PATTERN
           {
-            #{block_pattern(':include_examples')}
-            #{send_pattern(':include_examples')}
+            (block (send nil? :include_examples ...) ...)
+            (send nil? :include_examples ...)
           }
         PATTERN
 

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -29,14 +29,12 @@ module RuboCop
         MSG = 'Do not use `let!` to setup objects not referenced in tests.'
 
         # @!method example_or_shared_group_or_including?(node)
-        def_node_matcher :example_or_shared_group_or_including?,
-                         block_pattern(<<~PATTERN)
-                           {
-                             #SharedGroups.all
-                             #ExampleGroups.all
-                             #Includes.all
-                           }
-                         PATTERN
+        def_node_matcher :example_or_shared_group_or_including?, <<~PATTERN
+          (block {
+            (send #rspec? {#SharedGroups.all #ExampleGroups.all} ...)
+            (send nil? #Includes.all ...)
+          } ...)
+        PATTERN
 
         # @!method let_bang(node)
         def_node_matcher :let_bang, <<-PATTERN

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -78,7 +78,8 @@ module RuboCop
         PATTERN
 
         # @!method expect?(node)
-        def_node_matcher :expect?, send_pattern('#Expectations.all')
+        def_node_matcher :expect?, '(send nil? #Expectations.all ...)'
+
         # @!method aggregate_failures_block?(node)
         def_node_matcher :aggregate_failures_block?, <<-PATTERN
           (block (send nil? :aggregate_failures ...) ...)

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -82,12 +82,14 @@ module RuboCop
         MSG = 'Name your test subject if you need to reference it explicitly.'
 
         # @!method example_or_hook_block?(node)
-        def_node_matcher :example_or_hook_block?,
-                         block_pattern('{#Examples.all #Hooks.all}')
+        def_node_matcher :example_or_hook_block?, <<~PATTERN
+          (block (send nil? {#Examples.all #Hooks.all} ...) ...)
+        PATTERN
 
         # @!method shared_example?(node)
-        def_node_matcher :shared_example?,
-                         block_pattern('#SharedGroups.examples')
+        def_node_matcher :shared_example?, <<~PATTERN
+          (block (send #rspec? #SharedGroups.examples ...) ...)
+        PATTERN
 
         # @!method subject_usage(node)
         def_node_search :subject_usage, '$(send nil? :subject)'

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -64,17 +64,16 @@ module RuboCop
         # @!method regular_or_focused_example?(node)
         # @param [RuboCop::AST::Node] node
         # @return [Boolean]
-        def_node_matcher :regular_or_focused_example?,
-                         block_or_numblock_pattern(
-                           '{#Examples.regular | #Examples.focused}'
-                         )
+        def_node_matcher :regular_or_focused_example?, <<~PATTERN
+          ({block numblock} (send nil? {#Examples.regular #Examples.focused} ...) ...)
+        PATTERN
 
         # @!method includes_expectation?(node)
         # @param [RuboCop::AST::Node] node
         # @return [Boolean]
         def_node_search :includes_expectation?, <<~PATTERN
           {
-            #{send_pattern('#Expectations.all')}
+            (send nil? #Expectations.all ...)
             (send nil? `#matches_allowed_pattern? ...)
           }
         PATTERN

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -26,7 +26,9 @@ module RuboCop
         MSG = '`%<name>s` is already defined.'
 
         # @!method setup?(node)
-        def_node_matcher :setup?, block_pattern('{#Helpers.all #Subjects.all}')
+        def_node_matcher :setup?, <<~PATTERN
+          (block (send nil? {#Helpers.all #Subjects.all} ...) ...)
+        PATTERN
 
         # @!method first_argument_name(node)
         def_node_matcher :first_argument_name, '(send _ _ ({str sym} $_))'

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -38,20 +38,20 @@ module RuboCop
         MSG = 'Pending spec found.'
 
         # @!method skippable?(node)
-        def_node_matcher :skippable?,
-                         send_pattern(<<~PATTERN)
-                           {#ExampleGroups.regular #Examples.regular}
-                         PATTERN
+        def_node_matcher :skippable?, <<~PATTERN
+          {
+            (send #rspec? #ExampleGroups.regular ...)
+            (send nil? #Examples.regular ...)
+          }
+        PATTERN
 
         # @!method pending_block?(node)
-        def_node_matcher :pending_block?,
-                         send_pattern(<<~PATTERN)
-                           {
-                             #ExampleGroups.skipped
-                             #Examples.skipped
-                             #Examples.pending
-                           }
-                         PATTERN
+        def_node_matcher :pending_block?, <<~PATTERN
+          {
+            (send #rspec? #ExampleGroups.skipped ...)
+            (send nil? {#Examples.skipped #Examples.pending} ...)
+          }
+        PATTERN
 
         def on_send(node)
           return unless pending_block?(node) || skipped?(node)

--- a/lib/rubocop/cop/rspec/repeated_include_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_include_example.rb
@@ -56,12 +56,11 @@ module RuboCop
 
         # @!method include_examples?(node)
         def_node_matcher :include_examples?,
-                         send_pattern('#Includes.examples')
+                         '(send nil? #Includes.examples ...)'
 
         # @!method shared_examples_name(node)
-        def_node_matcher :shared_examples_name, <<-PATTERN
-          (send _ #Includes.examples $_ ...)
-        PATTERN
+        def_node_matcher :shared_examples_name,
+                         '(send nil? #Includes.examples $_name ...)'
 
         def on_begin(node)
           return unless several_include_examples?(node)

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -57,27 +57,26 @@ module RuboCop
         MSG_CONTEXT  = "Use `shared_context` when you don't define examples."
 
         # @!method examples?(node)
-        def_node_search :examples?,
-                        send_pattern('{#Includes.examples #Examples.all}')
+        def_node_search :examples?, <<~PATTERN
+          (send nil? {#Includes.examples #Examples.all} ...)
+        PATTERN
 
         # @!method context?(node)
         def_node_search :context?, <<-PATTERN
-          (
-            send #rspec? {
-              #Subjects.all
-              #Helpers.all
-              #Includes.context
-              #Hooks.all
-            } ...
+          (send nil?
+            {#Subjects.all #Helpers.all #Includes.context #Hooks.all} ...
           )
         PATTERN
 
         # @!method shared_context(node)
-        def_node_matcher :shared_context,
-                         block_pattern('#SharedGroups.context')
+        def_node_matcher :shared_context, <<~PATTERN
+          (block (send #rspec? #SharedGroups.context ...) ...)
+        PATTERN
+
         # @!method shared_example(node)
-        def_node_matcher :shared_example,
-                         block_pattern('#SharedGroups.examples')
+        def_node_matcher :shared_example, <<~PATTERN
+          (block (send #rspec? #SharedGroups.examples ...) ...)
+        PATTERN
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           context_with_only_examples(node) do

--- a/lib/rubocop/cop/rspec/shared_examples.rb
+++ b/lib/rubocop/cop/rspec/shared_examples.rb
@@ -24,10 +24,12 @@ module RuboCop
         extend AutoCorrector
 
         # @!method shared_examples(node)
-        def_node_matcher :shared_examples,
-                         send_pattern(
-                           '{#SharedGroups.all #Includes.all}'
-                         )
+        def_node_matcher :shared_examples, <<~PATTERN
+          {
+            (send #rspec? #SharedGroups.all ...)
+            (send nil? #Includes.all ...)
+          }
+        PATTERN
 
         def on_send(node)
           shared_examples(node) do

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -10,14 +10,12 @@ module RuboCop
       #
       #   Selectors which indicate that we should stop searching
       #
-      def_node_matcher :scope_change?,
-                       block_pattern(<<~PATTERN)
-                         {
-                           #SharedGroups.all
-                           #ExampleGroups.all
-                           #Includes.all
-                         }
-                       PATTERN
+      def_node_matcher :scope_change?, <<~PATTERN
+        (block {
+          (send #rspec? {#SharedGroups.all #ExampleGroups.all} ...)
+          (send nil? #Includes.all ...)
+        } ...)
+      PATTERN
 
       def lets
         find_all_in_scope(node, :let?)

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -26,21 +26,24 @@ module RuboCop
       def_node_matcher :explicit_rspec?, '(const {nil? cbase} :RSpec)'
 
       # @!method example_group?(node)
-      def_node_matcher :example_group?,
-                       block_or_numblock_pattern('#ExampleGroups.all')
+      def_node_matcher :example_group?, <<~PATTERN
+        ({block numblock} (send #rspec? #ExampleGroups.all ...) ...)
+      PATTERN
 
       # @!method shared_group?(node)
-      def_node_matcher :shared_group?, block_pattern('#SharedGroups.all')
+      def_node_matcher :shared_group?,
+                       '(block (send #rspec? #SharedGroups.all ...) ...)'
 
       # @!method spec_group?(node)
-      def_node_matcher :spec_group?,
-                       block_or_numblock_pattern(
-                         '{#SharedGroups.all #ExampleGroups.all}'
-                       )
+      def_node_matcher :spec_group?, <<~PATTERN
+        ({block numblock} (send #rspec?
+             {#SharedGroups.all #ExampleGroups.all}
+          ...) ...)
+      PATTERN
 
       # @!method example_group_with_body?(node)
       def_node_matcher :example_group_with_body?, <<-PATTERN
-        (block #{send_pattern('#ExampleGroups.all')} args !nil?)
+        (block (send #rspec? #ExampleGroups.all ...) args !nil?)
       PATTERN
 
       # @!method example?(node)

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -44,30 +44,34 @@ module RuboCop
       PATTERN
 
       # @!method example?(node)
-      def_node_matcher :example?, block_pattern('#Examples.all')
+      def_node_matcher :example?, '(block (send nil? #Examples.all ...) ...)'
 
       # @!method hook?(node)
-      def_node_matcher :hook?,
-                       block_or_numblock_pattern('#Hooks.all')
+      def_node_matcher :hook?, <<-PATTERN
+      {
+        (numblock (send nil? #Hooks.all ...) ...)
+        (block (send nil? #Hooks.all ...) ...)
+      }
+      PATTERN
 
       # @!method let?(node)
       def_node_matcher :let?, <<-PATTERN
         {
-          #{block_pattern('#Helpers.all')}
-          (send #rspec? #Helpers.all _ block_pass)
+          (block (send nil? #Helpers.all ...) ...)
+          (send nil? #Helpers.all _ block_pass)
         }
       PATTERN
 
       # @!method include?(node)
       def_node_matcher :include?, <<-PATTERN
         {
-          #{send_pattern('#Includes.all')}
-          #{block_pattern('#Includes.all')}
+          (block (send nil? #Includes.all ...) ...)
+          (send nil? #Includes.all ...)
         }
       PATTERN
 
       # @!method subject?(node)
-      def_node_matcher :subject?, block_pattern('#Subjects.all')
+      def_node_matcher :subject?, '(block (send nil? #Subjects.all ...) ...)'
 
       module ExampleGroups # :nodoc:
         class << self

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -10,22 +10,37 @@ module RuboCop
       module NodePattern
         # @deprecated Prefer using Node Pattern directly
         def send_pattern(string)
+          deprecation_warning __method__
           "(send #rspec? #{string} ...)"
         end
 
         # @deprecated Prefer using Node Pattern directly
         def block_pattern(string)
+          deprecation_warning __method__
           "(block #{send_pattern(string)} ...)"
         end
 
         # @deprecated Prefer using Node Pattern directly
         def numblock_pattern(string)
+          deprecation_warning __method__
           "(numblock #{send_pattern(string)} ...)"
         end
 
         # @deprecated Prefer using Node Pattern directly
         def block_or_numblock_pattern(string)
+          deprecation_warning __method__
           "{#{block_pattern(string)} #{numblock_pattern(string)}}"
+        end
+
+        private
+
+        def deprecation_warning(method)
+          # Only warn in derived extensions' specs
+          return unless defined?(::RSpec)
+
+          Kernel.warn <<~MESSAGE, uplevel: 2
+            Usage of #{method} is deprecated. Use node pattern explicitly.
+          MESSAGE
         end
       end
     end

--- a/lib/rubocop/rspec/language/node_pattern.rb
+++ b/lib/rubocop/rspec/language/node_pattern.rb
@@ -4,19 +4,26 @@ module RuboCop
   module RSpec
     module Language
       # Helper methods to detect RSpec DSL used with send and block
+      # @deprecated Prefer using Node Pattern directly
+      #   Use `'(block (send nil? #Example.all ...) ...)'` instead of
+      #   `block_pattern('#Example.all')`
       module NodePattern
+        # @deprecated Prefer using Node Pattern directly
         def send_pattern(string)
           "(send #rspec? #{string} ...)"
         end
 
+        # @deprecated Prefer using Node Pattern directly
         def block_pattern(string)
           "(block #{send_pattern(string)} ...)"
         end
 
+        # @deprecated Prefer using Node Pattern directly
         def numblock_pattern(string)
           "(numblock #{send_pattern(string)} ...)"
         end
 
+        # @deprecated Prefer using Node Pattern directly
         def block_or_numblock_pattern(string)
           "{#{block_pattern(string)} #{numblock_pattern(string)}}"
         end

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -150,14 +150,6 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
     RUBY
   end
 
-  it 'flags pending examples when receiver is explicit' do
-    expect_offense(<<-RUBY)
-      RSpec.xit 'test' do
-      ^^^^^^^^^^^^^^^^ Pending spec found.
-      end
-    RUBY
-  end
-
   it 'ignores describe' do
     expect_no_offenses(<<-RUBY)
       describe 'test' do; end


### PR DESCRIPTION
Follow-up to #1578
Fixes #1578

They introduce another level of indirection that is arguably harder to read.
```
send_pattern('{#Includes.examples #Examples.all}')
# vs
'(send nil? {#Includes.examples #Examples.all} ...)'

block_pattern('#ExampleGroups.all')
# vs
'(block (send #rspec? #ExampleGroups.all ...) ...)'

'(block $#{send_pattern('#Hooks.all')} _ nil?)'
# vs
'(block $(send nil? #Hooks.all ...) _ nil?)'

block_or_numblock_pattern('{#Examples.regular #Examples.focused}')
# vs
'({block numblock} (send nil? {#Examples.regular #Examples.focused} ...) ...)'
```

Those helpers implied that `#rspec?`, e.g. an explicit `RSpec` receiver or an implicit receiver can be matched, while in some cases like `let`/`before` using the explicit receiver is not supported by RSpec.


Some discussion: https://github.com/rubocop/rubocop-rspec/pull/1576#issuecomment-1421283557

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).