### PR TITLE
RSpec/MetadataStyle: Fix false positive for multiple strings preceding metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add support single quoted string and percent string and heredoc for `RSpec/Rails/HttpStatus`. ([@ydah])
 - Change to be inline disable for `RSpec/SpecFilePathFormat` like `RSpec/FilePath`. ([@ydah])
+- Fix a false positive for `RSpec/MetadataStyle` with example groups having multiple string arguments. ([@franzliedke])
 
 ## 2.24.1 (2023-09-23)
 
@@ -842,6 +843,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@faucct]: https://github.com/faucct
 [@foton]: https://github.com/foton
 [@francois-ferrandis]: https://github.com/francois-ferrandis
+[@franzliedke]: https://github.com/franzliedke
 [@g-rath]: https://github.com/G-Rath
 [@geniou]: https://github.com/geniou
 [@gsamokovarov]: https://github.com/gsamokovarov

--- a/lib/rubocop/cop/rspec/metadata_style.rb
+++ b/lib/rubocop/cop/rspec/metadata_style.rb
@@ -45,6 +45,11 @@ module RuboCop
         PATTERN
 
         def on_metadata(symbols, hash)
+          # RSpec example groups accept two string arguments. In such a case,
+          # the rspec_metadata matcher will interpret the second string
+          # argument as a metadata symbol.
+          symbols.shift if symbols.first&.str_type?
+
           symbols.each do |symbol|
             on_metadata_symbol(symbol)
           end

--- a/lib/rubocop/cop/rspec/mixin/metadata.rb
+++ b/lib/rubocop/cop/rspec/mixin/metadata.rb
@@ -30,12 +30,12 @@ module RuboCop
         def on_block(node)
           rspec_configure(node) do |block_var|
             metadata_in_block(node, block_var) do |metadata_arguments|
-              on_matadata_arguments(metadata_arguments)
+              on_metadata_arguments(metadata_arguments)
             end
           end
 
           rspec_metadata(node) do |metadata_arguments|
-            on_matadata_arguments(metadata_arguments)
+            on_metadata_arguments(metadata_arguments)
           end
         end
         alias on_numblock on_block
@@ -46,7 +46,7 @@ module RuboCop
 
         private
 
-        def on_matadata_arguments(metadata_arguments)
+        def on_metadata_arguments(metadata_arguments)
           *symbols, last = metadata_arguments
           hash = nil
           case last&.type

--- a/spec/rubocop/cop/rspec/metadata_style_spec.rb
+++ b/spec/rubocop/cop/rspec/metadata_style_spec.rb
@@ -203,6 +203,15 @@ RSpec.describe RuboCop::Cop::RSpec::MetadataStyle do
       end
     end
 
+    context 'with boolean hash metadata after 2 string arguments' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          describe 'Something', 'Something else', { a: true } do
+          end
+        RUBY
+      end
+    end
+
     context 'with 1 symbol metadata' do
       it 'registers offense' do
         expect_offense(<<~RUBY)
@@ -229,6 +238,21 @@ RSpec.describe RuboCop::Cop::RSpec::MetadataStyle do
 
         expect_correction(<<~RUBY)
           describe 'Something', b: true, a: true do
+          end
+        RUBY
+      end
+    end
+
+    context 'with symbol metadata after 2 string arguments' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          describe 'Something', 'Something else', :a do
+                                                  ^^ Use hash style for metadata.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          describe 'Something', 'Something else', a: true do
           end
         RUBY
       end


### PR DESCRIPTION
This fixes a false positive in an example group like the following:

```ruby
      response "404", "unauthorized access", api_docs: false do
        let(:authorization) { another_user.token }

        run_test!
      end
```

(This uses DSL from the `rswag` gem.)

Fixes #1714.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
