### PR TITLE
Change default.yml path to use `**/spec/*` instead of `spec/*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update the message output of `RSpec/ExpectActual` to include the word 'value'. ([@corydiamand])
 - Fix a false negative for `RSpec/Pending` when  `it` without body. ([@ydah])
 - Add new `RSpec/ReceiveMessages` cop. ([@ydah])
+- Change default.yml path to use `**/spec/*` instead of `spec/*`. ([@ydah])
 
 ## 2.22.0 (2023-05-06)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -181,10 +181,11 @@ RSpec/BeforeAfterAll:
   Description: Check that before/after(:all) isn't being used.
   Enabled: true
   Exclude:
-    - spec/spec_helper.rb
-    - spec/rails_helper.rb
-    - spec/support/**/*.rb
+    - "**/spec/spec_helper.rb"
+    - "**/spec/rails_helper.rb"
+    - "**/spec/support/**/*.rb"
   VersionAdded: '1.12'
+  VersionChanged: "<<next>>"
   StyleGuide: https://rspec.rubystyle.guide/#avoid-hooks-with-context-scope
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll
 
@@ -404,8 +405,9 @@ RSpec/ExpectActual:
   Description: Checks for `expect(...)` calls containing literal values.
   Enabled: true
   Exclude:
-    - spec/routing/**/*
+    - "**/spec/routing/**/*"
   VersionAdded: '1.7'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectActual
 
 RSpec/ExpectChange:
@@ -980,11 +982,11 @@ RSpec/FactoryBot/AttributeDefinedStatically:
   Description: Always declare attribute values as blocks.
   Enabled: true
   Include:
-    - spec/factories.rb
-    - spec/factories/**/*.rb
-    - features/support/factories/**/*.rb
+    - "**/spec/factories.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/features/support/factories/**/*.rb"
   VersionAdded: '1.28'
-  VersionChanged: '2.0'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/AttributeDefinedStatically
 
 RSpec/FactoryBot/ConsistentParenthesesStyle:
@@ -1003,26 +1005,26 @@ RSpec/FactoryBot/CreateList:
   Include:
     - "**/*_spec.rb"
     - "**/spec/**/*"
-    - spec/factories.rb
-    - spec/factories/**/*.rb
-    - features/support/factories/**/*.rb
+    - "**/spec/factories.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/features/support/factories/**/*.rb"
   EnforcedStyle: create_list
   SupportedStyles:
     - create_list
     - n_times
   VersionAdded: '1.25'
-  VersionChanged: '2.0'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/CreateList
 
 RSpec/FactoryBot/FactoryClassName:
   Description: Use string value when setting the class attribute explicitly.
   Enabled: true
   Include:
-    - spec/factories.rb
-    - spec/factories/**/*.rb
-    - features/support/factories/**/*.rb
+    - "**/spec/factories.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/features/support/factories/**/*.rb"
   VersionAdded: '1.37'
-  VersionChanged: '2.0'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/FactoryBot/FactoryClassName
 
 RSpec/FactoryBot/FactoryNameStyle:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -378,7 +378,7 @@ expect(foo).to be(nil)
 | Yes
 | No
 | 1.12
-| -
+| <<next>>
 |===
 
 Check that before/after(:all) isn't being used.
@@ -412,7 +412,7 @@ end
 | Name | Default value | Configurable values
 
 | Exclude
-| `spec/spec_helper.rb`, `spec/rails_helper.rb`, `+spec/support/**/*.rb+`
+| `+**/spec/spec_helper.rb+`, `+**/spec/rails_helper.rb+`, `+**/spec/support/**/*.rb+`
 | Array
 |===
 
@@ -1767,7 +1767,7 @@ end
 | Yes
 | Yes
 | 1.7
-| -
+| <<next>>
 |===
 
 Checks for `expect(...)` calls containing literal values.
@@ -1798,7 +1798,7 @@ expect(false).to eq(true)
 | Name | Default value | Configurable values
 
 | Exclude
-| `+spec/routing/**/*+`
+| `+**/spec/routing/**/*+`
 | Array
 |===
 

--- a/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_factorybot.adoc
@@ -9,7 +9,7 @@
 | Yes
 | Yes
 | 1.28
-| 2.0
+| <<next>>
 |===
 
 Always declare attribute values as blocks.
@@ -43,7 +43,7 @@ count { 1 }
 | Name | Default value | Configurable values
 
 | Include
-| `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
+| `+**/spec/factories.rb+`, `+**/spec/factories/**/*.rb+`, `+**/features/support/factories/**/*.rb+`
 | Array
 |===
 
@@ -131,7 +131,7 @@ build(
 | Yes
 | Yes
 | 1.25
-| 2.0
+| <<next>>
 |===
 
 Checks for create_list usage.
@@ -177,7 +177,7 @@ create_list :user, 3
 | Name | Default value | Configurable values
 
 | Include
-| `+**/*_spec.rb+`, `+**/spec/**/*+`, `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
+| `+**/*_spec.rb+`, `+**/spec/**/*+`, `+**/spec/factories.rb+`, `+**/spec/factories/**/*.rb+`, `+**/features/support/factories/**/*.rb+`
 | Array
 
 | EnforcedStyle
@@ -198,7 +198,7 @@ create_list :user, 3
 | Yes
 | Yes
 | 1.37
-| 2.0
+| <<next>>
 |===
 
 Use string value when setting the class attribute explicitly.
@@ -227,7 +227,7 @@ end
 | Name | Default value | Configurable values
 
 | Include
-| `spec/factories.rb`, `+spec/factories/**/*.rb+`, `+features/support/factories/**/*.rb+`
+| `+**/spec/factories.rb+`, `+**/spec/factories/**/*.rb+`, `+**/features/support/factories/**/*.rb+`
 | Array
 |===
 


### PR DESCRIPTION
This PR is change default.yml path to use `**/spec/*` instead of `spec/*`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
