### PR TITLE
Ignore if non-constant string is passed to double on `RSpec/VerifiedDoubleReference`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Ignore if non-constant string is passed to double on `RSpec/VerifiedDoubleReference`. ([@r7kamura])
+
 ## 2.23.0 (2023-07-30)
 
 - Add new `RSpec/Rails/NegationBeValid` cop. ([@ydah])

--- a/lib/rubocop/cop/rspec/verified_double_reference.rb
+++ b/lib/rubocop/cop/rspec/verified_double_reference.rb
@@ -73,7 +73,7 @@ module RuboCop
 
         def on_send(node)
           verified_double(node) do |class_reference|
-            break correct_style_detected unless opposing_style?(class_reference)
+            break correct_style_detected if correct_style?(class_reference)
 
             message = format(MSG, style: style)
             expression = class_reference.source_range
@@ -89,6 +89,11 @@ module RuboCop
 
         private
 
+        def correct_style?(class_reference)
+          !opposing_style?(class_reference) ||
+            non_constant_string?(class_reference)
+        end
+
         def opposing_style?(class_reference)
           class_reference_style = REFERENCE_TYPE_STYLES[class_reference.type]
 
@@ -96,6 +101,12 @@ module RuboCop
           return false unless class_reference_style
 
           class_reference_style != style
+        end
+
+        def non_constant_string?(class_reference)
+          return false unless class_reference.str_type?
+
+          !class_reference.value.match?(/\A(?:(?:::)?[A-Z]\w*)+\z/)
         end
 
         def correct_style(violation)

--- a/spec/rubocop/cop/rspec/verified_double_reference_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_double_reference_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubleReference do
           RUBY
         end
 
+        it 'does not flag a violation when using a non-constant string' do
+          expect_no_offenses(<<~RUBY)
+            #{verified_double}('a b')
+          RUBY
+        end
+
         include_examples 'detects style',
                          "#{verified_double}(ClassName)",
                          'constant'


### PR DESCRIPTION
In this case, I believe it is better not to make it a violation in this Cop, since it cannot be replaced by constant.

- Fix https://github.com/rubocop/rubocop-rspec/issues/1679
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

~~If you have created a new cop:~~

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

~~If you have modified an existing cop's configuration options:~~

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
