### PR TITLE
Fix infinite loop in ExcessiveDocstringSpacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix an infinite loop error when `RSpec/ExcessiveDocstringSpacing` finds a description with non-ASCII leading/trailing whitespace. ([@bcgraham])
+
 ## 2.23.2 (2023-08-09)
 
 - Fix an incorrect autocorrect for `RSpec/ReceiveMessages` when method is only non-word character. ([@marocchino])
@@ -797,6 +799,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@aried3r]: https://github.com/aried3r
 [@baberthal]: https://github.com/baberthal
 [@backus]: https://github.com/backus
+[@bcgraham]: https://github.com/bcgraham
 [@biinari]: https://github.com/biinari
 [@bmorrall]: https://github.com/bmorrall
 [@bquorning]: https://github.com/bquorning

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -66,7 +66,9 @@ module RuboCop
 
         # @param text [String]
         def strip_excessive_whitespace(text)
-          text.strip.gsub(/[[:blank:]]{2,}/, ' ')
+          text
+            .gsub(/[[:blank:]]{2,}/, ' ')
+            .gsub(/\A[[:blank:]]|[[:blank:]]\z/, '')
         end
 
         # @param node [RuboCop::AST::Node]

--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -28,8 +28,21 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'finds description with leading em space' do
       expect_offense(<<-RUBY)
-        describe '　　#mymethod' do
+        describe '\u3000\u3000#mymethod' do
                   ^^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        describe '#mymethod' do
+        end
+      RUBY
+    end
+
+    it 'finds description with leading non-breaking space' do
+      expect_offense(<<-RUBY)
+        describe '\u00a0#mymethod' do
+                  ^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
@@ -67,7 +80,33 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'finds description with trailing em space' do
       expect_offense(<<-RUBY)
-        describe '#mymethod　　' do
+        describe '#mymethod\u3000\u3000' do
+                  ^^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        describe '#mymethod' do
+        end
+      RUBY
+    end
+
+    it 'finds description with trailing non-breaking space' do
+      expect_offense(<<-RUBY)
+        describe '#mymethod\u00a0' do
+                  ^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        describe '#mymethod' do
+        end
+      RUBY
+    end
+
+    it 'finds description with leading and trailing non-breaking space' do
+      expect_offense(<<-RUBY)
+        describe '\u00a0#mymethod\u00a0' do
                   ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
@@ -205,6 +244,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
       RUBY
     end
 
+    it 'finds description with leading non-breaking space' do
+      expect_offense(<<-RUBY)
+        context '\u00a0#mymethod' do
+                 ^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        context '#mymethod' do
+        end
+      RUBY
+    end
+
     it 'finds interpolated description with leading whitespace' do
       expect_offense(<<-'RUBY')
         context "  when doing something #{:stuff}" do
@@ -227,6 +279,32 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
       expect_correction(<<-RUBY)
         context 'when doing something' do
+        end
+      RUBY
+    end
+
+    it 'finds description with trailing non-breaking space' do
+      expect_offense(<<-RUBY)
+        context '#mymethod\u00a0' do
+                 ^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        context '#mymethod' do
+        end
+      RUBY
+    end
+
+    it 'finds description with leading and trailing non-breaking space' do
+      expect_offense(<<-RUBY)
+        context '\u00a0#mymethod\u00a0' do
+                 ^^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        context '#mymethod' do
         end
       RUBY
     end
@@ -372,6 +450,19 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
       RUBY
     end
 
+    it 'finds description with leading non-breaking space' do
+      expect_offense(<<-RUBY)
+        it '\u00a0does something' do
+            ^^^^^^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it 'does something' do
+        end
+      RUBY
+    end
+
     it 'finds interpolated description with leading whitespace' do
       expect_offense(<<-'RUBY')
         it "  does something #{:stuff}" do
@@ -388,6 +479,32 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
     it 'finds description with trailing whitespace' do
       expect_offense(<<-RUBY)
         it 'does something  ' do
+            ^^^^^^^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it 'does something' do
+        end
+      RUBY
+    end
+
+    it 'finds description with trailing non-breaking space' do
+      expect_offense(<<-RUBY)
+        it 'does something\u00a0' do
+            ^^^^^^^^^^^^^^^ Excessive whitespace.
+        end
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it 'does something' do
+        end
+      RUBY
+    end
+
+    it 'finds description with leading and trailing non-breaking space' do
+      expect_offense(<<-RUBY)
+        it '\u00a0does something\u00a0' do
             ^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY


### PR DESCRIPTION
#### TL;DR: Reproduction
Leading/trailing non-ASCII whitespace triggers an infinite loop error.
```sh
ruby -e 'File.open("spec/file_spec.rb", "w+") { |f| f.puts "describe \'\u00a0foo\' do; end" }'
bundle exec rubocop --only RSpec/ExcessiveDocstringSpacing -a spec/file_spec.rb
```
#### Slightly longer
The test predicate for RSpec/ExcessiveDocstringSpacing now flags leading and trailing text matching [`[[:blank:]]`](https://github.com/rubocop/rubocop-rspec/blob/e09a7017ce918dd46db0f39c4a206a1fae7ad0c0/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb#L56-L60), but the corrector still calls [`strip`](https://github.com/rubocop/rubocop-rspec/blob/e09a7017ce918dd46db0f39c4a206a1fae7ad0c0/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb#L69)[^1].  [POSIX bracket expressions match non-ASCII characters](https://docs.ruby-lang.org/en/3.2/Regexp.html#class-Regexp-label-Character+Classes), but [strip only removes ASCII whitespace](https://docs.ruby-lang.org/en/3.2/String.html#class-String-label-Whitespace+in+Strings). The correction does not remove the offense. As a result, leading/trailing non-ASCII whitespace triggers an infinite correction loop, since the corrector doesn't remove the offending pattern.
#### Details

In 408e69be903f1114e44e2f1ea8ef70d8c02cf279, the test predicate for excessive whitespace was [changed](https://github.com/rubocop/rubocop-rspec/commit/408e69be903f1114e44e2f1ea8ef70d8c02cf279#diff-75148f9ae42c55870d87e3888b51b81f6f75e780890c95302fc22540f1ff5f5aR54-R70) to use `[[:blank:]]`:
```diff
         def excessive_whitespace?(text)
-          return true if text.start_with?(' ') || text.end_with?(' ')
-
-          text.match?(/[^\n ]  +[^ ]/)
+          text.match?(/
+            # Leading space
+            \A[[:blank:]]
+            |
+            # Trailing space
+            [[:blank:]]\z
+            |
+            # Two or more consecutive spaces, except if they are leading spaces
+            [^[[:space:]]][[:blank:]]{2,}[^[[:blank:]]]
+          /x)
         end
```
But the corrector method continued to use `strip` for leading/trailing whitespace, only using `[[:blank:]]` for internal whitespace:
```diff
         # @param text [String]
         def strip_excessive_whitespace(text)
-          text.strip.gsub(/  +/, ' ')
+          text.strip.gsub(/[[:blank:]]{2,}/, ' ')
         end
```
The test predicate now flags leading and trailing text matching `[[:blank:]]`, but the corrector still calls `strip`. [POSIX bracket expressions like `[[:blank:]]` match non-ASCII characters](https://docs.ruby-lang.org/en/3.2/Regexp.html#class-Regexp-label-Character+Classes), but [ `strip` only removes ASCII whitespace](https://docs.ruby-lang.org/en/3.2/String.html#class-String-label-Whitespace+in+Strings). Calling the corrector does not correct the problem. As a result, leading/trailing non-ASCII whitespace triggers an infinite correction loop.

[^1]: I've hard-coded the commit SHAs to the current `master` referent to keep it working into the future, but today, August 14, 2023, those point to today's `master`, 408e69be903f1114e44e2f1ea8ef70d8c02cf279.)
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [X] Updated documentation.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
