### PR TITLE
Fix order of arguments in `RSpec/Rails/MinitestAssertions` correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add new `RSpec/IndexedLet` cop. ([@dmitrytsepelev])
+- Fix order of expected and actual in correction for `RSpec/Rails/MinitestAssertions` ([@mvz])
 - Fix a false positive for `RSpec/FactoryBot/ConsistentParenthesesStyle` inside `&&`, `||` and `:?` when `omit_parentheses` is on ([@dmitrytsepelev])
 - Fix a false positive for `RSpec/PendingWithoutReason` when pending/skip has a reason inside an example group. ([@ydah])
 - Change `RSpec/ContainExactly` to ignore calls with no arguments, and change `RSpec/MatchArray` to ignore calls with an empty array literal argument. ([@ydah], [@bquorning])
@@ -809,6 +810,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@mlarraz]: https://github.com/mlarraz
 [@mockdeep]: https://github.com/mockdeep
 [@mothonmars]: https://github.com/MothOnMars
+[@mvz]: https://github.com/mvz
 [@nc-holodakg]: https://github.com/nc-holodakg
 [@nevir]: https://github.com/nevir
 [@ngouy]: https://github.com/ngouy

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -229,9 +229,9 @@ assert_equal a, b, "must be equal"
 refute_equal(a, b)
 
 # good
-expect(a).to eq(b)
-expect(a).to(eq(b), "must be equal")
-expect(a).not_to eq(b)
+expect(b).to eq(a)
+expect(b).to(eq(a), "must be equal")
+expect(b).not_to eq(a)
 ----
 
 === References

--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -13,9 +13,9 @@ module RuboCop
         #   refute_equal(a, b)
         #
         #   # good
-        #   expect(a).to eq(b)
-        #   expect(a).to(eq(b), "must be equal")
-        #   expect(a).not_to eq(b)
+        #   expect(b).to eq(a)
+        #   expect(b).to(eq(a), "must be equal")
+        #   expect(b).not_to eq(a)
         #
         class MinitestAssertions < Base
           extend AutoCorrector
@@ -43,9 +43,9 @@ module RuboCop
           def replacement(node, expected, actual, failure_message)
             runner = node.method?(:assert_equal) ? 'to' : 'not_to'
             if failure_message.nil?
-              "expect(#{expected.source}).#{runner} eq(#{actual.source})"
+              "expect(#{actual.source}).#{runner} eq(#{expected.source})"
             else
-              "expect(#{expected.source}).#{runner}(eq(#{actual.source}), " \
+              "expect(#{actual.source}).#{runner}(eq(#{expected.source}), " \
                 "#{failure_message.source})"
             end
           end

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -4,33 +4,33 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions, :config do
   it 'registers an offense when using `assert_equal`' do
     expect_offense(<<~RUBY)
       assert_equal(a, b)
-      ^^^^^^^^^^^^^^^^^^ Use `expect(a).to eq(b)`.
+      ^^^^^^^^^^^^^^^^^^ Use `expect(b).to eq(a)`.
     RUBY
 
     expect_correction(<<~RUBY)
-      expect(a).to eq(b)
+      expect(b).to eq(a)
     RUBY
   end
 
   it 'registers an offense when using `assert_equal` with no parentheses' do
     expect_offense(<<~RUBY)
       assert_equal a, b
-      ^^^^^^^^^^^^^^^^^ Use `expect(a).to eq(b)`.
+      ^^^^^^^^^^^^^^^^^ Use `expect(b).to eq(a)`.
     RUBY
 
     expect_correction(<<~RUBY)
-      expect(a).to eq(b)
+      expect(b).to eq(a)
     RUBY
   end
 
   it 'registers an offense when using `assert_equal` with failure message' do
     expect_offense(<<~RUBY)
       assert_equal a, b, "must be equal"
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to(eq(b), "must be equal")`.
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to(eq(a), "must be equal")`.
     RUBY
 
     expect_correction(<<~RUBY)
-      expect(a).to(eq(b), "must be equal")
+      expect(b).to(eq(a), "must be equal")
     RUBY
   end
 
@@ -38,36 +38,36 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions, :config do
      'multi-line arguments' do
     expect_offense(<<~RUBY)
       assert_equal(a,
-      ^^^^^^^^^^^^^^^ Use `expect(a).to(eq(b), "must be equal")`.
+      ^^^^^^^^^^^^^^^ Use `expect(b).to(eq(a), "must be equal")`.
                     b,
                     "must be equal")
     RUBY
 
     expect_correction(<<~RUBY)
-      expect(a).to(eq(b), "must be equal")
+      expect(b).to(eq(a), "must be equal")
     RUBY
   end
 
   it 'registers an offense when using `refute_equal`' do
     expect_offense(<<~RUBY)
       refute_equal a, b
-      ^^^^^^^^^^^^^^^^^ Use `expect(a).not_to eq(b)`.
+      ^^^^^^^^^^^^^^^^^ Use `expect(b).not_to eq(a)`.
     RUBY
 
     expect_correction(<<~RUBY)
-      expect(a).not_to eq(b)
+      expect(b).not_to eq(a)
     RUBY
   end
 
-  it 'does not register an offense when using `expect(a).to eq(b)`' do
+  it 'does not register an offense when using `expect(b).to eq(a)`' do
     expect_no_offenses(<<~RUBY)
-      expect(a).to eq(b)
+      expect(b).to eq(a)
     RUBY
   end
 
-  it 'does not register an offense when using `expect(a).not_to eq(b)`' do
+  it 'does not register an offense when using `expect(b).not_to eq(a)`' do
     expect_no_offenses(<<~RUBY)
-      expect(a).not_to eq(b)
+      expect(b).not_to eq(a)
     RUBY
   end
 end


### PR DESCRIPTION
The order of arguments in `assert_equals` is expected, then actual, while in `expect` syntax, the actual comes first.

In the existing correction, the actual value was incorrectly placed as argument for `eq`, while the expected value was placed as the argument for `expect`. This changes fixes the order so the resulting expression matches the intent of the original assertion.

[Mentioned here](https://github.com/rubocop/rubocop-rspec/issues/1485#issuecomment-1509276914).
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
