### PR TITLE
Fix `RSpec/NamedSubject` when block has no body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix a false negative for `RSpec/Pending` when  `it` without body. ([@ydah])
 - Add new `RSpec/ReceiveMessages` cop. ([@ydah])
 - Add `AllowedIdentifiers` and `AllowedPatterns` configuration option to `RSpec/IndexedLet`.  ([@ydah])
+- Fix `RSpec/NamedSubject` when block has no body. ([@splattael])
 
 ## 2.22.0 (2023-05-06)
 
@@ -867,6 +868,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@seanpdoyle]: https://github.com/seanpdoyle
 [@sl4vr]: https://github.com/sl4vr
 [@smcgivern]: https://github.com/smcgivern
+[@splattael]: https://github.com/splattael
 [@stephannv]: https://github.com/stephannv
 [@t3h2mas]: https://github.com/t3h2mas
 [@tdeo]: https://github.com/tdeo

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -145,7 +145,7 @@ module RuboCop
         end
 
         def find_subject(block_node)
-          block_node.body.child_nodes.find { |send_node| subject?(send_node) }
+          block_node.body&.child_nodes&.find { |send_node| subject?(send_node) }
         end
       end
     end

--- a/spec/rubocop/cop/rspec/named_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/named_subject_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
         end
       RUBY
     end
+
+    it 'ignores subject when block has no body' do
+      expect_no_offenses(<<-RUBY)
+        it "is a User" do
+          subject.each do
+            # empty body
+          end
+        end
+      RUBY
+    end
   end
 
   context 'when IgnoreSharedExamples is false' do


### PR DESCRIPTION
This MR fixes a regression for :policeman: `RSpec/NamedSubject` with `EnforcedStyle: named_only` in case a block has no body. For example:

```ruby
describe User do
  it "is a User" do
    subject.each do
      # empty body
    end
  end
end
```

### Exception/failure

```

Failures:

  1) RuboCop::Cop::RSpec::NamedSubject when EnforcedStyle is :named_only ignores subject when block has no body
     Failure/Error: block_node.body.child_nodes.find { |send_node| subject?(send_node) }

     NoMethodError:
       undefined method `child_nodes' for nil:NilClass

                 block_node.body.child_nodes.find { |send_node| subject?(send_node) }
                                ^^^^^^^^^^^^
     # ./lib/rubocop/cop/rspec/named_subject.rb:148:in `find_subject'
     # ./lib/rubocop/cop/rspec/named_subject.rb:143:in `block in nearest_subject'
     # ./lib/rubocop/cop/rspec/named_subject.rb:144:in `each'
     # ./lib/rubocop/cop/rspec/named_subject.rb:144:in `each'
     # ./lib/rubocop/cop/rspec/named_subject.rb:144:in `each'
     # ./lib/rubocop/cop/rspec/named_subject.rb:144:in `each'
     # ./lib/rubocop/cop/rspec/named_subject.rb:144:in `find'
     # ./lib/rubocop/cop/rspec/named_subject.rb:144:in `nearest_subject'
     # ./lib/rubocop/cop/rspec/named_subject.rb:134:in `subject_definition_is_named?'
     # ./lib/rubocop/cop/rspec/named_subject.rb:130:in `named_only?'
     # ./lib/rubocop/cop/rspec/named_subject.rb:121:in `allow_explicit_subject?'
     # ./lib/rubocop/cop/rspec/named_subject.rb:115:in `check_explicit_subject'
     # ./lib/rubocop/cop/rspec/named_subject.rb:103:in `block in on_block'
     # ./lib/rubocop/cop/rspec/named_subject.rb:104:in `block in subject_usage'
     # ./lib/rubocop/cop/rspec/named_subject.rb:99:in `subject_usage'
     # ./lib/rubocop/cop/rspec/named_subject.rb:102:in `on_block'
     # ./spec/support/expect_offense.rb:21:in `expect_no_offenses'
     # ./spec/rubocop/cop/rspec/named_subject_spec.rb:158:in `block (3 levels) in <top (required)>'

Finished in 0.09781 seconds (files took 0.70907 seconds to load)
20 examples, 1 failure

Failed examples:

rspec ./spec/rubocop/cop/rspec/named_subject_spec.rb:157 # RuboCop::Cop::RSpec::NamedSubject when EnforcedStyle is :named_only ignores subject when block has no body

Randomized with seed 26613

Coverage report generated for RSpec to /home/peter/devel/rubocop-rspec/coverage. 2012 / 3392 LOC (59.32%) covered.
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
```

Found at GitLab in https://gitlab.com/gitlab-org/gitlab/-/issues/249446#note_1461446904.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
