### PR TITLE
Correct some offenses for RuboCop v1.56.0

### DIFF
--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -51,7 +51,8 @@ module RuboCop
           parent = expect.parent
           return true unless parent
           return true if parent.begin_type?
-          return true if parent.block_type? && parent.body == expect
+
+          true if parent.block_type? && parent.body == expect
         end
       end
     end


### PR DESCRIPTION
https://github.com/rubocop/rubocop-rspec/pull/1690 needs this PR's changes.

```
❯ bundle exec rubocop -A
Inspecting 280 files
.....................................................................................................................................C..................................................................................................................................................

Offenses:

lib/rubocop/cop/rspec/void_expect.rb:53:11: C: [Corrected] Layout/EmptyLineAfterGuardClause: Add empty line after guard clause.
          return true if parent.begin_type?
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rspec/void_expect.rb:54:11: C: [Corrected] Style/RedundantReturn: Redundant return detected.
          return true if parent.block_type? && parent.body == expect
          ^^^^^^

280 files inspected, 2 offenses detected, 2 offenses corrected
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
