### PR TITLE
Use `\A` instead of `^` in `RSpec/PredicateMatcher`

### DIFF
--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -74,7 +74,7 @@ module RuboCop
             name[0..-2]
           when 'exist?', 'exists?'
             'exist'
-          when /^has_/
+          when /\Ahas_/
             name.sub('has_', 'have_')[0..-2]
           else
             "be_#{name[0..-2]}"
@@ -240,10 +240,10 @@ module RuboCop
             'include?'
           when 'respond_to'
             'respond_to?'
-          when /^have_(.+)/
+          when /\Ahave_(.+)/
             "has_#{Regexp.last_match(1)}?"
           else
-            "#{matcher[/^be_(.+)/, 1]}?"
+            "#{matcher[/\Abe_(.+)/, 1]}?"
           end
         end
         # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
It never multiline matches against method name.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
