### PR TITLE
Add support for `RSpec/ContainExactly` when calling `match_array` with no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group. ([@ydah])
+- Add support for `RSpec/ContainExactly` when calling `match_array` with no arguments. ([@ydah])
 
 ## 2.19.0 (2023-03-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -202,7 +202,7 @@ RSpec/ClassCheck:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ClassCheck
 
 RSpec/ContainExactly:
-  Description: Prefer `match_array` when matching array values.
+  Description: Checks where `contain_exactly` is used.
   Enabled: true
   VersionAdded: '2.19'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContainExactly

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -550,7 +550,11 @@ expect(object).to be_a_kind_of(String)
 | -
 |===
 
-Prefer `match_array` when matching array values.
+Checks where `contain_exactly` is used.
+
+This cop checks for the following:
+- Prefer `match_array` when matching array values.
+- Prefer `be_empty` when using `contain_exactly` with no arguments.
 
 === Examples
 
@@ -564,6 +568,14 @@ it { is_expected.to match_array(array1 + array2) }
 
 # good
 it { is_expected.to contain_exactly(content, *array) }
+
+# bad
+it { is_expected.to contain_exactly }
+it { is_expected.to contain_exactly() }
+
+# good
+it { is_expected.to be_empty }
+it { is_expected.to be_empty }
 ----
 
 === References

--- a/lib/rubocop/cop/rspec/contain_exactly.rb
+++ b/lib/rubocop/cop/rspec/contain_exactly.rb
@@ -3,7 +3,11 @@
 module RuboCop
   module Cop
     module RSpec
-      # Prefer `match_array` when matching array values.
+      # Checks where `contain_exactly` is used.
+      #
+      # This cop checks for the following:
+      # - Prefer `match_array` when matching array values.
+      # - Prefer `be_empty` when using `contain_exactly` with no arguments.
       #
       # @example
       #   # bad
@@ -14,23 +18,48 @@ module RuboCop
       #
       #   # good
       #   it { is_expected.to contain_exactly(content, *array) }
+      #
+      #   # bad
+      #   it { is_expected.to contain_exactly }
+      #   it { is_expected.to contain_exactly() }
+      #
+      #   # good
+      #   it { is_expected.to be_empty }
+      #   it { is_expected.to be_empty }
+      #
       class ContainExactly < Base
         extend AutoCorrector
 
         MSG = 'Prefer `match_array` when matching array values.'
+        MSG_EMPTY_COLLECTION =
+          'Prefer `be_empty` when matching an empty collection.'
         RESTRICT_ON_SEND = %i[contain_exactly].freeze
 
         def on_send(node)
-          return unless node.each_child_node.all?(&:splat_type?)
-
-          add_offense(node) do |corrector|
-            autocorrect(node, corrector)
+          if node.arguments.empty?
+            check_empty_collection(node)
+          else
+            check_populated_collection(node)
           end
         end
 
         private
 
-        def autocorrect(node, corrector)
+        def check_empty_collection(node)
+          add_offense(node, message: MSG_EMPTY_COLLECTION) do |corrector|
+            corrector.replace(node.source_range, 'be_empty')
+          end
+        end
+
+        def check_populated_collection(node)
+          return unless node.each_child_node.all?(&:splat_type?)
+
+          add_offense(node) do |corrector|
+            autocorrect_for_populated_array(node, corrector)
+          end
+        end
+
+        def autocorrect_for_populated_array(node, corrector)
           arrays = node.arguments.map do |splat_node|
             splat_node.children.first
           end

--- a/spec/rubocop/cop/rspec/contain_exactly_spec.rb
+++ b/spec/rubocop/cop/rspec/contain_exactly_spec.rb
@@ -44,4 +44,18 @@ RSpec.describe RuboCop::Cop::RSpec::ContainExactly do
       it { is_expected.to contain_exactly(*array, content) }
     RUBY
   end
+
+  it 'flags `contain_exactly` with no arguments' do
+    expect_offense(<<-RUBY)
+      it { is_expected.to contain_exactly }
+                          ^^^^^^^^^^^^^^^ Prefer `be_empty` when matching an empty collection.
+      it { is_expected.to contain_exactly() }
+                          ^^^^^^^^^^^^^^^^^ Prefer `be_empty` when matching an empty collection.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it { is_expected.to be_empty }
+      it { is_expected.to be_empty }
+    RUBY
+  end
 end


### PR DESCRIPTION
When calling `contain_exactly` with no arguments, you might as well use the simpler eq matcher with a [] argument.

Same fixing: https://github.com/rubocop/rubocop-rspec/pull/1597
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
