### PR TITLE
Add support single quoted string and percent string and heredoc for `RSpec/Rails/HttpStatus`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Add support single quoted string and percent string and heredoc for `RSpec/Rails/HttpStatus`. ([@ydah])
+
 ## 2.24.1 (2023-09-23)
 
 - Fix an error when using `RSpec/FilePath` and revert to enabled by default. If you have already moved to `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat`, disable `RSpec/FilePath` explicitly as `Enabled: false`. The `RSpec/FilePath` before migration and the `RSpec/SpecFilePathSuffix` and `RSpec/SpecFilePathFormat` as the target are available respectively. ([@ydah])

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -66,6 +66,8 @@ module RuboCop
 
           def on_send(node)
             http_status(node) do |arg|
+              return if arg.str_type? && arg.heredoc?
+
               checker = checker_class.new(arg)
               return unless checker.offensive?
 
@@ -105,6 +107,10 @@ module RuboCop
               format(MSG, prefer: prefer, current: current)
             end
 
+            def current
+              offense_range.source
+            end
+
             def offense_range
               node
             end
@@ -129,10 +135,6 @@ module RuboCop
               symbol.inspect
             end
 
-            def current
-              node.value.inspect
-            end
-
             private
 
             def symbol
@@ -140,7 +142,7 @@ module RuboCop
             end
 
             def number
-              node.source.delete('"').to_i
+              node.value.to_i
             end
           end
 
@@ -152,10 +154,6 @@ module RuboCop
 
             def prefer
               number.to_s
-            end
-
-            def current
-              symbol.inspect
             end
 
             private
@@ -190,10 +188,6 @@ module RuboCop
               end
             end
 
-            def current
-              offense_range.source
-            end
-
             private
 
             def symbol
@@ -201,15 +195,15 @@ module RuboCop
             end
 
             def number
-              node.source.to_i
+              node.value.to_i
             end
 
             def normalize_str
-              normalized = node.source.delete('"')
-              if normalized.match?(/\A\d+\z/)
-                ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(normalized.to_i)
+              str = node.value.to_s
+              if str.match?(/\A\d+\z/)
+                ::Rack::Utils::SYMBOL_TO_STATUS_CODE.key(str.to_i)
               else
-                normalized
+                str
               end
             end
           end

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       RUBY
     end
 
-    it 'registers an offense when using string value' do
+    it 'registers an offense when using double quoted string value' do
       expect_offense(<<-RUBY)
         it { is_expected.to have_http_status "200" }
                                              ^^^^^ Prefer `:ok` over `"200"` to describe HTTP status code.
@@ -23,6 +23,36 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
 
       expect_correction(<<-RUBY)
         it { is_expected.to have_http_status :ok }
+      RUBY
+    end
+
+    it 'registers an offense when using single quoted string value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status '200' }
+                                             ^^^^^ Prefer `:ok` over `'200'` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to have_http_status :ok }
+      RUBY
+    end
+
+    it 'registers an offense when using percent string value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status %[200] }
+                                             ^^^^^^ Prefer `:ok` over `%[200]` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to have_http_status :ok }
+      RUBY
+    end
+
+    it 'does not register an offense when using here document' do
+      expect_no_offenses(<<-RUBY)
+        it { is_expected.to have_http_status <<~HTTP }
+          200
+        HTTP
       RUBY
     end
 
@@ -66,10 +96,21 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       RUBY
     end
 
-    it 'registers an offense when using string value' do
+    it 'registers an offense when using double quoted string value' do
       expect_offense(<<-RUBY)
         it { is_expected.to have_http_status "ok" }
                                              ^^^^ Prefer `200` over `"ok"` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to have_http_status 200 }
+      RUBY
+    end
+
+    it 'registers an offense when using single quoted string value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status 'ok' }
+                                             ^^^^ Prefer `200` over `'ok'` to describe HTTP status code.
       RUBY
 
       expect_correction(<<-RUBY)
@@ -131,7 +172,7 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       RUBY
     end
 
-    it 'registers an offense when using string value' do
+    it 'registers an offense when using double quoted string value' do
       expect_offense(<<-RUBY)
         it { is_expected.to have_http_status "200" }
                             ^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status "200"` to describe HTTP status code.
@@ -142,6 +183,42 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
       expect_correction(<<-RUBY)
         it { is_expected.to be_ok }
         it { is_expected.to be_ok }
+      RUBY
+    end
+
+    it 'registers an offense when using single quoted string value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status '200' }
+                            ^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status '200'` to describe HTTP status code.
+        it { is_expected.to have_http_status 'ok' }
+                            ^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status 'ok'` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to be_ok }
+        it { is_expected.to be_ok }
+      RUBY
+    end
+
+    it 'registers an offense when using percent string value' do
+      expect_offense(<<-RUBY)
+        it { is_expected.to have_http_status %[200] }
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status %[200]` to describe HTTP status code.
+        it { is_expected.to have_http_status %[ok] }
+                            ^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status %[ok]` to describe HTTP status code.
+      RUBY
+
+      expect_correction(<<-RUBY)
+        it { is_expected.to be_ok }
+        it { is_expected.to be_ok }
+      RUBY
+    end
+
+    it 'does not register an offense when using here document' do
+      expect_no_offenses(<<-RUBY)
+        it { is_expected.to have_http_status <<~HTTP }
+          200
+        HTTP
       RUBY
     end
 


### PR DESCRIPTION
This PR add support single quoted string and percent string and heredoc for `RSpec/Rails/HttpStatus`.

reproduction code
```rb
it { is_expected.to have_http_status '200' }
it { is_expected.to have_http_status %[200] }
it { is_expected.to have_http_status <<~HTTP }
  200
HTTP
```

expected
```rb
it { is_expected.to have_http_status :ok }
it { is_expected.to have_http_status :ok }
it { is_expected.to have_http_status <<~HTTP } # not offense
  200
HTTP
```

actual
```rb
it { is_expected.to have_http_status }
it { is_expected.to have_http_status }
it { is_expected.to have_http_status }
  200
HTTP
```