### PR TITLE
Mark to `Safe: false` for `RSpec/Rails/NegationBeValid`  cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Mark to `Safe: false` for `RSpec/Rails/NegationBeValid`  cop. ([@ydah])
+
 ## 2.23.0 (2023-07-30)
 
 - Add new `RSpec/Rails/NegationBeValid` cop. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1108,12 +1108,14 @@ RSpec/Rails/MinitestAssertions:
 
 RSpec/Rails/NegationBeValid:
   Description: Enforces use of `be_invalid` or `not_to` for negated be_valid.
+  Safe: false
   EnforcedStyle: not_to
   SupportedStyles:
     - not_to
     - be_invalid
   Enabled: pending
   VersionAdded: '2.23'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/NegationBeValid
 
 RSpec/Rails/TravelAround:

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -267,13 +267,18 @@ expect(b).not_to eq(a)
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
 | Pending
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 2.23
-| -
+| <<next>>
 |===
 
 Enforces use of `be_invalid` or `not_to` for negated be_valid.
+
+=== Safety
+
+This cop is unsafe because it cannot guarantee that
+the test target is an instance of `ActiveModel::Validations``.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/rails/negation_be_valid.rb
+++ b/lib/rubocop/cop/rspec/rails/negation_be_valid.rb
@@ -6,6 +6,10 @@ module RuboCop
       module Rails
         # Enforces use of `be_invalid` or `not_to` for negated be_valid.
         #
+        # @safety
+        #   This cop is unsafe because it cannot guarantee that
+        #   the test target is an instance of `ActiveModel::Validations``.
+        #
         # @example EnforcedStyle: not_to (default)
         #   # bad
         #   expect(foo).to be_invalid


### PR DESCRIPTION
Resolve: https://github.com/rubocop/rubocop-rspec/pull/1665#issuecomment-1664171143

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
