### PR TITLE
Remove redundant config metadata

### DIFF
--- a/spec/rubocop/cop/rspec/be_empty_spec.rb
+++ b/spec/rubocop/cop/rspec/be_empty_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::BeEmpty, :config do
+RSpec.describe RuboCop::Cop::RSpec::BeEmpty do
   it 'registers an offense when using `expect(array).to contain_exactly`' do
     expect_offense(<<~RUBY)
       expect(array).to contain_exactly

--- a/spec/rubocop/cop/rspec/change_by_zero_spec.rb
+++ b/spec/rubocop/cop/rspec/change_by_zero_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::ChangeByZero, :config do
+RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
   it 'registers an offense when using `change` and argument to `by` is zero' do
     expect_offense(<<-RUBY)
       it do

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions, :config do
+RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
   it 'registers an offense when using `assert_equal`' do
     expect_offense(<<~RUBY)
       assert_equal(a, b)

--- a/spec/rubocop/cop/rspec/skip_block_inside_example_spec.rb
+++ b/spec/rubocop/cop/rspec/skip_block_inside_example_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe RuboCop::Cop::RSpec::SkipBlockInsideExample, :config do
+RSpec.describe RuboCop::Cop::RSpec::SkipBlockInsideExample do
   it 'registers an offense when using `skip` with a block' do
     expect_offense(<<~RUBY)
       it 'does something' do


### PR DESCRIPTION
Previously, this was needed to have control over "config" shared context
inclusion. We wanted to include ours, but not the one from `rubocop`.
This is a follow-up to #1332.

Thank you @r7kamura for bringing this up in https://github.com/rubocop/rubocop-factory_bot/pull/21

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).