### PR TITLE
Add support for shared groups to EmptyLineAfterExampleGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Make `RSpec/MatchArray` and `RSpec/ContainExactly` pending. ([@ydah])
 - Add autocorrect support for `RSpec/ScatteredSetup`. ([@ydah])
 - Fix a false negative for `RSpec/RedundantAround` when redundant numblock `around`. ([@ydah])
+- Add support for shared example groups to `RSpec/EmptyLineAfterExampleGroup`. ([@pirj])
 
 ## 2.19.0 (2023-03-06)
 

--- a/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example_group.rb
@@ -30,7 +30,7 @@ module RuboCop
         MSG = 'Add an empty line after `%<example_group>s`.'
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless example_group?(node)
+          return unless spec_group?(node)
 
           missing_separating_line_offense(node) do |method|
             format(MSG, example_group: method)

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -65,6 +65,34 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
     RUBY
   end
 
+  it 'checks for empty line after shared groups' do
+    expect_offense(<<-RUBY)
+      RSpec.context 'foo' do
+        shared_examples 'bar' do
+        end
+        ^^^ Add an empty line after `shared_examples`.
+        shared_context 'baz' do
+        end
+        ^^^ Add an empty line after `shared_context`.
+        it 'does something' do
+        end
+      end
+    RUBY
+
+    expect_correction(<<-RUBY)
+      RSpec.context 'foo' do
+        shared_examples 'bar' do
+        end
+
+        shared_context 'baz' do
+        end
+
+        it 'does something' do
+        end
+      end
+    RUBY
+  end
+
   it 'approves empty line after describe' do
     expect_no_offenses(<<-RUBY)
       RSpec.describe Foo do


### PR DESCRIPTION
fix #1582


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).