### PR TITLE
Add support `RSpec/Rails/HttpStatus` when `have_http_status` with string argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add new `RSpec/Eq` cop. ([@ydah])
 - Fix an incorrect autocorrect for `RSpec/ReceiveMessages` when return values declared between stubs. ([@marocchino])
 - Split `RSpec/FilePath` into `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat`. `RSpec/FilePath` cop is enabled by default, the two new cups are pending and need to be enabled explicitly. ([@ydah])
+- Add support `RSpec/Rails/HttpStatus` when `have_http_status` with string argument. ([@ydah])
 
 ## 2.23.2 (2023-08-09)
 

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -91,10 +91,12 @@ when setting for `EnforcedStyle: symbolic` or
 # bad
 it { is_expected.to have_http_status 200 }
 it { is_expected.to have_http_status 404 }
+it { is_expected.to have_http_status "403" }
 
 # good
 it { is_expected.to have_http_status :ok }
 it { is_expected.to have_http_status :not_found }
+it { is_expected.to have_http_status :forbidden }
 it { is_expected.to have_http_status :success }
 it { is_expected.to have_http_status :error }
 ----
@@ -106,10 +108,12 @@ it { is_expected.to have_http_status :error }
 # bad
 it { is_expected.to have_http_status :ok }
 it { is_expected.to have_http_status :not_found }
+it { is_expected.to have_http_status "forbidden" }
 
 # good
 it { is_expected.to have_http_status 200 }
 it { is_expected.to have_http_status 404 }
+it { is_expected.to have_http_status 403 }
 it { is_expected.to have_http_status :success }
 it { is_expected.to have_http_status :error }
 ----
@@ -121,8 +125,10 @@ it { is_expected.to have_http_status :error }
 # bad
 it { is_expected.to have_http_status :ok }
 it { is_expected.to have_http_status :not_found }
+it { is_expected.to have_http_status "forbidden" }
 it { is_expected.to have_http_status 200 }
 it { is_expected.to have_http_status 404 }
+it { is_expected.to have_http_status "403" }
 
 # good
 it { is_expected.to be_ok }

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -15,6 +15,17 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       RUBY
     end
 
+    it 'registers an offense when using string value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status "200" }
+                                             ^^^^^ Prefer `:ok` over `"200"` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to have_http_status :ok }
+      RUBY
+    end
+
     it 'does not register an offense when using symbolic value' do
       expect_no_offenses(<<-RUBY)
         it { is_expected.to have_http_status :ok }
@@ -48,6 +59,17 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       expect_offense(<<-RUBY)
         it { is_expected.to have_http_status :ok }
                                              ^^^ Prefer `200` over `:ok` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to have_http_status 200 }
+      RUBY
+    end
+
+    it 'registers an offense when using string value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status "ok" }
+                                             ^^^^ Prefer `200` over `"ok"` to describe HTTP status code.
       RUBY
 
       expect_correction(<<-RUBY)
@@ -105,6 +127,20 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       RUBY
 
       expect_correction(<<-RUBY)
+        it { is_expected.to be_ok }
+      RUBY
+    end
+
+    it 'registers an offense when using string value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status "200" }
+                            ^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status "200"` to describe HTTP status code.
+        it { is_expected.to have_http_status "ok" }
+                            ^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status "ok"` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to be_ok }
         it { is_expected.to be_ok }
       RUBY
     end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1702

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).