### PR TITLE
Fix an error when using `inherit_gem: rubocop-rspec: config/default.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix an error when using `inherit_gem: rubocop-rspec: config/default.yml`. ([@ydah])
+
 ## 2.24.0 (2023-09-08)
 
 - Split `RSpec/FilePath` into `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat`. `RSpec/FilePath` cop is enabled by default, the two new cops are pending and need to be enabled explicitly. ([@ydah])

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -27,9 +27,3 @@ renamed:
   RSpec/FactoryBot/FactoryClassName: FactoryBot/FactoryClassName
   RSpec/FactoryBot/FactoryNameStyle: FactoryBot/FactoryNameStyle
   RSpec/FactoryBot/SyntaxMethods: FactoryBot/SyntaxMethods
-
-split:
-  RSpec/FilePath:
-    alternatives:
-      - RSpec/SpecFilePathFormat
-      - RSpec/SpecFilePathSuffix

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2012,6 +2012,12 @@ expect { my_app.print_report }.to output('Hello World').to_stdout
 
 Checks that spec file paths are consistent and well-formed.
 
+This cop is deprecated.
+We plan to remove it in the next major version update to 3.0.
+The migration destinations are `RSpec/SpecFilePathSuffix`
+and `RSpec/SpecFilePathFormat`.
+If you are using this cop, please plan for migration.
+
 By default, this checks that spec file paths are consistent with the
 test subject and enforces that it reflects the described
 class/module and its optionally called out method.

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -5,6 +5,12 @@ module RuboCop
     module RSpec
       # Checks that spec file paths are consistent and well-formed.
       #
+      # This cop is deprecated.
+      # We plan to remove it in the next major version update to 3.0.
+      # The migration destinations are `RSpec/SpecFilePathSuffix`
+      # and `RSpec/SpecFilePathFormat`.
+      # If you are using this cop, please plan for migration.
+      #
       # By default, this checks that spec file paths are consistent with the
       # test subject and enforces that it reflects the described
       # class/module and its optionally called out method.


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/pull/1698#discussion_r1319868935

Once we delete it from config/obsoletion.yml, because it is an error if it is a split.

How about proceeding as follows?
- Remove the configuration from config/obsoletion.yml once, since split would result in an error. (Patch version release)
- Release a version that warns if `RSpec/FilePath` is used (Next and subsequent releases)
- Remove `RSpec/FilePath` in the next major version update

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).