### PR TITLE
Auto-correct `InternalAffairs/LocationExpression` offenses

### DIFF
--- a/lib/rubocop/cop/rspec/be_nil.rb
+++ b/lib/rubocop/cop/rspec/be_nil.rb
@@ -57,7 +57,7 @@ module RuboCop
           return unless be_nil_matcher?(node)
 
           add_offense(node, message: BE_MSG) do |corrector|
-            corrector.replace(node.loc.expression, 'be(nil)')
+            corrector.replace(node.source_range, 'be(nil)')
           end
         end
 
@@ -65,7 +65,7 @@ module RuboCop
           return unless nil_value_expectation?(node)
 
           add_offense(node, message: BE_NIL_MSG) do |corrector|
-            corrector.replace(node.loc.expression, 'be_nil')
+            corrector.replace(node.source_range, 'be_nil')
           end
         end
       end

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -99,7 +99,7 @@ module RuboCop
         private
 
         def check_offense(node)
-          expression = node.loc.expression
+          expression = node.source_range
           if compound_expectations?(node)
             add_offense(expression, message: message_compound) do |corrector|
               autocorrect_compound(corrector, node)
@@ -117,7 +117,7 @@ module RuboCop
 
         def autocorrect(corrector, node)
           corrector.replace(node.parent.loc.selector, 'not_to')
-          range = node.loc.dot.with(end_pos: node.loc.expression.end_pos)
+          range = node.loc.dot.with(end_pos: node.source_range.end_pos)
           corrector.remove(range)
         end
 
@@ -126,7 +126,7 @@ module RuboCop
 
           change_nodes(node) do |change_node|
             corrector.replace(change_node.loc.selector, negated_matcher)
-            range = node.loc.dot.with(end_pos: node.loc.expression.end_pos)
+            range = node.loc.dot.with(end_pos: node.source_range.end_pos)
             corrector.remove(range)
           end
         end

--- a/lib/rubocop/cop/rspec/duplicated_metadata.rb
+++ b/lib/rubocop/cop/rspec/duplicated_metadata.rb
@@ -39,7 +39,7 @@ module RuboCop
           corrector.remove(
             range_with_surrounding_comma(
               range_with_surrounding_space(
-                node.location.expression,
+                node.source_range,
                 side: :left
               ),
               :left

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -174,7 +174,7 @@ module RuboCop
 
         def removed_range(node)
           range_by_whole_lines(
-            node.location.expression,
+            node.source_range,
             include_final_newline: true
           )
         end

--- a/lib/rubocop/cop/rspec/empty_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_hook.rb
@@ -38,7 +38,7 @@ module RuboCop
           empty_hook?(node) do |hook|
             add_offense(hook) do |corrector|
               corrector.remove(
-                range_with_surrounding_space(node.loc.expression, side: :left)
+                range_with_surrounding_space(node.source_range, side: :left)
               )
             end
           end

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -88,7 +88,7 @@ module RuboCop
         end
 
         def docstring(node)
-          expr = node.loc.expression
+          expr = node.source_range
 
           Parser::Source::Range.new(
             expr.source_buffer,

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -74,7 +74,7 @@ module RuboCop
         end
 
         def docstring(node)
-          expr = node.loc.expression
+          expr = node.source_range
 
           Parser::Source::Range.new(
             expr.source_buffer,

--- a/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/attribute_defined_statically.rb
@@ -96,7 +96,7 @@ module RuboCop
             left_braces, right_braces = braces(node)
 
             argument = node.first_argument
-            expression = argument.location.expression
+            expression = argument.source_range
             corrector.insert_before(expression, left_braces)
             corrector.insert_after(expression, right_braces)
           end

--- a/lib/rubocop/cop/rspec/factory_bot/syntax_methods.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/syntax_methods.rb
@@ -71,14 +71,14 @@ module RuboCop
 
           def crime_scene(node)
             range_between(
-              node.loc.expression.begin_pos,
+              node.source_range.begin_pos,
               node.loc.selector.end_pos
             )
           end
 
           def offense(node)
             range_between(
-              node.loc.expression.begin_pos,
+              node.source_range.begin_pos,
               node.loc.selector.begin_pos
             )
           end

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -87,7 +87,7 @@ module RuboCop
 
         def with_surrounding(focus)
           range_with_space =
-            range_with_surrounding_space(focus.loc.expression, side: :left)
+            range_with_surrounding_space(focus.source_range, side: :left)
 
           range_with_surrounding_comma(range_with_space, :left)
         end

--- a/lib/rubocop/cop/rspec/mixin/location_help.rb
+++ b/lib/rubocop/cop/rspec/mixin/location_help.rb
@@ -14,7 +14,7 @@ module RuboCop
         #      ^^^^^
         def arguments_with_whitespace(node)
           node.loc.selector.end.with(
-            end_pos: node.loc.expression.end_pos
+            end_pos: node.source_range.end_pos
           )
         end
 
@@ -27,8 +27,8 @@ module RuboCop
           return unless (parent = node.parent)
           return unless parent.block_type?
 
-          node.loc.expression.end.with(
-            end_pos: parent.loc.expression.end_pos
+          node.source_range.end.with(
+            end_pos: parent.source_range.end_pos
           )
         end
       end

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -84,7 +84,7 @@ module RuboCop
 
         def remove_predicate(corrector, predicate)
           range = predicate.loc.dot.with(
-            end_pos: predicate.loc.expression.end_pos
+            end_pos: predicate.source_range.end_pos
           )
 
           corrector.remove(range)
@@ -99,7 +99,7 @@ module RuboCop
           block = block_loc ? block_loc.source : ''
 
           corrector.replace(
-            matcher.loc.expression,
+            matcher.source_range,
             to_predicate_matcher(predicate.method_name) + args + block
           )
         end
@@ -214,7 +214,7 @@ module RuboCop
 
         def corrector_explicit(corrector, to_node, actual, matcher, block_child)
           replacement_matcher = replacement_matcher(to_node)
-          corrector.replace(matcher.loc.expression, replacement_matcher)
+          corrector.replace(matcher.source_range, replacement_matcher)
           move_predicate(corrector, actual, matcher, block_child)
           corrector.replace(to_node.loc.selector, 'to')
         end
@@ -226,7 +226,7 @@ module RuboCop
           block = block_loc ? block_loc.source : ''
 
           corrector.remove(block_loc) if block_loc
-          corrector.insert_after(actual.loc.expression,
+          corrector.insert_after(actual.source_range,
                                  ".#{predicate}" + args + block)
         end
 

--- a/lib/rubocop/cop/rspec/rails/inferred_spec_type.rb
+++ b/lib/rubocop/cop/rspec/rails/inferred_spec_type.rb
@@ -96,12 +96,12 @@ module RuboCop
           # @return [Parser::Source::Range]
           def remove_range(node)
             if node.left_sibling
-              node.loc.expression.with(
-                begin_pos: node.left_sibling.loc.expression.end_pos
+              node.source_range.with(
+                begin_pos: node.left_sibling.source_range.end_pos
               )
             elsif node.right_sibling
-              node.loc.expression.with(
-                end_pos: node.right_sibling.loc.expression.begin_pos
+              node.source_range.with(
+                end_pos: node.right_sibling.source_range.begin_pos
               )
             end
           end

--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -80,7 +80,7 @@ module RuboCop
 
         def range(node, offending_node)
           offending_node.loc.dot.with(
-            end_pos: node.loc.expression.end_pos
+            end_pos: node.source_range.end_pos
           )
         end
       end

--- a/lib/rubocop/cop/rspec/sort_metadata.rb
+++ b/lib/rubocop/cop/rspec/sort_metadata.rb
@@ -38,8 +38,8 @@ module RuboCop
           metadata = symbols + pairs
 
           range_between(
-            metadata.first.loc.expression.begin_pos,
-            metadata.last.loc.expression.end_pos
+            metadata.first.source_range.begin_pos,
+            metadata.last.source_range.end_pos
           )
         end
 

--- a/lib/rubocop/cop/rspec/variable_name.rb
+++ b/lib/rubocop/cop/rspec/variable_name.rb
@@ -53,7 +53,7 @@ module RuboCop
             return if variable.dstr_type? || variable.dsym_type?
             return if matches_allowed_pattern?(variable.value)
 
-            check_name(node, variable.value, variable.loc.expression)
+            check_name(node, variable.value, variable.source_range)
           end
         end
 

--- a/lib/rubocop/cop/rspec/verified_double_reference.rb
+++ b/lib/rubocop/cop/rspec/verified_double_reference.rb
@@ -76,7 +76,7 @@ module RuboCop
             break correct_style_detected unless opposing_style?(class_reference)
 
             message = format(MSG, style: style)
-            expression = class_reference.loc.expression
+            expression = class_reference.source_range
 
             add_offense(expression, message: message) do |corrector|
               violation = class_reference.children.last.to_s


### PR DESCRIPTION
Since `InternalAffairs/LocationExpression` cop has been added to rubocop/rubocop, rubocop-rspec's CI now fails.

- https://github.com/rubocop/rubocop/pull/11630

I noticed this while working on the following pull request:

- https://github.com/rubocop/rubocop-rspec/pull/1497
- https://github.com/rubocop/rubocop-rspec/actions/runs/4278832511/jobs/7448945890