### PR TITLE
Fix a false positive for `RSpec/EmptyExampleGroup` when example group with examples defined in `if` branch inside iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false negative for `RSpec/ExcessiveDocstringSpacing` when finds description with em space. ([@ydah])
+- Fix a false positive for `RSpec/EmptyExampleGroup` when example group with examples defined in `if` branch inside iterator. ([@ydah])
 
 ## 2.22.0 (2023-05-06)
 

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -131,6 +131,7 @@ module RuboCop
           {
             #examples_directly_or_in_block?
             (begin <#examples_directly_or_in_block? ...>)
+            (begin <#examples_in_branches? ...>)
           }
         PATTERN
 
@@ -169,6 +170,8 @@ module RuboCop
         end
 
         def examples_in_branches?(condition_node)
+          return if !condition_node.if_type? && !condition_node.case_type?
+
           condition_node.branches.any? { |branch| examples?(branch) }
         end
 

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -224,6 +224,55 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
     RUBY
   end
 
+  it 'ignores example group with examples defined in `if` branch ' \
+     'inside iterator' do
+    expect_no_offenses(<<~RUBY)
+      describe 'RuboCop monthly' do
+        [1, 2, 3].each do |page|
+          version = 2.3
+
+          if RUBY_VERSION >= version
+            it { expect(use_safe_navigation_operator?(code)).to be(true) }
+          else
+            warn 'Ruby < 2.3 is barely supported, please use a newer version for development.'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores example group with examples defined in nested iterators' do
+    expect_no_offenses(<<~RUBY)
+      describe 'RuboCop weekly' do
+        some_method
+        [1, 2, 3].each do |page|
+          [4, 5, 6].each do |index|
+            it { expect(newspaper(page)).to have_ads }
+          end
+        end
+        more_surroundings
+      end
+    RUBY
+  end
+
+  it 'ignores example group with examples defined in nested `if` branch' do
+    expect_no_offenses(<<~RUBY)
+      describe 'RuboCop monthly' do
+        version = 2.3
+
+        if RUBY_VERSION >= version
+          if RUBY_VERSION <= 3.1
+            it { expect(use_safe_navigation_operator?(code)).to be(true) }
+          else
+            warn 'Ruby > 3.1 is barely supported, please use a newer version for development.'
+          end
+        else
+          warn 'Ruby < 2.3 is barely supported, please use a newer version for development.'
+        end
+      end
+    RUBY
+  end
+
   it 'ignores example group with examples defined in an custom block' do
     expect_no_offenses(<<~RUBY)
       context 'without arguments' do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1656

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).