### PR TITLE
Adding the word 'value' to the expect_actual cop to help make the mes…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix a false negative for `RSpec/ExcessiveDocstringSpacing` when finds description with em space. ([@ydah])
 - Fix a false positive for `RSpec/EmptyExampleGroup` when example group with examples defined in `if` branch inside iterator. ([@ydah])
+- Update the message output of `RSpec/ExpectActual` to include the word 'value'. ([@corydiamand])
 
 ## 2.22.0 (2023-05-06)
 
@@ -784,6 +785,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@cfabianski]: https://github.com/cfabianski
 [@clupprich]: https://github.com/clupprich
 [@composerinteralia]: https://github.com/composerinteralia
+[@corydiamand]: https://github.com/corydiamand
 [@darhazer]: https://github.com/Darhazer
 [@daveworth]: https://github.com/daveworth
 [@dduugg]: https://github.com/dduugg

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -24,7 +24,7 @@ module RuboCop
       class ExpectActual < Base
         extend AutoCorrector
 
-        MSG = 'Provide the actual you are testing to `expect(...)`.'
+        MSG = 'Provide the actual value you are testing to `expect(...)`.'
 
         RESTRICT_ON_SEND = Runners.all
 
@@ -77,7 +77,7 @@ module RuboCop
 
         private
 
-        # This is not implement using a NodePattern because it seems
+        # This is not implemented using a NodePattern because it seems
         # to not be able to match against an explicit (nil) sexp
         def literal?(node)
           node && (simple_literal?(node) || complex_literal?(node))

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(123).to eq(bar)
-                 ^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^ Provide the actual value you are testing to `expect(...)`.
           expect(12.3).to eq(bar)
-                 ^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^ Provide the actual value you are testing to `expect(...)`.
           expect(1i).to eq(bar)
-                 ^^ Provide the actual you are testing to `expect(...)`.
+                 ^^ Provide the actual value you are testing to `expect(...)`.
           expect(1r).to eq(bar)
-                 ^^ Provide the actual you are testing to `expect(...)`.
+                 ^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -34,9 +34,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(true).to eq(bar)
-                 ^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^ Provide the actual value you are testing to `expect(...)`.
           expect(false).to eq(bar)
-                 ^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -56,9 +56,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect("foo").to eq(bar)
-                 ^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^ Provide the actual value you are testing to `expect(...)`.
           expect(:foo).to eq(bar)
-                 ^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(nil).to eq(bar)
-                 ^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -109,9 +109,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect([123]).to eq(bar)
-                 ^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^ Provide the actual value you are testing to `expect(...)`.
           expect([[123]]).to eq(bar)
-                 ^^^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -131,9 +131,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(foo: 1, bar: 2).to eq(bar)
-                 ^^^^^^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^^^^^^^^^^ Provide the actual value you are testing to `expect(...)`.
           expect(foo: 1, bar: [{}]).to eq(bar)
-                 ^^^^^^^^^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^^^^^^^^^^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -153,9 +153,9 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1..2).to eq(bar)
-                 ^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^ Provide the actual value you are testing to `expect(...)`.
           expect(1...2).to eq(bar)
-                 ^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -175,7 +175,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(/foo|bar/).to eq(bar)
-                 ^^^^^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(true).to be(a)
-                 ^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -239,7 +239,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1).to be == a
-                 ^ Provide the actual you are testing to `expect(...)`.
+                 ^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -258,7 +258,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1).to eql(bar)
-                 ^ Provide the actual you are testing to `expect(...)`.
+                 ^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -277,7 +277,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1).to equal(bar)
-                 ^ Provide the actual you are testing to `expect(...)`.
+                 ^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -296,7 +296,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect([1,2,3]).to include(a)
-                 ^^^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY
@@ -309,7 +309,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       describe Foo do
         it 'uses expect incorrectly' do
           expect([1,2,3]).to eq([1, 2, 3])
-                 ^^^^^^^ Provide the actual you are testing to `expect(...)`.
+                 ^^^^^^^ Provide the actual value you are testing to `expect(...)`.
         end
       end
     RUBY


### PR DESCRIPTION
…sage more clear.

The output message from the ExpectActual could be a little confusing to someone not familiar with the meaning of the word 'actual' in this context. Adding the word 'value' to the output helps make it a little bit more clear, but open to suggestions.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).