### PR TITLE
Fix `RSpec/LetBeforeExamples` autocorrect incompatible with `RSpec/ScatteredLet` autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix a false negative for `RSpec/Pending` when  `it` without body. ([@ydah])
 - Add new `RSpec/ReceiveMessages` cop. ([@ydah])
 - Add `AllowedIdentifiers` and `AllowedPatterns` configuration option to `RSpec/IndexedLet`.  ([@ydah])
+- Fix `RSpec/LetBeforeExamples` autocorrect incompatible with `RSpec/ScatteredLet` autocorrect. ([@ydah])
 
 ## 2.22.0 (2023-05-06)
 

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -51,6 +51,10 @@ module RuboCop
           }
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [RSpec::ScatteredLet]
+        end
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group_with_body?(node)
 


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1669

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
