### PR TITLE
Use offense instead of violation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,9 @@ Naming/InclusiveLanguage:
     auto_correct:
       Suggestions:
         - autocorrect
+    ' a violation':
+      Suggestions:
+        - an offense
     behaviour:
       Suggestions:
         - behavior
@@ -79,6 +82,9 @@ Naming/InclusiveLanguage:
     'does not registers':
       Suggestions:
         - does not register
+    violation:
+      Suggestions:
+        - offense
 
 RSpec:
   Language:

--- a/lib/rubocop/cop/rspec/variable_definition.rb
+++ b/lib/rubocop/cop/rspec/variable_definition.rb
@@ -35,7 +35,7 @@ module RuboCop
           return unless inside_example_group?(node)
 
           variable_definition?(node) do |variable|
-            next unless style_violation?(variable)
+            next unless style_offense?(variable)
 
             add_offense(
               variable,
@@ -59,7 +59,7 @@ module RuboCop
           end
         end
 
-        def style_violation?(variable)
+        def style_offense?(variable)
           style == :symbols && string?(variable) ||
             style == :strings && symbol?(variable)
         end

--- a/lib/rubocop/cop/rspec/verified_double_reference.rb
+++ b/lib/rubocop/cop/rspec/verified_double_reference.rb
@@ -79,8 +79,8 @@ module RuboCop
             expression = class_reference.source_range
 
             add_offense(expression, message: message) do |corrector|
-              violation = class_reference.source
-              corrector.replace(expression, correct_style(violation))
+              offense = class_reference.source
+              corrector.replace(expression, correct_style(offense))
 
               opposite_style_detected
             end
@@ -98,11 +98,11 @@ module RuboCop
           class_reference_style != style
         end
 
-        def correct_style(violation)
+        def correct_style(offense)
           if style == :string
-            "'#{violation}'"
+            "'#{offense}'"
           else
-            violation.gsub(/^['"]|['"]$/, '')
+            offense.gsub(/^['"]|['"]$/, '')
           end
         end
       end

--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
-  it 'flags violations for `background`' do
+  it 'flags offenses for `background`' do
     expect_offense(<<-RUBY)
       describe 'some feature' do
         background do; end
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     RUBY
   end
 
-  it 'flags violations for `scenario`' do
+  it 'flags offenses for `scenario`' do
     expect_offense(<<-RUBY)
       RSpec.describe 'some feature' do
         scenario 'Foo' do; end
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     RUBY
   end
 
-  it 'flags violations for `xscenario`' do
+  it 'flags offenses for `xscenario`' do
     expect_offense(<<-RUBY)
       describe 'Foo' do
         RSpec.xscenario 'Baz' do; end
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     RUBY
   end
 
-  it 'flags violations for `given`' do
+  it 'flags offenses for `given`' do
     expect_offense(<<-RUBY)
       RSpec.describe 'Foo' do
         given(:foo) { :foo }
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     RUBY
   end
 
-  it 'flags violations for `given!`' do
+  it 'flags offenses for `given!`' do
     expect_offense(<<-RUBY)
       describe 'Foo' do
         given!(:foo) { :foo }
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     RUBY
   end
 
-  it 'flags violations for `feature`' do
+  it 'flags offenses for `feature`' do
     expect_offense(<<-RUBY)
       RSpec.feature 'Foo' do; end
             ^^^^^^^ Use `describe` instead of `feature`.
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     RUBY
   end
 
-  it 'flags violations inside shared groups' do
+  it 'flags offenses inside shared groups' do
     expect_offense(<<-RUBY)
       RSpec.shared_examples_for 'common scenarios' do
         feature 'Foo' do; end

--- a/spec/rubocop/cop/rspec/describe_symbol_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_symbol_spec.rb
@@ -1,28 +1,28 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::DescribeSymbol do
-  it 'flags violations for `describe :symbol`' do
+  it 'flags offenses for `describe :symbol`' do
     expect_offense(<<-RUBY)
       describe(:some_method) { }
                ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
-  it 'flags violations for `describe :symbol` with multiple arguments' do
+  it 'flags offenses for `describe :symbol` with multiple arguments' do
     expect_offense(<<-RUBY)
       describe(:some_method, "description") { }
                ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
-  it 'flags violations for `RSpec.describe :symbol`' do
+  it 'flags offenses for `RSpec.describe :symbol`' do
     expect_offense(<<-RUBY)
       RSpec.describe(:some_method, "description") { }
                      ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
-  it 'flags violations for a nested `describe`' do
+  it 'flags offenses for a nested `describe`' do
     expect_offense(<<-RUBY)
       RSpec.describe Foo do
         describe :to_s do

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
   context 'when SkipBlocks is `true`' do
     let(:cop_config) { { 'SkipBlocks' => true } }
 
-    it 'ignores violations within non-rspec blocks' do
+    it 'ignores offenses within non-rspec blocks' do
       expect_offense(<<-RUBY)
         describe MyClass do
           controller(ApplicationController) do
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
   end
 
   context 'when SkipBlocks is `false`' do
-    it 'flags violations within all blocks' do
+    it 'flags offenses within all blocks' do
       expect_offense(<<-RUBY)
         describe MyClass do
           controller(ApplicationController) do
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       RUBY
     end
 
-    it 'ignores violations within a class scope change' do
+    it 'ignores offenses within a class scope change' do
       expect_no_offenses(<<-RUBY)
         describe MyNamespace::MyClass do
           before do
@@ -206,7 +206,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       RUBY
     end
 
-    it 'ignores violations within a hook scope change' do
+    it 'ignores offenses within a hook scope change' do
       expect_no_offenses(<<-RUBY)
         describe do
           before do
@@ -334,7 +334,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       RUBY
     end
 
-    it 'ignores violations within a class scope change' do
+    it 'ignores offenses within a class scope change' do
       expect_no_offenses(<<-RUBY)
         describe MyNamespace::MyClass do
           before do
@@ -346,7 +346,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       RUBY
     end
 
-    it 'ignores violations within a hook scope change' do
+    it 'ignores offenses within a hook scope change' do
       expect_no_offenses(<<-RUBY)
         describe do
           before do

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
     RUBY
   end
 
-  it 'flags but does not autocorrect violations for other matchers' do
+  it 'flags but does not autocorrect offenses for other matchers' do
     expect_offense(<<-RUBY)
       describe Foo do
         it 'uses expect incorrectly' do

--- a/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
+++ b/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike do
   context 'when the enforced style is `it_behaves_like`' do
     let(:enforced_style) { :it_behaves_like }
 
-    it 'flags a violation for it_should_behave_like' do
+    it 'flags an offense for it_should_behave_like' do
       expect_offense(<<-RUBY)
         it_should_behave_like 'a foo'
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `it_behaves_like` over `it_should_behave_like` when including examples in a nested context.
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike do
       RUBY
     end
 
-    it 'does not flag a violation for it_behaves_like' do
+    it 'does not flag an offense for it_behaves_like' do
       expect_no_offenses("it_behaves_like 'a foo'")
     end
   end
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike do
   context 'when the enforced style is `it_should_behave_like`' do
     let(:enforced_style) { :it_should_behave_like }
 
-    it 'flags a violation for it_behaves_like' do
+    it 'flags an offense for it_behaves_like' do
       expect_offense(<<-RUBY)
         it_behaves_like 'a foo'
         ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `it_should_behave_like` over `it_behaves_like` when including examples in a nested context.
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike do
       RUBY
     end
 
-    it 'does not flag a violation for it_behaves_like' do
+    it 'does not flag an offense for it_behaves_like' do
       expect_no_offenses("it_should_behave_like 'a foo'")
     end
   end

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
   end
 
-  it 'generates a todo based on the worst violation' do
+  it 'generates a todo based on the worst offense' do
     inspect_source(<<-RUBY, 'spec/foo_spec.rb')
       describe Foo do
         it 'uses expect twice' do

--- a/spec/rubocop/cop/rspec/repeated_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
     RUBY
   end
 
-  it 'does not register a violation if rspec tag magic is involved' do
+  it 'does not register an offense if rspec tag magic is involved' do
     expect_no_offenses(<<-RUBY)
       describe 'doing x' do
         it "does x" do

--- a/spec/rubocop/cop/rspec/verified_double_reference_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_double_reference_spec.rb
@@ -19,11 +19,11 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubleReference do
           { 'EnforcedStyle' => 'constant' }
         end
 
-        it 'does not flag a violation when using a constant reference' do
+        it 'does not flag an offense when using a constant reference' do
           expect_no_offenses("#{verified_double}(ClassName)")
         end
 
-        it 'flags a violation when using a string reference' do
+        it 'flags an offense when using a string reference' do
           expect_offense(<<~RUBY, verified_double: verified_double)
             %{verified_double}('ClassName')
             _{verified_double} ^^^^^^^^^^^ Use a constant class reference for verified doubles.
@@ -50,11 +50,11 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubleReference do
           { 'EnforcedStyle' => 'string' }
         end
 
-        it 'does not flag a violation when using a string reference' do
+        it 'does not flag an offense when using a string reference' do
           expect_no_offenses("#{verified_double}('ClassName')")
         end
 
-        it 'flags a violation when using a constant reference' do
+        it 'flags an offense when using a constant reference' do
           expect_offense(<<~RUBY, verified_double: verified_double)
             %{verified_double}(ClassName)
             _{verified_double} ^^^^^^^^^ Use a string class reference for verified doubles.
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubleReference do
     end
   end
 
-  it 'does not flag a violation when reference is not a supported style' do
+  it 'does not flag an offense when reference is not a supported style' do
     expect_no_offenses(<<~RUBY)
       klass = Array
       instance_double(klass)


### PR DESCRIPTION
This PR change to use offense instead of violation. And this PR set also `Naming/InclusiveLanguage`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
