### PR TITLE
Fix an incorrect autocorrect for `RSpec/VerifiedDoubleReference` when namespaced class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix a false positive for `RSpec/PendingWithoutReason` when `skip` is passed a block inside example. ([@ydah], [@pirj])
 - Rename `RSpec/PendingBlockInsideExample` cop to `RSpec/SkipBlockInsideExample`. ([@pirj])
 - Deprecate `send_pattern`/`block_pattern`/`numblock_pattern` helpers in favour of using node pattern explicitly. ([@pirj], [@ydah])
+- Fix an incorrect autocorrect for `RSpec/VerifiedDoubleReference` when namespaced class. ([@ydah])
 
 ## 2.18.1 (2023-01-19)
 

--- a/lib/rubocop/cop/rspec/verified_double_reference.rb
+++ b/lib/rubocop/cop/rspec/verified_double_reference.rb
@@ -79,7 +79,7 @@ module RuboCop
             expression = class_reference.source_range
 
             add_offense(expression, message: message) do |corrector|
-              violation = class_reference.children.last.to_s
+              violation = class_reference.source
               corrector.replace(expression, correct_style(violation))
 
               opposite_style_detected
@@ -102,7 +102,7 @@ module RuboCop
           if style == :string
             "'#{violation}'"
           else
-            violation
+            violation.gsub(/^['"]|['"]$/, '')
           end
         end
       end

--- a/spec/rubocop/cop/rspec/verified_double_reference_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_double_reference_spec.rb
@@ -27,10 +27,16 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubleReference do
           expect_offense(<<~RUBY, verified_double: verified_double)
             %{verified_double}('ClassName')
             _{verified_double} ^^^^^^^^^^^ Use a constant class reference for verified doubles.
+            %{verified_double}('Foo::Bar::Baz')
+            _{verified_double} ^^^^^^^^^^^^^^^ Use a constant class reference for verified doubles.
+            %{verified_double}('::Foo::Bar')
+            _{verified_double} ^^^^^^^^^^^^ Use a constant class reference for verified doubles.
           RUBY
 
           expect_correction(<<~RUBY)
             #{verified_double}(ClassName)
+            #{verified_double}(Foo::Bar::Baz)
+            #{verified_double}(::Foo::Bar)
           RUBY
         end
 
@@ -52,10 +58,16 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubleReference do
           expect_offense(<<~RUBY, verified_double: verified_double)
             %{verified_double}(ClassName)
             _{verified_double} ^^^^^^^^^ Use a string class reference for verified doubles.
+            %{verified_double}(Foo::Bar::Baz)
+            _{verified_double} ^^^^^^^^^^^^^ Use a string class reference for verified doubles.
+            %{verified_double}(::Foo::Bar)
+            _{verified_double} ^^^^^^^^^^ Use a string class reference for verified doubles.
           RUBY
 
           expect_correction(<<~RUBY)
             #{verified_double}('ClassName')
+            #{verified_double}('Foo::Bar::Baz')
+            #{verified_double}('::Foo::Bar')
           RUBY
         end
 


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1588

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
