### PR TITLE
Fix a false negative for `RSpec/Pending` when  `it` without body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix a false negative for `RSpec/ExcessiveDocstringSpacing` when finds description with em space. ([@ydah])
 - Fix a false positive for `RSpec/EmptyExampleGroup` when example group with examples defined in `if` branch inside iterator. ([@ydah])
 - Update the message output of `RSpec/ExpectActual` to include the word 'value'. ([@corydiamand])
+- Fix a false negative for `RSpec/Pending` when  `it` without body. ([@ydah])
 
 ## 2.22.0 (2023-05-06)
 

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -41,8 +41,13 @@ module RuboCop
         def_node_matcher :skippable?, <<~PATTERN
           {
             (send #rspec? #ExampleGroups.regular ...)
-            (send nil? #Examples.regular ...)
+            #skippable_example?
           }
+        PATTERN
+
+        # @!method skippable_example?(node)
+        def_node_matcher :skippable_example?, <<~PATTERN
+          (send nil? #Examples.regular ...)
         PATTERN
 
         # @!method pending_block?(node)
@@ -62,7 +67,12 @@ module RuboCop
         private
 
         def skipped?(node)
-          skippable?(node) && skipped_in_metadata?(node)
+          skippable?(node) && skipped_in_metadata?(node) ||
+            skipped_regular_example_without_body?(node)
+        end
+
+        def skipped_regular_example_without_body?(node)
+          skippable_example?(node) && !node.block_node
         end
       end
     end

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Pending do
+  it 'flags it without body' do
+    expect_offense(<<-RUBY)
+      it 'test'
+      ^^^^^^^^^ Pending spec found.
+    RUBY
+  end
+
+  it 'flags it without body inside describe block' do
+    expect_offense(<<-RUBY)
+      describe 'test' do
+        it 'test'
+        ^^^^^^^^^ Pending spec found.
+      end
+    RUBY
+  end
+
   it 'flags xcontext' do
     expect_offense(<<-RUBY)
       xcontext 'test' do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1663

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).