### PR TITLE
Fix a few bugs in RSpec/ReceiveMessages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false positive for `RSpec/ReceiveMessages` when return with splat. ([@marocchino])
+
 ## 2.23.1 (2023-08-07)
 
 - Mark to `Safe: false` for `RSpec/Rails/NegationBeValid`  cop. ([@ydah])
@@ -843,6 +845,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@lokhi]: https://github.com/lokhi
 [@luke-hill]: https://github.com/luke-hill
 [@m-yamashita01]: https://github.com/M-Yamashita01
+[@marocchino]: https://github.com/marocchino
 [@miguelfteixeira]: https://github.com/miguelfteixeira
 [@mkenyon]: https://github.com/mkenyon
 [@mkrawc]: https://github.com/mkrawc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix an incorrect autocorrect for `RSpec/ReceiveMessages` when method is only non-word character. ([@marocchino])
 - Fix a false positive for `RSpec/ReceiveMessages` when return with splat. ([@marocchino])
 
 ## 2.23.1 (2023-08-07)

--- a/lib/rubocop/cop/rspec/receive_messages.rb
+++ b/lib/rubocop/cop/rspec/receive_messages.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         # @!method allow_receive_message?(node)
         def_node_matcher :allow_receive_message?, <<~PATTERN
-          (send (send nil? :allow ...) :to (send (send nil? :receive (sym _)) :and_return !#heredoc?))
+          (send (send nil? :allow ...) :to (send (send nil? :receive (sym _)) :and_return !#heredoc_or_splat?))
         PATTERN
 
         # @!method allow_argument(node)
@@ -147,8 +147,9 @@ module RuboCop
           range_by_whole_lines(item.source_range, include_final_newline: true)
         end
 
-        def heredoc?(node)
-          (node.str_type? || node.dstr_type?) && node.heredoc?
+        def heredoc_or_splat?(node)
+          (node.str_type? || node.dstr_type?) && node.heredoc? ||
+            node.splat_type?
         end
 
         def requires_quotes?(value)

--- a/lib/rubocop/cop/rspec/receive_messages.rb
+++ b/lib/rubocop/cop/rspec/receive_messages.rb
@@ -153,7 +153,7 @@ module RuboCop
         end
 
         def requires_quotes?(value)
-          value.match?(/^:".*?"|=$/)
+          value.match?(/^:".*?"|=$|^\W+$/)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/receive_messages_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_messages_spec.rb
@@ -40,6 +40,24 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveMessages, :config do
   end
 
   it 'registers an offense when multiple messeages stubbed on the ' \
+     'same object and symbol methods' do
+    expect_offense(<<~RUBY)
+      before do
+        allow(Service).to receive(:`).and_return(true)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `receive_messages` instead of multiple stubs on lines [3].
+        allow(Service).to receive(:[]).and_return(true)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `receive_messages` instead of multiple stubs on lines [2].
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      before do
+        allow(Service).to receive_messages('`': true, '[]': true)
+      end
+    RUBY
+  end
+
+  it 'registers an offense when multiple messeages stubbed on the ' \
      'same object and return array' do
     expect_offense(<<~RUBY)
       before do

--- a/spec/rubocop/cop/rspec/receive_messages_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_messages_spec.rb
@@ -101,6 +101,26 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveMessages, :config do
   end
 
   it 'does not register an offense when multiple messeages stubbed on the ' \
+     'same object and return with splat' do
+    expect_no_offenses(<<~RUBY)
+      before do
+        allow(Service).to receive(:foo).and_return(*array)
+        allow(Service).to receive(:bar).and_return(*array)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when multiple messeages stubbed on the ' \
+     'same object and return multiple' do
+    expect_no_offenses(<<~RUBY)
+      before do
+        allow(Service).to receive(:foo).and_return(1, 2)
+        allow(Service).to receive(:bar).and_return(3, 4)
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when multiple messeages stubbed on the ' \
      'same object and message order' do
     expect_no_offenses(<<~RUBY)
       before do


### PR DESCRIPTION
Fixed a few bugs.
- Methods consisting of only symbols need quotes.
- If and_return is passed as a splat, it shouldn't be detected because it can't be converted to a hash.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- ~~[ ] Updated documentation~~.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

