### PR TITLE
Remove unnecessary `$` for `RSpec/ChangeByZero`

### DIFF
--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -77,7 +77,7 @@ module RuboCop
             (block
               (send nil? :change)
               (args)
-              (send (...) $_)) :by
+              (send (...) _)) :by
             (int 0))
         PATTERN
 


### PR DESCRIPTION
This PR is remove unnecessary `$` for `RSpec/ChangeByZero`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).