### PR TITLE
Add documentation for `RSpec/ExampleLength` configuration option `CountAsOne: [method_call]`

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1542,9 +1542,10 @@ A long example is usually more difficult to understand. Consider
 extracting out some behavior, e.g. with a `let` block, or a helper
 method.
 
-You can set literals you want to fold with `CountAsOne`.
-Available are: 'array', 'hash', and 'heredoc'. Each literal
-will be counted as one line regardless of its actual size.
+You can set constructs you want to fold with `CountAsOne`.
+Available are: 'array', 'hash', 'heredoc', and 'method_call'.
+Each construct will be counted as one line regardless of
+its actual size.
 
 === Examples
 
@@ -1567,7 +1568,7 @@ it do
 end
 ----
 
-==== CountAsOne: ['array', 'heredoc']
+==== CountAsOne: ['array', 'heredoc', 'method_call']
 
 [source,ruby]
 ----
@@ -1585,7 +1586,12 @@ it do
     Heredoc
     content.
   HEREDOC
-end                 # 5 points
+
+  foo(            # +1
+    1,
+    2
+  )
+end               # 6 points
 ----
 
 === Configurable attributes

--- a/lib/rubocop/cop/rspec/example_length.rb
+++ b/lib/rubocop/cop/rspec/example_length.rb
@@ -26,11 +26,12 @@ module RuboCop
       #     expect(result).to be(true)
       #   end
       #
-      # You can set literals you want to fold with `CountAsOne`.
-      # Available are: 'array', 'hash', and 'heredoc'. Each literal
-      # will be counted as one line regardless of its actual size.
+      # You can set constructs you want to fold with `CountAsOne`.
+      # Available are: 'array', 'hash', 'heredoc', and 'method_call'.
+      # Each construct will be counted as one line regardless of
+      # its actual size.
       #
-      # @example CountAsOne: ['array', 'heredoc']
+      # @example CountAsOne: ['array', 'heredoc', 'method_call']
       #
       #   it do
       #     array = [         # +1
@@ -46,7 +47,12 @@ module RuboCop
       #       Heredoc
       #       content.
       #     HEREDOC
-      #   end                 # 5 points
+      #
+      #     foo(            # +1
+      #       1,
+      #       2
+      #     )
+      #   end               # 6 points
       #
       class ExampleLength < Base
         include CodeLength

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.33'
+  spec.add_runtime_dependency 'rubocop', '~> 1.40'
   spec.add_runtime_dependency 'rubocop-capybara', '~> 2.17'
   spec.add_runtime_dependency 'rubocop-factory_bot', '~> 2.22'
 end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1728

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
