### PR TITLE
Bump version to v2.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.23.1 (2023-08-07)
+
 - Mark to `Safe: false` for `RSpec/Rails/NegationBeValid`  cop. ([@ydah])
 - Declare autocorrect as unsafe for `RSpec/ReceiveMessages`. ([@bquorning])
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -735,7 +735,6 @@ RSpec/ReceiveMessages:
   Enabled: pending
   SafeAutoCorrect: false
   VersionAdded: '2.23'
-  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveMessages
 
 RSpec/ReceiveNever:
@@ -1117,7 +1116,6 @@ RSpec/Rails/NegationBeValid:
     - be_invalid
   Enabled: pending
   VersionAdded: '2.23'
-  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/NegationBeValid
 
 RSpec/Rails/TravelAround:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4273,7 +4273,7 @@ expect(foo).to receive(:bar).at_most(:twice).times
 | Yes
 | Yes (Unsafe)
 | 2.23
-| <<next>>
+| -
 |===
 
 Checks for multiple messages stubbed on the same object.

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -270,7 +270,7 @@ expect(b).not_to eq(a)
 | No
 | Yes (Unsafe)
 | 2.23
-| <<next>>
+| -
 |===
 
 Enforces use of `be_invalid` or `not_to` for negated be_valid.

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.23.0'
+      STRING = '2.23.1'
     end
   end
 end


### PR DESCRIPTION
Marking two cops as unsafe / unsafe to autocorrect.

I am not sure if the `VersionChanged` changes should just be removed, seeing that we’re changing the cops in the same minor version as the cops were added?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
