### PR TITLE
add configure doc for empty_example_group.rb

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1157,6 +1157,35 @@ describe Bacon do
 end
 ----
 
+==== configuration
+
+[source,ruby]
+----
+# .rubocop.yml
+# RSpec:
+#   Language:
+#     Includes:
+#       Examples:
+#         - include_tests
+
+# spec_helper.rb
+RSpec.configure do |config|
+  config.alias_it_behaves_like_to(:include_tests)
+end
+
+# bacon_spec.rb
+describe Bacon do
+  let(:bacon)      { Bacon.new(chunkiness) }
+  let(:chunkiness) { false                 }
+
+  context 'extra chunky' do   # not flagged by rubocop
+    let(:chunkiness) { true }
+
+    include_tests 'shared tests'
+  end
+end
+----
+
 === References
 
 * https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -35,6 +35,30 @@ module RuboCop
       #     pending 'will add tests later'
       #   end
       #
+      # @example configuration
+      # # .rubocop.yml
+      # RSpec:
+      #   Language:
+      #     Includes:
+      #       Examples:
+      #         - include_tests
+      
+      # # spec_helper.rb
+      # RSpec.configure do |config|
+      #   config.alias_it_behaves_like_to(:include_tests)
+      # end
+      
+      # # bacon_spec.rb
+      # describe Bacon do
+      #   let(:bacon)      { Bacon.new(chunkiness) }
+      #   let(:chunkiness) { false                 }
+      
+      #   context 'extra chunky' do   # not flagged by rubocop
+      #     let(:chunkiness) { true }
+      
+      #     include_tests 'shared tests'
+      #   end
+      # end
       class EmptyExampleGroup < Base
         extend AutoCorrector
 

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -36,29 +36,29 @@ module RuboCop
       #   end
       #
       # @example configuration
-      # # .rubocop.yml
-      # RSpec:
-      #   Language:
-      #     Includes:
-      #       Examples:
-      #         - include_tests
-      
-      # # spec_helper.rb
-      # RSpec.configure do |config|
-      #   config.alias_it_behaves_like_to(:include_tests)
-      # end
-      
-      # # bacon_spec.rb
-      # describe Bacon do
-      #   let(:bacon)      { Bacon.new(chunkiness) }
-      #   let(:chunkiness) { false                 }
-      
-      #   context 'extra chunky' do   # not flagged by rubocop
-      #     let(:chunkiness) { true }
-      
-      #     include_tests 'shared tests'
+      #   # .rubocop.yml
+      #   # RSpec:
+      #   #   Language:
+      #   #     Includes:
+      #   #       Examples:
+      #   #         - include_tests
+      #
+      #   # spec_helper.rb
+      #   RSpec.configure do |config|
+      #     config.alias_it_behaves_like_to(:include_tests)
       #   end
-      # end
+      #
+      #   # bacon_spec.rb
+      #   describe Bacon do
+      #     let(:bacon)      { Bacon.new(chunkiness) }
+      #     let(:chunkiness) { false                 }
+      #
+      #     context 'extra chunky' do   # not flagged by rubocop
+      #       let(:chunkiness) { true }
+      #
+      #       include_tests 'shared tests'
+      #     end
+      #   end
       class EmptyExampleGroup < Base
         extend AutoCorrector
 


### PR DESCRIPTION
based on v1 doc
https://www.rubydoc.info/gems/rubocop-rspec/1.15.0/RuboCop/Cop/RSpec/EmptyExampleGroup

and upgrade doc.
https://github.com/rubocop/rubocop-rspec/blob/cd6a30efa9094e389cf9e4dd473b7631fe18bab1/docs/modules/ROOT/pages/upgrade_to_version_2.adoc#adjust-the-configuration-of-rspecemptyexamplegroup
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).