### PR TITLE
Add `Strict` configuration option to `RSpec/PendingWithoutReason`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group. ([@ydah])
 - Change `RSpec/ContainExactly` to ignore calls with no arguments, and change `RSpec/MatchArray` to ignore calls with an empty array literal argument. ([@ydah], [@bquorning])
 - Add new `RSpec/BeEmpty` cop. ([@ydah], [@bquorning])
+- Add support for `RSpec/ContainExactly` when calling `match_array` with no arguments. ([@ydah])
+- Fix an incorrect autocorrect for `RSpec/MatchArray` when calling `match_array` with an empty array literal. ([@bquorning])
+- Add `Strict` configuration option to `RSpec/PendingWithoutReason`. ([@ydah])
 
 ## 2.19.0 (2023-03-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -695,7 +695,9 @@ RSpec/Pending:
 RSpec/PendingWithoutReason:
   Description: Checks for pending or skipped examples without reason.
   Enabled: pending
+  Strict: false
   VersionAdded: '2.16'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PendingWithoutReason
 
 RSpec/PredicateMatcher:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3953,66 +3953,78 @@ end
 | Yes
 | No
 | 2.16
-| -
+| <<next>>
 |===
 
 Checks for pending or skipped examples without reason.
 
 === Examples
 
+==== Strict: false (default)
+
 [source,ruby]
 ----
-# bad
-pending 'does something' do
-end
-
-# bad
-it 'does something', :pending do
-end
-
 # bad
 it 'does something' do
   pending
 end
 
 # bad
-xdescribe 'something' do
-end
-
-# bad
-skip 'does something' do
-end
-
-# bad
 it 'does something', :skip do
 end
 
-# bad
-it 'does something' do
-  skip
+# good
+it 'does something', skip: 'reason' do
 end
-
-# bad
-it 'does something'
 
 # good
 it 'does something' do
   pending 'reason'
 end
 
-# good
-it 'does something' do
-  skip 'reason'
+# also good - when pending/skip block with string argument
+pending 'does something' do
 end
 
-# good
-it 'does something', pending: 'reason' do
+# also good - when xdescribe block with string argument
+xdescribe 'something' do
 end
 
-# good
-it 'does something', skip: 'reason' do
+# also good - when pending/skip block with string argument
+#             but not inside an example
+RSpec.describe 'something' do
+  pending 'does something'
 end
 ----
+
+==== Strict: true
+
+[source,ruby]
+----
+# bad - when pending/skip block with string argument
+pending 'does something' do
+end
+
+# bad - when xdescribe block with string argument
+xdescribe 'something' do
+end
+
+# bad - when pending/skip block with string argument
+#       but not inside an example
+RSpec.describe 'something' do
+  pending 'does something'
+end
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| Strict
+| `false`
+| Boolean
+|===
 
 === References
 

--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -70,12 +70,7 @@ module RuboCop
 
         # @!method skipped_by_example_method?(node)
         def_node_matcher :skipped_by_example_method?, <<~PATTERN
-          (send nil? ${#Examples.skipped #Examples.pending})
-        PATTERN
-
-        # @!method skipped_by_example_method_with_block?(node)
-        def_node_matcher :skipped_by_example_method_with_block?, <<~PATTERN
-          ({block numblock} (send nil? ${#Examples.skipped #Examples.pending} ...) ...)
+          (send nil? ${#Examples.skipped #Examples.pending} ...)
         PATTERN
 
         # @!method metadata_without_reason?(node)
@@ -140,10 +135,6 @@ module RuboCop
 
         def on_skipped_by_example_method(node)
           skipped_by_example_method?(node) do |pending|
-            add_offense(node, message: "Give the reason for #{pending}.")
-          end
-
-          skipped_by_example_method_with_block?(node.parent) do |pending|
             add_offense(node, message: "Give the reason for #{pending}.")
           end
         end

--- a/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
@@ -18,17 +18,6 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason, :ruby27 do
     end
   end
 
-  context 'when pending/skip has a reason inside an example group' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~RUBY)
-        RSpec.describe Foo do
-          skip 'does something'
-          pending 'does something'
-        end
-      RUBY
-    end
-  end
-
   context 'when pending/skip by metadata on example with reason' do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
@@ -1,284 +1,299 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason, :ruby27 do
-  context 'when pending/skip has a reason inside an example' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~'RUBY')
-        RSpec.describe Foo do
-          it 'does something' do
-            pending 'reason'
-            pending "#{reason}"
-            pending `echo #{reason}`
-            skip 'reason'
-            skip "#{reason}"
-            skip `echo #{reason}`
-          end
-        end
-      RUBY
-    end
-  end
+  context 'when Strict: true' do
+    let(:cop_config) { { 'Strict' => true } }
 
-  context 'when pending/skip by metadata on example with reason' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~RUBY)
-        RSpec.describe Foo do
-          it 'does something', pending: 'reason' do
+    context 'when pending/skip has a reason inside an example group' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            skip 'does something'
+            ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            pending 'does something'
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
           end
-          it 'does something', skip: 'reason' do
-          end
-          it 'does something', pending: 'reason' do
-            _1
-          end
-          it 'does something', skip: 'reason' do
-            _1
-          end
-        end
-      RUBY
+        RUBY
+      end
     end
-  end
 
-  context 'when pending/skip by metadata on example group with reason' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~RUBY)
-        describe 'something', pending: 'reason' do
-        end
-        describe 'something', skip: 'reason' do
-        end
-        describe 'something', pending: 'reason' do
-          _1
-        end
-        describe 'something', skip: 'reason' do
-          _1
-        end
-      RUBY
-    end
-  end
-
-  context 'when pending/skip not inside an example' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~RUBY)
-        FactoryBot.define do
-          factory :task do
-            pending
-            skip
-            pending { true }
-            skip { true }
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when pending/skip with receiver' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~RUBY)
-        RSpec.describe Foo do
-          it 'does something' do
-            Foo.pending
-            Foo.skip
-          end
-          it 'does something' do
-            _1.pending
-            _1.skip
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when pending/skip is an argument' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~RUBY)
-        RSpec.describe Foo do
-          it 'does something' do
-            expect('foo').to eq(pending)
-            expect('foo').to eq(skip)
-            foo(bar, pending, skip)
-            foo(bar, pending: pending, skip: skip)
-            is_expected.to match_array([foo, pending, skip, bar])
-            list = [skip, pending]
-            foo(list)
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when pending/skip by example method with block' do
-    it 'registers offense' do
-      expect_offense(<<~RUBY)
-        RSpec.describe Foo do
-          pending 'does something' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
-          end
-          skip 'does something' do
-          ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-          end
-          skip 'does something' do
-          ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-            _1
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when pending inside an example with a block' do
-    it 'registers no offense' do
-      # `ArgumentError` is raised when block is given to `pending` inside
-      # an example.
-      expect_no_offenses(<<~RUBY)
-        RSpec.describe Foo do
-          it 'does something' do
+    context 'when pending/skip by example method with block' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
             pending 'does something' do
-              do_something
-            end
-            pending 'does something' do
-              _1.do_something
-            end
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when skip inside an example with a block' do
-    it 'registers no offense' do
-      # RSpec ignores the block
-      expect_no_offenses(<<~RUBY)
-        RSpec.describe Foo do
-          it 'does something' do
-            skip 'does something' do
-              do_something
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
             end
             skip 'does something' do
-              _1.do_something
+            ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            end
+            skip 'does something' do
+            ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+              _1
             end
           end
-        end
-      RUBY
+        RUBY
+      end
     end
-  end
 
-  context 'when pending/skip by metadata on example without reason' do
-    it 'registers offense' do
-      expect_offense(<<~RUBY)
-        RSpec.describe Foo do
-          it 'does something', :pending do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
-          end
-          it 'does something', :skip do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-          end
-          it 'does something', pending: true do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
-          end
-          it 'does something', skip: true do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-          end
-          it 'does something', :pending do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
-            _1
-          end
-          it 'does something', :skip do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-            _1
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when pending/skip by metadata on example group without reason' do
-    it 'registers offense' do
-      expect_offense(<<~RUBY)
-        describe 'something', :pending do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
-        end
-        describe 'something', :skip do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-        end
-        describe 'something', pending: true do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
-        end
-        describe 'something', skip: true do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-        end
-        describe 'something', :pending do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
-          _1
-        end
-        describe 'something', :skip do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-          _1
-        end
-      RUBY
-    end
-  end
-
-  context 'when pending/skip without reason' do
-    it 'registers offense' do
-      expect_offense(<<~RUBY)
-        RSpec.describe Foo do
-          pending
-          ^^^^^^^ Give the reason for pending.
-          skip
-          ^^^^ Give the reason for skip.
-        end
-        RSpec.describe Foo do
-          context 'when something' do
-            pending
-            ^^^^^^^ Give the reason for pending.
-          end
-          context 'when something' do
-            skip
-            ^^^^ Give the reason for skip.
-          end
-        end
-        RSpec.describe Foo do
-          it 'does something' do
-            pending
-            ^^^^^^^ Give the reason for pending.
-          end
-          it 'does something' do
-            skip
-            ^^^^ Give the reason for skip.
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when pending/skip without reason with other statement' do
-    it 'registers offense' do
-      expect_offense(<<~RUBY)
-        RSpec.describe Foo do
-          before { buzz! }
-          pending
-          ^^^^^^^ Give the reason for pending.
-          skip
-          ^^^^ Give the reason for skip.
-          context 'when something' do
-            let(:foo) { 'bar' }
-            pending
-            ^^^^^^^ Give the reason for pending.
-            skip
-            ^^^^ Give the reason for skip.
+    context 'when pending/skip has a reason inside an example' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~'RUBY')
+          RSpec.describe Foo do
             it 'does something' do
-              do_something
+              pending 'reason'
+              pending "#{reason}"
+              pending `echo #{reason}`
+              skip 'reason'
+              skip "#{reason}"
+              skip `echo #{reason}`
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by metadata on example with reason' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something', pending: 'reason' do
+            end
+            it 'does something', skip: 'reason' do
+            end
+            it 'does something', pending: 'reason' do
+              _1
+            end
+            it 'does something', skip: 'reason' do
+              _1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by metadata on example group with reason' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          describe 'something', pending: 'reason' do
+          end
+          describe 'something', skip: 'reason' do
+          end
+          describe 'something', pending: 'reason' do
+            _1
+          end
+          describe 'something', skip: 'reason' do
+            _1
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip not inside an example' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          FactoryBot.define do
+            factory :task do
+              pending
+              skip
+              pending { true }
+              skip { true }
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip with receiver' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              Foo.pending
+              Foo.skip
+            end
+            it 'does something' do
+              _1.pending
+              _1.skip
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip is an argument' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              expect('foo').to eq(pending)
+              expect('foo').to eq(skip)
+              foo(bar, pending, skip)
+              foo(bar, pending: pending, skip: skip)
+              is_expected.to match_array([foo, pending, skip, bar])
+              list = [skip, pending]
+              foo(list)
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending inside an example with a block' do
+      it 'registers no offense' do
+        # `ArgumentError` is raised when block is given to `pending` inside
+        # an example.
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              pending 'does something' do
+                do_something
+              end
+              pending 'does something' do
+                _1.do_something
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when skip inside an example with a block' do
+      it 'registers no offense' do
+        # RSpec ignores the block
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              skip 'does something' do
+                do_something
+              end
+              skip 'does something' do
+                _1.do_something
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by metadata on example without reason' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something', :pending do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+            end
+            it 'does something', :skip do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            end
+            it 'does something', pending: true do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+            end
+            it 'does something', skip: true do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            end
+            it 'does something', :pending do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+              _1
+            end
+            it 'does something', :skip do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+              _1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by metadata on example group without reason' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          describe 'something', :pending do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+          end
+          describe 'something', :skip do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+          end
+          describe 'something', pending: true do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+          end
+          describe 'something', skip: true do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+          end
+          describe 'something', :pending do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+            _1
+          end
+          describe 'something', :skip do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            _1
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip without reason' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            pending
+            ^^^^^^^ Give the reason for pending.
+            skip
+            ^^^^ Give the reason for skip.
+          end
+          RSpec.describe Foo do
+            context 'when something' do
+              pending
+              ^^^^^^^ Give the reason for pending.
+            end
+            context 'when something' do
+              skip
+              ^^^^ Give the reason for skip.
+            end
+          end
+          RSpec.describe Foo do
+            it 'does something' do
+              pending
+              ^^^^^^^ Give the reason for pending.
+            end
+            it 'does something' do
+              skip
+              ^^^^ Give the reason for skip.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip without reason with other statement' do
+      it 'registers offense when block case' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            before { buzz! }
+            pending
+            ^^^^^^^ Give the reason for pending.
+            skip
+            ^^^^ Give the reason for skip.
+            context 'when something' do
+              let(:foo) { 'bar' }
               pending
               ^^^^^^^ Give the reason for pending.
               skip
               ^^^^ Give the reason for skip.
-              do_something
+              it 'does something' do
+                do_something
+                pending
+                ^^^^^^^ Give the reason for pending.
+                skip
+                ^^^^ Give the reason for skip.
+                do_something
+              end
             end
           end
-        end
-      RUBY
-    end
+        RUBY
+      end
 
-    context 'with a numblock' do
-      it 'registers offense' do
+      it 'registers offense when numblock case' do
         expect_offense(<<~RUBY)
           RSpec.describe Foo do
             pending
@@ -305,90 +320,483 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason, :ruby27 do
         RUBY
       end
     end
-  end
 
-  context 'when pending/skip inside conditional' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~RUBY)
-        RSpec.describe Foo do
-          it 'does something' do
-            pending if RUBY_VERSION < '3.0'
-            if RUBY_VERSION < '3.0'
-              skip
+    context 'when pending/skip inside conditional' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              pending if RUBY_VERSION < '3.0'
+              if RUBY_VERSION < '3.0'
+                skip
+              end
             end
           end
-        end
-      RUBY
+        RUBY
+      end
     end
-  end
 
-  context 'when skipped by example group method' do
-    it 'registers offense' do
-      expect_offense(<<~RUBY)
-        RSpec.describe 'Foo' do
-          xdescribe 'something' do
-          ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+    context 'when skipped by example group method' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe 'Foo' do
+            xdescribe 'something' do
+            ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            end
+            xdescribe 'something' do
+            ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+              _1.do_something
+            end
           end
-          xdescribe 'something' do
-          ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+        RUBY
+      end
+    end
+
+    context 'when skipped by top-level example group' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.xdescribe 'something' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+          end
+          RSpec.xdescribe 'something' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
             _1.do_something
           end
-        end
-      RUBY
+        RUBY
+      end
     end
-  end
 
-  context 'when skipped by top-level example group' do
-    it 'registers offense' do
-      expect_offense(<<~RUBY)
-        RSpec.xdescribe 'something' do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-        end
-        RSpec.xdescribe 'something' do
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-          _1.do_something
-        end
-      RUBY
-    end
-  end
-
-  context 'when skipped by example method' do
-    it 'registers offense' do
-      expect_offense(<<~RUBY)
-        RSpec.describe 'Foo' do
-          skip 'does something' do
-          ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
-          end
-          xit 'something' do
-          ^^^^^^^^^^^^^^^ Give the reason for xit.
-          end
-          xit 'something' do
-          ^^^^^^^^^^^^^^^ Give the reason for xit.
-            _1.do_something
-          end
-          pending 'does something' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
-            _1
-          end
-        end
-      RUBY
-    end
-  end
-
-  context 'when skipped inside an example' do
-    it 'registers no offense' do
-      expect_no_offenses(<<~RUBY)
-        RSpec.describe Foo do
-          it 'does something' do
+    context 'when skipped by example method' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe 'Foo' do
             skip 'does something' do
-              do_something
+            ^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            end
+            xit 'something' do
+            ^^^^^^^^^^^^^^^ Give the reason for xit.
+            end
+            xit 'something' do
+            ^^^^^^^^^^^^^^^ Give the reason for xit.
+              _1.do_something
+            end
+            pending 'does something' do
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+              _1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when skipped inside an example' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              skip 'does something' do
+                do_something
+              end
+              skip 'does something' do
+                _1
+              end
+            end
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'when Strict: false' do
+    let(:cop_config) { { 'Strict' => false } }
+
+    context 'when pending/skip with string inside an example group' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            skip 'does something'
+            pending 'does something'
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by example method with block' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            pending 'does something' do
+            end
+            skip 'does something' do
             end
             skip 'does something' do
               _1
             end
           end
-        end
-      RUBY
+        RUBY
+      end
+    end
+
+    context 'when pending/skip has a reason inside an example' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~'RUBY')
+          RSpec.describe Foo do
+            it 'does something' do
+              pending 'reason'
+              pending "#{reason}"
+              pending `echo #{reason}`
+              skip 'reason'
+              skip "#{reason}"
+              skip `echo #{reason}`
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by metadata on example with reason' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something', pending: 'reason' do
+            end
+            it 'does something', skip: 'reason' do
+            end
+            it 'does something', pending: 'reason' do
+              _1
+            end
+            it 'does something', skip: 'reason' do
+              _1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by metadata on example group with reason' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          describe 'something', pending: 'reason' do
+          end
+          describe 'something', skip: 'reason' do
+          end
+          describe 'something', pending: 'reason' do
+            _1
+          end
+          describe 'something', skip: 'reason' do
+            _1
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip not inside an example' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          FactoryBot.define do
+            factory :task do
+              pending
+              skip
+              pending { true }
+              skip { true }
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip with receiver' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              Foo.pending
+              Foo.skip
+            end
+            it 'does something' do
+              _1.pending
+              _1.skip
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip is an argument' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              expect('foo').to eq(pending)
+              expect('foo').to eq(skip)
+              foo(bar, pending, skip)
+              foo(bar, pending: pending, skip: skip)
+              is_expected.to match_array([foo, pending, skip, bar])
+              list = [skip, pending]
+              foo(list)
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending inside an example with a block' do
+      it 'registers no offense' do
+        # `ArgumentError` is raised when block is given to `pending` inside
+        # an example.
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              pending 'does something' do
+                do_something
+              end
+              pending 'does something' do
+                _1.do_something
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when skip inside an example with a block' do
+      it 'registers no offense' do
+        # RSpec ignores the block
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              skip 'does something' do
+                do_something
+              end
+              skip 'does something' do
+                _1.do_something
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by metadata on example without reason' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something', :pending do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+            end
+            it 'does something', :skip do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            end
+            it 'does something', pending: true do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+            end
+            it 'does something', skip: true do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            end
+            it 'does something', :pending do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+              _1
+            end
+            it 'does something', :skip do
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+              _1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip by metadata on example group without reason' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          describe 'something', :pending do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+          end
+          describe 'something', :skip do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+          end
+          describe 'something', pending: true do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+          end
+          describe 'something', skip: true do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+          end
+          describe 'something', :pending do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for pending.
+            _1
+          end
+          describe 'something', :skip do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Give the reason for skip.
+            _1
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip without reason' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            pending
+            ^^^^^^^ Give the reason for pending.
+            skip
+            ^^^^ Give the reason for skip.
+          end
+          RSpec.describe Foo do
+            context 'when something' do
+              pending
+              ^^^^^^^ Give the reason for pending.
+            end
+            context 'when something' do
+              skip
+              ^^^^ Give the reason for skip.
+            end
+          end
+          RSpec.describe Foo do
+            it 'does something' do
+              pending
+              ^^^^^^^ Give the reason for pending.
+            end
+            it 'does something' do
+              skip
+              ^^^^ Give the reason for skip.
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip without reason with other statement' do
+      it 'registers offense when block case' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            before { buzz! }
+            pending
+            ^^^^^^^ Give the reason for pending.
+            skip
+            ^^^^ Give the reason for skip.
+            context 'when something' do
+              let(:foo) { 'bar' }
+              pending
+              ^^^^^^^ Give the reason for pending.
+              skip
+              ^^^^ Give the reason for skip.
+              it 'does something' do
+                do_something
+                pending
+                ^^^^^^^ Give the reason for pending.
+                skip
+                ^^^^ Give the reason for skip.
+                do_something
+              end
+            end
+          end
+        RUBY
+      end
+
+      it 'registers offense when numblock case' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            pending
+            ^^^^^^^ Give the reason for pending.
+            skip
+            ^^^^ Give the reason for skip.
+            _1
+            context 'when something' do
+              _1
+              pending
+              ^^^^^^^ Give the reason for pending.
+              skip
+              ^^^^ Give the reason for skip.
+              it 'does something' do
+                _1
+                skip
+                ^^^^ Give the reason for skip.
+                pending
+                ^^^^^^^ Give the reason for pending.
+                _1
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when pending/skip inside conditional' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              pending if RUBY_VERSION < '3.0'
+              if RUBY_VERSION < '3.0'
+                skip
+              end
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when skipped by example group method' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe 'Foo' do
+            xdescribe 'something' do
+            end
+            xdescribe 'something' do
+              _1.do_something
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when skipped by top-level example group' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.xdescribe 'something' do
+          end
+          RSpec.xdescribe 'something' do
+            _1.do_something
+          end
+        RUBY
+      end
+    end
+
+    context 'when skipped by example method' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe 'Foo' do
+            skip 'does something' do
+            end
+            xit 'something' do
+            end
+            xit 'something' do
+              _1.do_something
+            end
+            pending 'does something' do
+              _1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'when skipped inside an example' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          RSpec.describe Foo do
+            it 'does something' do
+              skip 'does something' do
+                do_something
+              end
+              skip 'does something' do
+                _1
+              end
+            end
+          end
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
This PR is add `Strict` configuration option to `RSpec/PendingWithoutReason`.
The following PR was found to be an incorrect fix, so I have reverted and added support for this option.
- https://github.com/rubocop/rubocop-rspec/pull/1598

This option works as before by default, but setting it to `Strict: false` will make it a violation only in the following cases
- when a `pending` or `skip` method is called with no arguments
- When a pending/skip is done as metadata for example or example group, but there is no reason for it
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
