### PR TITLE
Add autocorrect support for `RSpec/ScatteredSetup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Change `RSpec/ContainExactly` to ignore calls with no arguments, and change `RSpec/MatchArray` to ignore calls with an empty array literal argument. ([@ydah], [@bquorning])
 - Add new `RSpec/BeEmpty` cop. ([@ydah], [@bquorning])
 - Make `RSpec/MatchArray` and `RSpec/ContainExactly` pending. ([@ydah])
+- Add autocorrect support for `RSpec/ScatteredSetup`. ([@ydah])
 
 ## 2.19.0 (2023-03-06)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4601,7 +4601,7 @@ end
 
 | Enabled
 | Yes
-| No
+| Yes
 | 1.10
 | -
 |===

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   it 'flags multiple hooks in the same example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         before { bar }
         ^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 3).
@@ -10,10 +10,17 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
         ^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        before { bar
+      baz }
+      end
+    RUBY
   end
 
   it 'flags multiple hooks of the same scope with different symbols' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         after { bar }
         ^^^^^^^^^^^^^ Do not define multiple `after` hooks in the same example group (also defined on lines 3, 4).
@@ -23,15 +30,30 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
         ^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `after` hooks in the same example group (also defined on lines 2, 3).
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        after { bar
+      baz
+      baz }
+      end
+    RUBY
   end
 
   it 'flags multiple before(:all) hooks in the same example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         before(:all) { bar }
         ^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 3).
         before(:all) { baz }
         ^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        before(:all) { bar
+      baz }
       end
     RUBY
   end
@@ -104,7 +126,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'flags hooks with similar metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         before(:each, :special_case) { foo }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on lines 3, 4, 5).
@@ -114,6 +136,16 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on lines 2, 3, 5).
         before(special_case: true) { bar }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on lines 2, 3, 4).
+        before(:example, special_case: false) { bar }
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        before(:each, :special_case) { foo
+      bar
+      bar
+      bar }
         before(:example, special_case: false) { bar }
       end
     RUBY


### PR DESCRIPTION
This PR adds autocorrect support for `RSpec/ScatteredSetup`

In https://github.com/rubocop/rubocop-rspec/pull/1611 . I'd like to add support for automatic correction that causes `RSpec/Rails/TravelAround` cop to trigger`RSpec/ScatteredSetup`. WDYT?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
