### PR TITLE
Require RuboCop 1.33 or higher and smaller than 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix a false positive in `RSpec/IndexedLet` with suffixes after index-like numbers. ([@pirj])
 - Fix an error for `RSpec/Rails/HaveHttpStatus` with comparison with strings containing non-numeric characters. ([@ydah])
 - Fix an error for `RSpec/MatchArray` when `match_array` with no argument. ([@ydah])
+- Require RuboCop 1.33 or higher and smaller than 2.0. ([@ydah])
 
 ## 2.20.0 (2023-04-18)
 

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.33'
+  spec.add_runtime_dependency 'rubocop', '>= 1.33', '< 2.0'
   spec.add_runtime_dependency 'rubocop-capybara', '~> 2.17'
 end


### PR DESCRIPTION
This PR requires RuboCop 1.33 or higher and smaller than 2.0. By doing this, we would only need to be concerned with the lower limit of the version, making management easier. WDYT?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).