### PR TITLE
Fix a false positive for `RSpec/MatchArray` when `match_array` with an empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/MatchArray` when `match_array` with an empty array. ([@ydah])
+
 ## 2.19.0 (2023-03-06)
 
 - Fix a false positive for `RSpec/ContextWording` when context is interpolated string literal or execute string. ([@ydah])

--- a/lib/rubocop/cop/rspec/match_array.rb
+++ b/lib/rubocop/cop/rspec/match_array.rb
@@ -23,9 +23,14 @@ module RuboCop
         MSG = 'Prefer `contain_exactly` when matching an array literal.'
         RESTRICT_ON_SEND = %i[match_array].freeze
 
+        # @!method match_array_with_empty_array?(node)
+        def_node_matcher :match_array_with_empty_array?, <<~PATTERN
+          (send nil? :match_array (array))
+        PATTERN
+
         def on_send(node)
-          return unless node.first_argument.array_type?
-          return if node.first_argument.percent_literal?
+          return if match_array_with_empty_array?(node)
+          return unless offensive_argument?(node)
 
           add_offense(node) do |corrector|
             array_contents = node.arguments.flat_map(&:to_a)
@@ -34,6 +39,14 @@ module RuboCop
               "contain_exactly(#{array_contents.map(&:source).join(', ')})"
             )
           end
+        end
+
+        private
+
+        def offensive_argument?(node)
+          return unless (first_argument = node.first_argument)
+
+          first_argument.array_type? && !first_argument.percent_literal?
         end
       end
     end

--- a/spec/rubocop/cop/rspec/match_array_spec.rb
+++ b/spec/rubocop/cop/rspec/match_array_spec.rb
@@ -41,4 +41,18 @@ RSpec.describe RuboCop::Cop::RSpec::MatchArray do
       it { is_expected.to match_array(%i(foo bar baz)) }
     RUBY
   end
+
+  it 'does not flag `match_array` with an empty array' do
+    expect_no_offenses(<<-RUBY)
+      it { is_expected.to match_array([]) }
+      it { is_expected.to match_array(%w()) }
+      it { is_expected.to match_array(%i()) }
+    RUBY
+  end
+
+  it 'does not flag `match_array` with no arguments' do
+    expect_no_offenses(<<-RUBY)
+      it { is_expected.to match_array }
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix: #1591

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).