### PR TITLE
Fix autocorrect in `RSpec/ReceiveMessages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix an infinite loop error when `RSpec/ExcessiveDocstringSpacing` finds a description with non-ASCII leading/trailing whitespace. ([@bcgraham])
+- Fix an incorrect autocorrect for `RSpec/ReceiveMessages` when return values declared between stubs. ([@marocchino])
 
 ## 2.23.2 (2023-08-09)
 

--- a/lib/rubocop/cop/rspec/receive_messages.rb
+++ b/lib/rubocop/cop/rspec/receive_messages.rb
@@ -124,7 +124,7 @@ module RuboCop
 
         def register_offense(item, repeated_lines, args)
           add_offense(item, message: message(repeated_lines)) do |corrector|
-            if item.loc.line < repeated_lines.min
+            if item.loc.line > repeated_lines.max
               replace_to_receive_messages(corrector, item, args)
             else
               corrector.remove(item_range_by_whole_lines(item))


### PR DESCRIPTION
If you replace the first one, you can reference the object before initializing any objects that may be in between. So I changed it to replace it in the last position.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- ~~[ ] Updated documentation.~~
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

Related #1677