### PR TITLE
Bump version to v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.25.0 (2023-10-27)
+
 - Add support single quoted string and percent string and heredoc for `RSpec/Rails/HttpStatus`. ([@ydah])
 - Change to be inline disable for `RSpec/SpecFilePathFormat` like `RSpec/FilePath`. ([@ydah])
 - Fix a false positive for `RSpec/MetadataStyle` with example groups having multiple string arguments. ([@franzliedke])

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: ~
+version: '2.25'
 nav:
   - modules/ROOT/nav.adoc

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.24.1'
+      STRING = '2.25.0'
     end
   end
 end


### PR DESCRIPTION
Is it time for a new release?

Changelog:

>- Add support single quoted string and percent string and heredoc for `RSpec/Rails/HttpStatus`. ([@ydah])
>- Change to be inline disable for `RSpec/SpecFilePathFormat` like `RSpec/FilePath`. ([@ydah])
>- Fix a false positive for `RSpec/MetadataStyle` with example groups having multiple string arguments. ([@franzliedke])

[@franzliedke]: https://github.com/franzliedke
[@ydah]: https://github.com/ydah
