### PR TITLE
Fix a false positive `RSpec/Focus` when chained method call and inside define method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix an incorrect autocorrect for `RSpec/ReceiveMessages` when return values declared between stubs. ([@marocchino])
 - Split `RSpec/FilePath` into `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat`. `RSpec/FilePath` cop is enabled by default, the two new cups are pending and need to be enabled explicitly. ([@ydah])
 - Add support `RSpec/Rails/HttpStatus` when `have_http_status` with string argument. ([@ydah])
+- Fix a false positive `RSpec/Focus` when chained method call and inside define method. ([@ydah])
 
 ## 2.23.2 (2023-08-09)
 

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -79,6 +79,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          return if node.chained? || node.each_ancestor(:def, :defs).any?
+
           focus_metadata(node) do |focus|
             add_offense(focus) do |corrector|
               if focus.pair_type? || focus.str_type? || focus.sym_type?

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -220,4 +220,43 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       describe 'test', js: true do; end
     RUBY
   end
+
+  it 'ignores with chained method calls' do
+    expect_no_offenses(<<-RUBY)
+      let(:fit) { Tax.federal_income_tax }
+      let(:fit_id) { fit.id }
+    RUBY
+  end
+
+  it 'ignores when inside define method' do
+    expect_no_offenses(<<-RUBY)
+      context 'test' do
+        def foo
+          fdescribe 'test'
+          ffeature 'test'
+          fcontext 'test'
+          fit 'test'
+          fscenario 'test'
+          fexample 'test'
+          fspecify 'test'
+          focus 'test'
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores when inside define singleton method' do
+    expect_no_offenses(<<-RUBY)
+      def self.foo
+        fdescribe 'test'
+        ffeature 'test'
+        fcontext 'test'
+        fit 'test'
+        fscenario 'test'
+        fexample 'test'
+        fspecify 'test'
+        focus 'test'
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/398

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).