### PR TITLE
Enable a few pending cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -126,11 +126,17 @@ Layout/LineContinuationSpacing:
   Enabled: true
 Layout/LineEndStringConcatenationIndentation:
   Enabled: true
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+Lint/NonAtomicFileOperation:
+  Enabled: true
 Style/EmptyHeredoc:
   Enabled: true
 Style/RedundantHeredocDelimiterQuotes:
   Enabled: true
 Style/RedundantStringEscape:
+  Enabled: true
+Style/ReturnNilInPredicateMethodDefinition:
   Enabled: true
 
 # Enable our own pending cops.
@@ -166,6 +172,8 @@ RSpec/MetadataStyle:
 RSpec/NoExpectationExample:
   Enabled: true
 RSpec/PendingWithoutReason:
+  Enabled: true
+RSpec/ReceiveMessages:
   Enabled: true
 RSpec/RedundantAround:
   Enabled: true

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -148,15 +148,15 @@ module RuboCop
         end
 
         def offensive_described_class?(node)
-          return unless node.const_type?
+          return false unless node.const_type?
 
           # E.g. `described_class::CONSTANT`
-          return if contains_described_class?(node)
+          return false if contains_described_class?(node)
 
           nearest_described_class, = node.each_ancestor(:block)
             .map { |ancestor| described_constant(ancestor) }.find(&:itself)
 
-          return if nearest_described_class.equal?(node)
+          return false if nearest_described_class.equal?(node)
 
           full_const_name(nearest_described_class) == full_const_name(node)
         end

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -162,7 +162,7 @@ module RuboCop
         end
 
         def conditionals_with_examples?(body)
-          return unless body.begin_type? || body.case_type?
+          return false unless body.begin_type? || body.case_type?
 
           body.each_descendant(:if, :case).any? do |condition_node|
             examples_in_branches?(condition_node)
@@ -170,7 +170,7 @@ module RuboCop
         end
 
         def examples_in_branches?(condition_node)
-          return if !condition_node.if_type? && !condition_node.case_type?
+          return false if !condition_node.if_type? && !condition_node.case_type?
 
           condition_node.branches.any? { |branch| examples?(branch) }
         end

--- a/lib/rubocop/cop/rspec/empty_line_after_example.rb
+++ b/lib/rubocop/cop/rspec/empty_line_after_example.rb
@@ -71,8 +71,8 @@ module RuboCop
 
         def next_one_line_example?(node)
           next_sibling = node.right_sibling
-          return unless next_sibling
-          return unless example?(next_sibling)
+          return false unless next_sibling
+          return false unless example?(next_sibling)
 
           next_sibling.single_line?
         end

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -67,7 +67,7 @@ module RuboCop
         private
 
         def skipped?(node)
-          skippable?(node) && skipped_in_metadata?(node) ||
+          (skippable?(node) && skipped_in_metadata?(node)) ||
             skipped_regular_example_without_body?(node)
         end
 

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -202,7 +202,7 @@ module RuboCop
 
           return false if allowed_explicit_matchers.include?(name)
 
-          name.start_with?('be_', 'have_') && !name.end_with?('?') ||
+          (name.start_with?('be_', 'have_') && !name.end_with?('?')) ||
             %w[include respond_to].include?(name)
         end
 

--- a/lib/rubocop/cop/rspec/receive_messages.rb
+++ b/lib/rubocop/cop/rspec/receive_messages.rb
@@ -148,7 +148,7 @@ module RuboCop
         end
 
         def heredoc_or_splat?(node)
-          (node.str_type? || node.dstr_type?) && node.heredoc? ||
+          ((node.str_type? || node.dstr_type?) && node.heredoc?) ||
             node.splat_type?
         end
 

--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -57,7 +57,7 @@ module RuboCop
         end
 
         def block_with_args?(node)
-          return unless node&.block_type?
+          return false unless node&.block_type?
 
           node.arguments?
         end

--- a/lib/rubocop/cop/rspec/variable_definition.rb
+++ b/lib/rubocop/cop/rspec/variable_definition.rb
@@ -60,8 +60,8 @@ module RuboCop
         end
 
         def style_offense?(variable)
-          style == :symbols && string?(variable) ||
-            style == :strings && symbol?(variable)
+          (style == :symbols && string?(variable)) ||
+            (style == :strings && symbol?(variable))
         end
 
         def string?(node)

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -19,6 +19,6 @@ module FileHelper
 
   def create_dir(file_path)
     dir_path = File.dirname(file_path)
-    FileUtils.makedirs dir_path unless File.exist?(dir_path)
+    FileUtils.makedirs dir_path
   end
 end


### PR DESCRIPTION
Enabling 3 pending cops:

- Lint/AmbiguousOperatorPrecedence
- Lint/NonAtomicFileOperation
- Style/ReturnNilInPredicateMethodDefinition
- RSpec/ReceiveMessages (not sure how we missed that one)

Is there any reason not to enable all pending cops?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
