### PR TITLE
Add support for `RSpec/HaveHttpStatus` when using `response.code`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Add autocorrect support for `RSpec/ScatteredSetup`. ([@ydah])
 - Fix a false negative for `RSpec/RedundantAround` when redundant numblock `around`. ([@ydah])
 - Add support for shared example groups to `RSpec/EmptyLineAfterExampleGroup`. ([@pirj])
+- Add support for `RSpec/HaveHttpStatus` when using `response.code`. ([@ydah])
 
 ## 2.19.0 (2023-03-06)
 

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -53,6 +53,7 @@ Checks that tests use `have_http_status` instead of equality matchers.
 ----
 # bad
 expect(response.status).to be(200)
+expect(response.code).to eq("200")
 
 # good
 expect(response).to have_http_status(200)

--- a/spec/rubocop/cop/rspec/rails/have_http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/have_http_status_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HaveHttpStatus do
     RUBY
   end
 
+  it 'registers an offense for `expect(response.code).to eq("200")`' do
+    expect_offense(<<~RUBY)
+      it { expect(response.code).to eq("200") }
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `expect(response).to have_http_status(200)` over `expect(response.code).to eq("200")`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      it { expect(response).to have_http_status(200) }
+    RUBY
+  end
+
   it 'does not register an offense for `is_expected.to be(200)`' do
     expect_no_offenses(<<~RUBY)
       it { is_expected.to be(200) }


### PR DESCRIPTION
Fixes #1609
This PR adds support for `RSpec/HaveHttpStatus` when using `response.code`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).