### PR TITLE
Bump version to v2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.21.0 (2023-05-05)
+
 - Fix a false positive in `RSpec/IndexedLet` with suffixes after index-like numbers. ([@pirj])
 - Fix an error for `RSpec/Rails/HaveHttpStatus` with comparison with strings containing non-numeric characters. ([@ydah])
 - Fix an error for `RSpec/MatchArray` when `match_array` with no argument. ([@ydah])

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: ~
+version: '2.21'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.20.0'
+      STRING = '2.21.0'
     end
   end
 end


### PR DESCRIPTION
Let's release v2.21.0. Next release after this one (v2.22.0) will be all about extracting the factory_bot cops.
