### PR TITLE
Fix an incorrect autocorrect for `RSpec/Rails/TravelAround` when other before block exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group. ([@ydah])
 - Add support for `RSpec/ContainExactly` when calling `match_array` with no arguments. ([@ydah])
 - Fix an incorrect autocorrect for `RSpec/MatchArray` when calling `match_array` with an empty array literal. ([@bquorning])
+- Fix an incorrect autocorrect for `RSpec/Rails/TravelAround` when other before block exist. ([@ydah])
 
 ## 2.19.0 (2023-03-06)
 

--- a/spec/rubocop/cop/rspec/rails/travel_around_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/travel_around_spec.rb
@@ -67,6 +67,56 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::TravelAround do
     end
   end
 
+  context 'with `freeze_time` in `around` and other `before` with `{}' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        before { do_some_preparation }
+
+        around do |example|
+          freeze_time do
+          ^^^^^^^^^^^^^^ Prefer to travel in `before` rather than `around`.
+            example.run
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        before { do_some_preparation;freeze_time }
+
+        around do |example|
+          example.run
+        end
+      RUBY
+    end
+  end
+
+  context 'with `freeze_time` in `around` and other multiline `before` block' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        before do
+          do_some_preparation
+        end
+
+        around do |example|
+          freeze_time do
+          ^^^^^^^^^^^^^^ Prefer to travel in `before` rather than `around`.
+            example.run
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        before do
+          do_some_preparation;freeze_time
+        end
+
+        around do |example|
+          example.run
+        end
+      RUBY
+    end
+  end
+
   context 'with `freeze_time` in `around(:each)`' do
     it 'registers offense' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
This PR fixes an incorrect autocorrect for `RSpec/Rails/TravelAround` when other before block exist.

## Expected behavior

### Given

```ruby
before { do_some_preparation }
around do |example|
  freeze_time do
    example.run
  end
end
```

### Corrected

```ruby
before { do_some_preparation;freeze_time }
around do |example|
  example.run
end
```

## Actual behavior

### Given

```ruby
before { do_some_preparation }
around do |example|
  freeze_time do
    example.run
  end
end
```

### Corrected

```ruby
before { do_some_preparation }
before { freeze_time }

around do |example|
  example.run
end
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
