### PR TITLE
Fix a false negative for `RSpec/ExcessiveDocstringSpacing` when finds description with em space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false negative for `RSpec/ExcessiveDocstringSpacing` when finds description with em space. ([@ydah])
+
 ## 2.22.0 (2023-05-06)
 
 - Extract factory_bot cops to a separate repository, [`rubocop-factory_bot`](https://github.com/rubocop/rubocop-factory_bot). The `rubocop-factory_bot` repository is a dependency of `rubocop-rspec` and the factory_bot cops are aliased (`RSpec/FactoryBot/Foo` == `FactoryBot/Foo`) until v3.0 is released, so the change will be invisible to users until then. ([@ydah])

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -52,14 +52,21 @@ module RuboCop
 
         # @param text [String]
         def excessive_whitespace?(text)
-          return true if text.start_with?(' ') || text.end_with?(' ')
-
-          text.match?(/[^\n ]  +[^ ]/)
+          text.match?(/
+            # Leading space
+            \A[[:blank:]]
+            |
+            # Trailing space
+            [[:blank:]]\z
+            |
+            # Two or more consecutive spaces, except if they are leading spaces
+            [^[[:space:]]][[:blank:]]{2,}[^[[:blank:]]]
+          /x)
         end
 
         # @param text [String]
         def strip_excessive_whitespace(text)
-          text.strip.gsub(/  +/, ' ')
+          text.strip.gsub(/[[:blank:]]{2,}/, ' ')
         end
 
         # @param node [RuboCop::AST::Node]

--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -26,6 +26,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
       RUBY
     end
 
+    it 'finds description with leading em space' do
+      expect_offense(<<-RUBY)
+        describe '　　#mymethod' do
+                  ^^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        describe '#mymethod' do
+        end
+      RUBY
+    end
+
     it 'finds interpolated description with leading whitespace' do
       expect_offense(<<-'RUBY')
         describe "  ##{:stuff}" do
@@ -42,6 +55,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
     it 'finds description with trailing whitespace' do
       expect_offense(<<-RUBY)
         describe '#mymethod  ' do
+                  ^^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        describe '#mymethod' do
+        end
+      RUBY
+    end
+
+    it 'finds description with trailing em space' do
+      expect_offense(<<-RUBY)
+        describe '#mymethod　　' do
                   ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY


### PR DESCRIPTION
This PR is fix a false negative for `RSpec/ExcessiveDocstringSpacing` when finds description with em space.

The motivation for this PR is to be able to detect and autocorrect the em space that are sometimes left behind because they cannot be detected by the current `RSpec/ExcessiveDocstringSpacing`.

```ruby
describe '　　#mymethod' do
       # ^^ em space
end

describe '#mymethod　　' do
                 # ^^ em space
end
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).