### PR TITLE
Declare autocorrect as unsafe for `RSpec/ReceiveMessages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Mark to `Safe: false` for `RSpec/Rails/NegationBeValid`  cop. ([@ydah])
+- Declare autocorrect as unsafe for `RSpec/ReceiveMessages`. ([@bquorning])
 
 ## 2.23.0 (2023-07-30)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -733,7 +733,9 @@ RSpec/ReceiveCounts:
 RSpec/ReceiveMessages:
   Description: Checks for multiple messages stubbed on the same object.
   Enabled: pending
+  SafeAutoCorrect: false
   VersionAdded: '2.23'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveMessages
 
 RSpec/ReceiveNever:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4271,12 +4271,18 @@ expect(foo).to receive(:bar).at_most(:twice).times
 
 | Pending
 | Yes
-| Yes
+| Yes (Unsafe)
 | 2.23
-| -
+| <<next>>
 |===
 
 Checks for multiple messages stubbed on the same object.
+
+=== Safety
+
+The autocorrection is marked as unsafe, because it may change the
+order of stubs. This in turn may cause e.g. variables to be called
+before they are defined.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/receive_messages.rb
+++ b/lib/rubocop/cop/rspec/receive_messages.rb
@@ -5,6 +5,11 @@ module RuboCop
     module RSpec
       # Checks for multiple messages stubbed on the same object.
       #
+      # @safety
+      #   The autocorrection is marked as unsafe, because it may change the
+      #   order of stubs. This in turn may cause e.g. variables to be called
+      #   before they are defined.
+      #
       # @example
       #   # bad
       #   before do


### PR DESCRIPTION
As suggested in #1677.

I am unsure if I should change `VersionChanged` for the cop too.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
