### PR TITLE
Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group. ([@ydah])
+
 ## 2.19.0 (2023-03-06)
 
 - Fix a false positive for `RSpec/ContextWording` when context is interpolated string literal or execute string. ([@ydah])

--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -70,7 +70,12 @@ module RuboCop
 
         # @!method skipped_by_example_method?(node)
         def_node_matcher :skipped_by_example_method?, <<~PATTERN
-          (send nil? ${#Examples.skipped #Examples.pending} ...)
+          (send nil? ${#Examples.skipped #Examples.pending})
+        PATTERN
+
+        # @!method skipped_by_example_method_with_block?(node)
+        def_node_matcher :skipped_by_example_method_with_block?, <<~PATTERN
+          ({block numblock} (send nil? ${#Examples.skipped #Examples.pending} ...) ...)
         PATTERN
 
         # @!method metadata_without_reason?(node)
@@ -135,6 +140,10 @@ module RuboCop
 
         def on_skipped_by_example_method(node)
           skipped_by_example_method?(node) do |pending|
+            add_offense(node, message: "Give the reason for #{pending}.")
+          end
+
+          skipped_by_example_method_with_block?(node.parent) do |pending|
             add_offense(node, message: "Give the reason for #{pending}.")
           end
         end

--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -107,7 +107,7 @@ module RuboCop
             on_skipped_by_example_method(node)
             on_skipped_by_example_group_method(node)
           elsif example?(parent)
-            on_skipped_by_in_example_method(node, parent)
+            on_skipped_by_in_example_method(node)
           end
         end
 
@@ -126,7 +126,7 @@ module RuboCop
             explicit_rspec?(node.receiver)
         end
 
-        def on_skipped_by_in_example_method(node, _direct_parent)
+        def on_skipped_by_in_example_method(node)
           skipped_in_example?(node) do |pending|
             add_offense(node, message: "Give the reason for #{pending}.")
           end

--- a/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason, :ruby27 do
     end
   end
 
+  context 'when pending/skip has a reason inside an example group' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe Foo do
+          skip 'does something'
+          pending 'does something'
+        end
+      RUBY
+    end
+  end
+
   context 'when pending/skip by metadata on example with reason' do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1596

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
