### PR TITLE
Fix a false negative for `RSpec/RedundantAround` when redundant numblock `around`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add new `RSpec/BeEmpty` cop. ([@ydah], [@bquorning])
 - Make `RSpec/MatchArray` and `RSpec/ContainExactly` pending. ([@ydah])
 - Add autocorrect support for `RSpec/ScatteredSetup`. ([@ydah])
+- Fix a false negative for `RSpec/RedundantAround` when redundant numblock `around`. ([@ydah])
 
 ## 2.19.0 (2023-03-06)
 

--- a/lib/rubocop/cop/rspec/redundant_around.rb
+++ b/lib/rubocop/cop/rspec/redundant_around.rb
@@ -27,7 +27,14 @@ module RuboCop
             autocorrect(corrector, node)
           end
         end
-        alias on_numblock on_block
+
+        def on_numblock(node)
+          return unless match_redundant_around_hook_numblock?(node)
+
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
 
         def on_send(node)
           return unless match_redundant_around_hook_send?(node)
@@ -46,6 +53,11 @@ module RuboCop
             (args _?)
             (send _ :run)
           )
+        PATTERN
+
+        # @!method match_redundant_around_hook_numblock?(node)
+        def_node_matcher :match_redundant_around_hook_numblock?, <<~PATTERN
+          (numblock (send _ :around) ... (send _ :run))
         PATTERN
 
         # @!method match_redundant_around_hook_send?(node)

--- a/spec/rubocop/cop/rspec/redundant_around_spec.rb
+++ b/spec/rubocop/cop/rspec/redundant_around_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::RedundantAround do
+RSpec.describe RuboCop::Cop::RSpec::RedundantAround, :ruby27 do
   context 'with another node in `around`' do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)
@@ -18,6 +18,18 @@ RSpec.describe RuboCop::Cop::RSpec::RedundantAround do
       expect_no_offenses(<<~RUBY)
         around do |example|
           foo { example.run }
+        end
+      RUBY
+    end
+  end
+
+  context 'with another node in numblock `around`' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        around do
+          _1.run
+
+          foo
         end
       RUBY
     end


### PR DESCRIPTION
This PR fixes a false negative for `RSpec/RedundantAround` when redundant numblock `around`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
