### PR TITLE
Replace Relish RSpec links with rspec.info

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2879,7 +2879,7 @@ end
 
 * https://rspec.rubystyle.guide/#declare-constants
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration
-* https://relishapp.com/rspec/rspec-mocks/docs/mutating-constants
+* https://rspec.info/features/3-12/rspec-mocks/mutating-constants
 
 == RSpec/LetBeforeExamples
 
@@ -5295,7 +5295,7 @@ end
 === References
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubleReference
-* https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles
+* https://rspec.info/features/3-12/rspec-mocks/verifying-doubles
 
 == RSpec/VerifiedDoubles
 
@@ -5349,7 +5349,7 @@ end
 
 * https://rspec.rubystyle.guide/#doubles
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
-* https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles
+* https://rspec.info/features/3-12/rspec-mocks/verifying-doubles
 
 == RSpec/VoidExpect
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -32,7 +32,7 @@ over
 calculator.compute(line_item).should == 5
 ----
 
-is a feature of RSpec itself – you can read about it in the https://relishapp.com/rspec/rspec-expectations/docs/syntax-configuration#disable-should-syntax[RSpec Documentation].
+is a feature of RSpec itself – you can read about it in the "Disable should syntax" section of https://rspec.info/features/3-12/rspec-expectations/syntax-configuration[RSpec Documentation].
 
 === Enforcing an explicit RSpec receiver for top-level methods (disabling monkey patching)
 
@@ -54,6 +54,6 @@ describe MyClass do
 end
 ----
 
-can be achieved using RSpec's `disable_monkey_patching!` method, which you can read more about in the https://relishapp.com/rspec/rspec-core/v/3-7/docs/configuration/zero-monkey-patching-mode#monkey-patched-methods-are-undefined-with-%60disable-monkey-patching!%60[RSpec Documentation]. This will also prevent `should` from being defined on every object in your system.
+can be achieved using RSpec's `disable_monkey_patching!` method, which you can read more about in the https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode[RSpec Documentation]. This will also prevent `should` from being defined on every object in your system.
 
 Before disabling `should` you will need all your specs to use the `expect` syntax. You can use http://yujinakayama.me/transpec/[Transpec], which will do the conversion for you.

--- a/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
+++ b/lib/rubocop/cop/rspec/leaky_constant_declaration.rb
@@ -17,7 +17,7 @@ module RuboCop
       # Anonymous classes are fine, since they don't result in global
       # namespace name clashes.
       #
-      # @see https://relishapp.com/rspec/rspec-mocks/docs/mutating-constants
+      # @see https://rspec.info/features/3-12/rspec-mocks/mutating-constants
       #
       # @example Constants leak between examples
       #   # bad

--- a/lib/rubocop/cop/rspec/verified_double_reference.rb
+++ b/lib/rubocop/cop/rspec/verified_double_reference.rb
@@ -7,7 +7,7 @@ module RuboCop
       #
       # Only investigates references that are one of the supported styles.
       #
-      # @see https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles
+      # @see https://rspec.info/features/3-12/rspec-mocks/verifying-doubles
       #
       # This cop can be configured in your configuration using the
       # `EnforcedStyle` option and supports `--auto-gen-config`.

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -5,7 +5,7 @@ module RuboCop
     module RSpec
       # Prefer using verifying doubles over normal doubles.
       #
-      # @see https://relishapp.com/rspec/rspec-mocks/docs/verifying-doubles
+      # @see https://rspec.info/features/3-12/rspec-mocks/verifying-doubles
       #
       # @example
       #   # bad


### PR DESCRIPTION
Unfortunately, Relish is no more.

See:
 - https://mattwynne.net/relish
 - https://github.com/rspec/relish-root-repo/issues/5#issuecomment-1446152910
 - https://mattwynne.net/new-beginning
 - https://github.com/rspec/rspec.github.io/pull/183

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).