### PR TITLE
Add `AllowedIdentifiers` and `AllowedPatterns` configuration option to `RSpec/Pending`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Add `AllowedIdentifiers` and `AllowedPatterns` configuration option to `RSpec/Pending`. ([@ydah])
+
 ## 2.23.0 (2023-07-30)
 
 - Add new `RSpec/Rails/NegationBeValid` cop. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -702,7 +702,10 @@ RSpec/Pending:
   Description: Checks for any pending or skipped examples.
   Enabled: false
   VersionAdded: '1.25'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Pending
+  AllowedIdentifiers: []
+  AllowedPatterns: []
 
 RSpec/PendingWithoutReason:
   Description: Checks for pending or skipped examples without reason.

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4009,7 +4009,7 @@ let!(:other) { other }
 | Yes
 | No
 | 1.25
-| -
+| <<next>>
 |===
 
 Checks for any pending or skipped examples.
@@ -4044,6 +4044,42 @@ end
 describe MyClass do
 end
 ----
+
+==== `AllowedIdentifiers: ['run_test!']`
+
+[source,ruby]
+----
+# good
+response '201', 'foo created' do
+  run_test!
+end
+----
+
+==== `AllowedPatterns: ['it']`
+
+[source,ruby]
+----
+# good
+describe SomeService do
+  it
+  xit 'test' do
+  end
+end
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedIdentifiers
+| `[]`
+| Array
+
+| AllowedPatterns
+| `[]`
+| Array
+|===
 
 === References
 

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -32,8 +32,24 @@ module RuboCop
       #   describe MyClass do
       #   end
       #
+      # @example `AllowedIdentifiers: ['run_test!']`
+      #   # good
+      #   response '201', 'foo created' do
+      #     run_test!
+      #   end
+      #
+      # @example `AllowedPatterns: ['it']`
+      #   # good
+      #   describe SomeService do
+      #     it
+      #     xit 'test' do
+      #     end
+      #   end
+      #
       class Pending < Base
         include SkipOrPending
+        include AllowedIdentifiers
+        include AllowedPattern
 
         MSG = 'Pending spec found.'
 
@@ -60,6 +76,7 @@ module RuboCop
 
         def on_send(node)
           return unless pending_block?(node) || skipped?(node)
+          return if allowed?(node.method_name.to_s)
 
           add_offense(node)
         end
@@ -73,6 +90,11 @@ module RuboCop
 
         def skipped_regular_example_without_body?(node)
           skippable_example?(node) && !node.block_node
+        end
+
+        def allowed?(method_name)
+          allowed_identifier?(method_name) ||
+            matches_allowed_pattern?(method_name)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Pending do
+  let(:allowed_patterns) { [] }
+  let(:allowed_identifiers) { [] }
+  let(:cop_config) do
+    {
+      'AllowedIdentifiers' => allowed_identifiers,
+      'AllowedPatterns' => allowed_patterns
+    }
+  end
+
   it 'flags it without body' do
     expect_offense(<<-RUBY)
       it 'test'
@@ -224,5 +233,33 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
     expect_no_offenses(<<-RUBY)
       subject { Project.pending }
     RUBY
+  end
+
+  context 'when AllowedIdentifiers is set' do
+    let(:allowed_identifiers) { %w[it xcontext] }
+
+    it 'ignores allowed indexed let' do
+      expect_no_offenses(<<~RUBY)
+        describe SomeService do
+          it
+          xcontext 'test' do
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when AllowedPatterns is set' do
+    let(:allowed_patterns) { %w[it] }
+
+    it 'ignores allowed indexed let' do
+      expect_no_offenses(<<~RUBY)
+        describe SomeService do
+          it
+          xit 'test' do
+          end
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1678

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
