### PR TITLE
Fix an error when using `RSpec/FilePath` and revert to enabled by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -98,6 +98,9 @@ RSpec/ExampleLength:
     - heredoc
   Max: 11
 
+RSpec/FilePath:
+  Enabled: false
+
 RSpec/DescribeClass:
   Exclude:
     - spec/project/**/*.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Master (Unreleased)
 
+- Fix an error when using `RSpec/FilePath` and revert to enabled by default. If you have already moved to `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat`, disable `RSpec/FilePath` explicitly as `Enabled: false`. The `RSpec/FilePath` before migration and the `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat` as the target are available respectively. ([@ydah])
+
 ## 2.24.0 (2023-09-08)
 
-- Split `RSpec/FilePath` into `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat`. `RSpec/FilePath` cop is enabled by default, the two new cops are pending and need to be enabled explicitly. ([@ydah])
+- Split `RSpec/FilePath` into `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat`. `RSpec/FilePath` cop is disabled by default and the two new cops are pending and need to be enabled explicitly. ([@ydah])
 - Add new `RSpec/Eq` cop. ([@ydah])
 - Add `RSpec/MetadataStyle` and `RSpec/EmptyMetadata` cops. ([@r7kamura])
 - Add support `RSpec/Rails/HttpStatus` when `have_http_status` with string argument. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -448,7 +448,7 @@ RSpec/ExpectOutput:
 
 RSpec/FilePath:
   Description: Checks that spec file paths are consistent and well-formed.
-  Enabled: false
+  Enabled: true
   Include:
     - "**/*_spec*rb*"
     - "**/spec/**/*"

--- a/config/obsoletion.yml
+++ b/config/obsoletion.yml
@@ -27,9 +27,3 @@ renamed:
   RSpec/FactoryBot/FactoryClassName: FactoryBot/FactoryClassName
   RSpec/FactoryBot/FactoryNameStyle: FactoryBot/FactoryNameStyle
   RSpec/FactoryBot/SyntaxMethods: FactoryBot/SyntaxMethods
-
-split:
-  RSpec/FilePath:
-    alternatives:
-      - RSpec/SpecFilePathFormat
-      - RSpec/SpecFilePathSuffix

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2003,7 +2003,7 @@ expect { my_app.print_report }.to output('Hello World').to_stdout
 |===
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
-| Disabled
+| Enabled
 | Yes
 | No
 | 1.2
@@ -2011,6 +2011,12 @@ expect { my_app.print_report }.to output('Hello World').to_stdout
 |===
 
 Checks that spec file paths are consistent and well-formed.
+
+This cop is deprecated.
+We plan to remove it in the next major version update to 3.0.
+The migration targets are `RSpec/SpecFilePathSuffix`
+and `RSpec/SpecFilePathFormat`.
+If you are using this cop, please plan for migration.
 
 By default, this checks that spec file paths are consistent with the
 test subject and enforces that it reflects the described

--- a/lib/rubocop/cop/rspec/file_path.rb
+++ b/lib/rubocop/cop/rspec/file_path.rb
@@ -5,6 +5,12 @@ module RuboCop
     module RSpec
       # Checks that spec file paths are consistent and well-formed.
       #
+      # This cop is deprecated.
+      # We plan to remove it in the next major version update to 3.0.
+      # The migration targets are `RSpec/SpecFilePathSuffix`
+      # and `RSpec/SpecFilePathFormat`.
+      # If you are using this cop, please plan for migration.
+      #
       # By default, this checks that spec file paths are consistent with the
       # test subject and enforces that it reflects the described
       # class/module and its optionally called out method.


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1717

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
