### PR TITLE
Make `RSpec/MatchArray` and `RSpec/ContainExactly` pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group. ([@ydah])
 - Change `RSpec/ContainExactly` to ignore calls with no arguments, and change `RSpec/MatchArray` to ignore calls with an empty array literal argument. ([@ydah], [@bquorning])
 - Add new `RSpec/BeEmpty` cop. ([@ydah], [@bquorning])
+- Make `RSpec/MatchArray` and `RSpec/ContainExactly` pending. ([@ydah])
 
 ## 2.19.0 (2023-03-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -209,7 +209,7 @@ RSpec/ClassCheck:
 
 RSpec/ContainExactly:
   Description: Checks where `contain_exactly` is used.
-  Enabled: true
+  Enabled: pending
   VersionAdded: '2.19'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContainExactly
 
@@ -570,7 +570,7 @@ RSpec/LetSetup:
 
 RSpec/MatchArray:
   Description: Checks where `match_array` is used.
-  Enabled: true
+  Enabled: pending
   VersionAdded: '2.19'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MatchArray
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -573,7 +573,7 @@ expect(object).to be_a_kind_of(String)
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Enabled
+| Pending
 | Yes
 | Yes
 | 2.19
@@ -2913,7 +2913,7 @@ end
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Enabled
+| Pending
 | Yes
 | Yes
 | 2.19


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1612

This PR is make `RSpec/MatchArray` and `RSpec/ContainExactly` pending.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).