### PR TITLE
Correct offenses for `InternalAffairs/RedundantSourceRange`

### DIFF
--- a/lib/rubocop/cop/rspec/be_nil.rb
+++ b/lib/rubocop/cop/rspec/be_nil.rb
@@ -57,7 +57,7 @@ module RuboCop
           return unless be_nil_matcher?(node)
 
           add_offense(node, message: BE_MSG) do |corrector|
-            corrector.replace(node.source_range, 'be(nil)')
+            corrector.replace(node, 'be(nil)')
           end
         end
 
@@ -65,7 +65,7 @@ module RuboCop
           return unless nil_value_expectation?(node)
 
           add_offense(node, message: BE_NIL_MSG) do |corrector|
-            corrector.replace(node.source_range, 'be_nil')
+            corrector.replace(node, 'be_nil')
           end
         end
       end

--- a/lib/rubocop/cop/rspec/contain_exactly.rb
+++ b/lib/rubocop/cop/rspec/contain_exactly.rb
@@ -47,7 +47,7 @@ module RuboCop
 
         def check_empty_collection(node)
           add_offense(node, message: MSG_EMPTY_COLLECTION) do |corrector|
-            corrector.replace(node.source_range, 'be_empty')
+            corrector.replace(node, 'be_empty')
           end
         end
 
@@ -64,7 +64,7 @@ module RuboCop
             splat_node.children.first
           end
           corrector.replace(
-            node.source_range,
+            node,
             "match_array(#{arrays.map(&:source).join(' + ')})"
           )
         end

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -93,8 +93,8 @@ module RuboCop
         end
 
         def swap(corrector, actual, expected)
-          corrector.replace(actual.source_range, expected.source)
-          corrector.replace(expected.source_range, actual.source)
+          corrector.replace(actual, expected.source)
+          corrector.replace(expected, actual.source)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/match_array.rb
+++ b/lib/rubocop/cop/rspec/match_array.rb
@@ -54,7 +54,7 @@ module RuboCop
 
         def check_empty_array(node)
           add_offense(node, message: MSG_EMPTY_ARRAY) do |corrector|
-            corrector.replace(node.source_range, 'eq([])')
+            corrector.replace(node, 'eq([])')
           end
         end
 
@@ -64,7 +64,7 @@ module RuboCop
           add_offense(node) do |corrector|
             array_contents = node.arguments.flat_map(&:to_a)
             corrector.replace(
-              node.source_range,
+              node,
               "contain_exactly(#{array_contents.map(&:source).join(', ')})"
             )
           end

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -226,8 +226,7 @@ module RuboCop
           block = block_loc ? block_loc.source : ''
 
           corrector.remove(block_loc) if block_loc
-          corrector.insert_after(actual,
-                                 ".#{predicate}" + args + block)
+          corrector.insert_after(actual, ".#{predicate}" + args + block)
         end
 
         # rubocop:disable Metrics/MethodLength

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -99,7 +99,7 @@ module RuboCop
           block = block_loc ? block_loc.source : ''
 
           corrector.replace(
-            matcher.source_range,
+            matcher,
             to_predicate_matcher(predicate.method_name) + args + block
           )
         end
@@ -214,7 +214,7 @@ module RuboCop
 
         def corrector_explicit(corrector, to_node, actual, matcher, block_child)
           replacement_matcher = replacement_matcher(to_node)
-          corrector.replace(matcher.source_range, replacement_matcher)
+          corrector.replace(matcher, replacement_matcher)
           move_predicate(corrector, actual, matcher, block_child)
           corrector.replace(to_node.loc.selector, 'to')
         end
@@ -226,7 +226,7 @@ module RuboCop
           block = block_loc ? block_loc.source : ''
 
           corrector.remove(block_loc) if block_loc
-          corrector.insert_after(actual.source_range,
+          corrector.insert_after(actual,
                                  ".#{predicate}" + args + block)
         end
 

--- a/lib/rubocop/cop/rspec/rails/have_http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/have_http_status.rb
@@ -38,7 +38,7 @@ module RuboCop
             match_status(node) do |response_status, to, match, status|
               message = format(MSG, to: to, match: match.source, status: status)
               add_offense(node, message: message) do |corrector|
-                corrector.replace(response_status.source_range, 'response')
+                corrector.replace(response_status, 'response')
                 corrector.replace(match.loc.selector, 'have_http_status')
               end
             end


### PR DESCRIPTION
https://github.com/rubocop/rubocop-rspec/actions/runs/4464125341/jobs/7839977882?pr=1605#logs

```
Inspecting 278 files
............C...........C....................C.........................C.........................C.C..................................................................................................................................................................................

Offenses:

lib/rubocop/cop/rspec/be_nil.rb:60:36: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
            corrector.replace(node.source_range, 'be(nil)')
                                   ^^^^^^^^^^^^
lib/rubocop/cop/rspec/be_nil.rb:68:36: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
            corrector.replace(node.source_range, 'be_nil')
                                   ^^^^^^^^^^^^
lib/rubocop/cop/rspec/contain_exactly.rb:50:36: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
            corrector.replace(node.source_range, 'be_empty')
                                   ^^^^^^^^^^^^
lib/rubocop/cop/rspec/contain_exactly.rb:6[7](https://github.com/rubocop/rubocop-rspec/actions/runs/4464125341/jobs/7839977882?pr=1605#step:5:8):1[8](https://github.com/rubocop/rubocop-rspec/actions/runs/4464125341/jobs/7839977882?pr=1605#step:5:9): C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
            node.source_range,
                 ^^^^^^^^^^^^
lib/rubocop/cop/rspec/expect_actual.rb:[9](https://github.com/rubocop/rubocop-rspec/actions/runs/4464125341/jobs/7839977882?pr=1605#step:5:10)6:36: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
          corrector.replace(actual.source_range, expected.source)
                                   ^^^^^^^^^^^^
lib/rubocop/cop/rspec/expect_actual.rb:97:38: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
          corrector.replace(expected.source_range, actual.source)
                                     ^^^^^^^^^^^^
lib/rubocop/cop/rspec/match_array.rb:57:36: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
            corrector.replace(node.source_range, 'eq([])')
                                   ^^^^^^^^^^^^
lib/rubocop/cop/rspec/match_array.rb:67:20: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
              node.source_range,
                   ^^^^^^^^^^^^
lib/rubocop/cop/rspec/predicate_matcher.rb:[10](https://github.com/rubocop/rubocop-rspec/actions/runs/4464125341/jobs/7839977882?pr=1605#step:5:11)2:21: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
            matcher.source_range,
                    ^^^^^^^^^^^^
lib/rubocop/cop/rspec/predicate_matcher.rb:217:37: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
          corrector.replace(matcher.source_range, replacement_matcher)
                                    ^^^^^^^^^^^^
lib/rubocop/cop/rspec/predicate_matcher.rb:229:41: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
          corrector.insert_after(actual.source_range,
                                        ^^^^^^^^^^^^
lib/rubocop/cop/rspec/rails/have_http_status.rb:41:51: C: [Correctable] InternalAffairs/RedundantSourceRange: Remove the redundant source_range.
                corrector.replace(response_status.source_range, 'response')
                                                  ^^^^^^^^^^^^

278 files inspected, [12](https://github.com/rubocop/rubocop-rspec/actions/runs/4464125341/jobs/7839977882?pr=1605#step:5:13) offenses detected, 12 offenses autocorrectable
Error: Process completed with exit code 1.
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).