### PR TITLE
Fix an error for `RSpec/Rails/HaveHttpStatus` with comparison with strings containing non-numeric characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive in `RSpec/IndexedLet` with suffixes after index-like numbers. ([@pirj])
+- Fix an error for `RSpec/Rails/HaveHttpStatus` with comparison with strings containing non-numeric characters. ([@ydah])
 
 ## 2.20.0 (2023-04-18)
 

--- a/lib/rubocop/cop/rspec/rails/have_http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/have_http_status.rb
@@ -18,7 +18,7 @@ module RuboCop
           extend AutoCorrector
 
           MSG =
-            'Prefer `expect(response).%<to>s have_http_status(%<status>i)` ' \
+            'Prefer `expect(response).%<to>s have_http_status(%<status>s)` ' \
             'over `%<bad_code>s`.'
 
           RUNNERS = %i[to to_not not_to].to_set
@@ -37,12 +37,14 @@ module RuboCop
 
           def on_send(node)
             match_status(node) do |response_status, to, match, status|
+              return unless status.to_s.match?(/\A\d+\z/)
+
               message = format(MSG, to: to, status: status,
                                     bad_code: node.source)
               add_offense(node, message: message) do |corrector|
                 corrector.replace(response_status, 'response')
                 corrector.replace(match.loc.selector, 'have_http_status')
-                corrector.replace(match.first_argument, status.to_i.to_s)
+                corrector.replace(match.first_argument, status.to_s)
               end
             end
           end

--- a/spec/rubocop/cop/rspec/rails/have_http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/have_http_status_spec.rb
@@ -45,4 +45,10 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HaveHttpStatus do
       it { expect(res.status).to be(200) }
     RUBY
   end
+
+  it 'ignores statuses that would not coerce to an integer' do
+    expect_no_offenses(<<~RUBY)
+      it { expect(response.status).to eq("404 Not Found") }
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1623

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
