### PR TITLE
Correct `InternalAffairs/ProcessedSourceBufferName` cop

### DIFF
--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -165,7 +165,7 @@ module RuboCop
         end
 
         def expanded_file_path
-          File.expand_path(processed_source.buffer.name)
+          File.expand_path(processed_source.file_path)
         end
       end
     end


### PR DESCRIPTION
The CI running RuboCop in Edge is failed. We correct offense for `InternalAffairs/ProcessedSourceBufferName` cop. https://github.com/rubocop/rubocop-rspec/actions/runs/4241877273/jobs/7372656638

Follow up: https://github.com/rubocop/rubocop/pull/11606

```
lib/rubocop/cop/rspec/file_path.rb:168:45: C: [Correctable] InternalAffairs/ProcessedSourceBufferName: Use file_path instead.
          File.expand_path(processed_source.buffer.name)
                                            ^^^^^^^^^^^

277 files inspected, 1 offense detected, 1 offense autocorrectable
Error: Process completed with exit code 1.
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).