### PR TITLE
Fix an invalid autocorrect for RSpec/MatchArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group. ([@ydah])
 - Add support for `RSpec/ContainExactly` when calling `match_array` with no arguments. ([@ydah])
+- Fix an incorrect autocorrect for `RSpec/MatchArray` when calling `match_array` with an empty array literal. ([@bquorning])
 
 ## 2.19.0 (2023-03-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -563,7 +563,7 @@ RSpec/LetSetup:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetSetup
 
 RSpec/MatchArray:
-  Description: Prefer `contain_exactly` when matching an array literal.
+  Description: Checks where `match_array` is used.
   Enabled: true
   VersionAdded: '2.19'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MatchArray

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2898,7 +2898,11 @@ end
 | -
 |===
 
-Prefer `contain_exactly` when matching an array literal.
+Checks where `match_array` is used.
+
+This cop checks for the following:
+- Prefer `contain_exactly` when matching an array with values.
+- Prefer `eq` when using `match_array` with an empty array literal.
 
 === Examples
 
@@ -2915,6 +2919,13 @@ it { is_expected.to match_array([content] + array) }
 
 # good
 it { is_expected.to match_array(%w(tremble in fear foolish mortals)) }
+
+# bad
+it { is_expected.to match_array([]) }
+it { is_expected.to match_array(%w[]) }
+
+# good
+it { is_expected.to eq([]) }
 ----
 
 === References

--- a/spec/rubocop/cop/rspec/match_array_spec.rb
+++ b/spec/rubocop/cop/rspec/match_array_spec.rb
@@ -23,6 +23,23 @@ RSpec.describe RuboCop::Cop::RSpec::MatchArray do
     RUBY
   end
 
+  it 'flags `match_array` with an empty array literal argument' do
+    expect_offense(<<-RUBY)
+      it { is_expected.to match_array([]) }
+                          ^^^^^^^^^^^^^^^ Prefer `eq` when matching an empty array literal.
+      it { is_expected.to match_array(%w()) }
+                          ^^^^^^^^^^^^^^^^^ Prefer `eq` when matching an empty array literal.
+      it { is_expected.to match_array(%i()) }
+                          ^^^^^^^^^^^^^^^^^ Prefer `eq` when matching an empty array literal.
+    RUBY
+
+    expect_correction(<<-RUBY)
+      it { is_expected.to eq([]) }
+      it { is_expected.to eq([]) }
+      it { is_expected.to eq([]) }
+    RUBY
+  end
+
   it 'does not flag `contain_exactly`' do
     expect_no_offenses(<<-RUBY)
       it { is_expected.to contain_exactly(content1, content2) }


### PR DESCRIPTION
When calling `match_array` with an empty array literal, you might as well use the simpler `eq` matcher with a `[]` argument.

Fixes #1591.
Closes #1592.
Closes #1594.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
