### PR TITLE
Fix a false positive for RSpec/FactoryBot/ConsistentParenthesesStyle inside &&, || and :? when omit_parentheses is on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/FactoryBot/ConsistentParenthesesStyle` inside `&&`, `||` and `:?` when `omit_parentheses` is on ([@dmitrytsepelev])
 - Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group. ([@ydah])
 - Add support for `RSpec/ContainExactly` when calling `match_array` with no arguments. ([@ydah])
 - Fix an incorrect autocorrect for `RSpec/MatchArray` when calling `match_array` with an empty array literal. ([@bquorning])
@@ -762,6 +763,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@dduugg]: https://github.com/dduugg
 [@deivid-rodriguez]: https://github.com/deivid-rodriguez
 [@dgollahon]: https://github.com/dgollahon
+[@dmitrytsepelev]: https://github.com/dmitrytsepelev
 [@drowze]: https://github.com/Drowze
 [@dswij]: https://github.com/dswij
 [@dvandersluis]: https://github.com/dvandersluis

--- a/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
+++ b/lib/rubocop/cop/rspec/factory_bot/consistent_parentheses_style.rb
@@ -100,10 +100,10 @@ module RuboCop
             end
           end
 
+          AMBIGUOUS_TYPES = %i[send pair array and or if].freeze
+
           def ambiguous_without_parentheses?(node)
-            node.parent&.send_type? ||
-              node.parent&.pair_type? ||
-              node.parent&.array_type?
+            node.parent && AMBIGUOUS_TYPES.include?(node.parent.type)
           end
 
           def remove_parentheses(corrector, node)

--- a/spec/rubocop/cop/rspec/factory_bot/consistent_parentheses_style_spec.rb
+++ b/spec/rubocop/cop/rspec/factory_bot/consistent_parentheses_style_spec.rb
@@ -199,6 +199,24 @@ RSpec.describe RuboCop::Cop::RSpec::FactoryBot::ConsistentParenthesesStyle do
       end
     end
 
+    %w[&& ||].each do |operator|
+      context "with #{operator}" do
+        it 'does not flag the call' do
+          expect_no_offenses(<<~RUBY)
+            can_create_user? #{operator} create(:user)
+          RUBY
+        end
+      end
+    end
+
+    context 'with ternary operator' do
+      it 'does not flag the call' do
+        expect_no_offenses(<<~RUBY)
+          can_create_user? ? create(:user) : nil
+        RUBY
+      end
+    end
+
     context 'with mixed tests' do
       it 'flags the call not to use parentheses' do
         expect_offense(<<~RUBY)


### PR DESCRIPTION
Now cop does not suggest changes in following situations (these suggestions end up in invalid syntax):

```
can_create_user? && create(:user)
can_create_user? || create(:user)
can_create_user? ? create(:user) : nil
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [X] Updated documentation.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
