### PR TITLE
Add support for enforcing symbolized shared examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add support for correcting "it will" (future tense) for `RSpec/ExampleWording`. ([@jdufresne])
 - Add new `RSpec/RemoveConst` cop. ([@swelther])
 - Ensure `PendingWithoutReason` can detect violations inside shared groups. ([@robinaugh])
+- Add support for `symbol` style for `RSpec/SharedExamples`. ([@jessieay])
 
 ## 2.25.0 (2023-10-27)
 
@@ -862,6 +863,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@jaredmoody]: https://github.com/jaredmoody
 [@jdufresne]: https://github.com/jdufresne
 [@jeffreyc]: https://github.com/jeffreyc
+[@jessieay]: https://github.com/jessieay
 [@jfragoulis]: https://github.com/jfragoulis
 [@johnny-miyake]: https://github.com/johnny-miyake
 [@jojos003]: https://github.com/jojos003

--- a/config/default.yml
+++ b/config/default.yml
@@ -844,9 +844,14 @@ RSpec/SharedContext:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedContext
 
 RSpec/SharedExamples:
-  Description: Enforces use of string to titleize shared examples.
+  Description: Checks for consistent style for shared example names.
   Enabled: true
+  EnforcedStyle: string
+  SupportedStyles:
+    - string
+    - symbol
   VersionAdded: '1.25'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples
 
 RSpec/SingleArgumentMessageChain:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5050,12 +5050,18 @@ end
 | Yes
 | Yes
 | 1.25
-| -
+| <<next>>
 |===
 
-Enforces use of string to titleize shared examples.
+Checks for consistent style for shared example names.
+
+Enforces either `string` or `symbol` for shared example names.
+
+This cop can be configured using the `EnforcedStyle` option
 
 === Examples
+
+==== `EnforcedStyle: string` (default)
 
 [source,ruby]
 ----
@@ -5073,6 +5079,35 @@ shared_examples 'foo bar baz'
 shared_examples_for 'foo bar baz'
 include_examples 'foo bar baz'
 ----
+
+==== `EnforcedStyle: symbol`
+
+[source,ruby]
+----
+# bad
+it_behaves_like 'foo bar baz'
+it_should_behave_like 'foo bar baz'
+shared_examples 'foo bar baz'
+shared_examples_for 'foo bar baz'
+include_examples 'foo bar baz'
+
+# good
+it_behaves_like :foo_bar_baz
+it_should_behave_like :foo_bar_baz
+shared_examples :foo_bar_baz
+shared_examples_for :foo_bar_baz
+include_examples :foo_bar_baz
+----
+
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| EnforcedStyle
+| `string`
+| `string`, `symbol`
+|===
 
 === References
 

--- a/spec/rubocop/cop/rspec/shared_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_examples_spec.rb
@@ -1,73 +1,154 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
-  it 'registers an offense when using symbolic title' do
-    expect_offense(<<~RUBY)
-      it_behaves_like :foo_bar_baz
-                      ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
-      it_should_behave_like :foo_bar_baz
+  context 'when using default (string) enforced style' do
+    it 'registers an offense when using symbolic title' do
+      expect_offense(<<~RUBY)
+        it_behaves_like :foo_bar_baz
+                        ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
+        it_should_behave_like :foo_bar_baz
+                              ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
+        shared_examples :foo_bar_baz
+                        ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
+        shared_examples_for :foo_bar_baz
                             ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
-      shared_examples :foo_bar_baz
-                      ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
-      shared_examples_for :foo_bar_baz
-                          ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
-      include_examples :foo_bar_baz
-                       ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
-      include_examples :foo_bar_baz, 'foo', 'bar'
-                       ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
+        include_examples :foo_bar_baz
+                         ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
+        include_examples :foo_bar_baz, 'foo', 'bar'
+                         ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
 
-      shared_examples :foo_bar_baz, 'foo', 'bar' do |param|
-                      ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
-        # ...
-      end
+        shared_examples :foo_bar_baz, 'foo', 'bar', :foo_bar, 5 do |param|
+                        ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
+          # ...
+        end
 
-      RSpec.shared_examples :foo_bar_baz
-                            ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
-    RUBY
+        RSpec.shared_examples :foo_bar_baz
+                              ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
+      RUBY
 
-    expect_correction(<<~RUBY)
-      it_behaves_like 'foo bar baz'
-      it_should_behave_like 'foo bar baz'
-      shared_examples 'foo bar baz'
-      shared_examples_for 'foo bar baz'
-      include_examples 'foo bar baz'
-      include_examples 'foo bar baz', 'foo', 'bar'
+      expect_correction(<<~RUBY)
+        it_behaves_like 'foo bar baz'
+        it_should_behave_like 'foo bar baz'
+        shared_examples 'foo bar baz'
+        shared_examples_for 'foo bar baz'
+        include_examples 'foo bar baz'
+        include_examples 'foo bar baz', 'foo', 'bar'
 
-      shared_examples 'foo bar baz', 'foo', 'bar' do |param|
-        # ...
-      end
+        shared_examples 'foo bar baz', 'foo', 'bar', :foo_bar, 5 do |param|
+          # ...
+        end
 
-      RSpec.shared_examples 'foo bar baz'
-    RUBY
+        RSpec.shared_examples 'foo bar baz'
+      RUBY
+    end
+
+    it 'does not register an offense when using string title' do
+      expect_no_offenses(<<~RUBY)
+        it_behaves_like 'foo bar baz'
+        it_should_behave_like 'foo bar baz'
+        shared_examples 'foo bar baz'
+        shared_examples_for 'foo bar baz'
+        include_examples 'foo bar baz'
+        include_examples 'foo bar baz', 'foo', 'bar'
+
+        shared_examples 'foo bar baz', 'foo', 'bar' do |param|
+          # ...
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when using Module/Class title' do
+      expect_no_offenses(<<~RUBY)
+        it_behaves_like FooBarBaz
+        it_should_behave_like FooBarBaz
+        shared_examples FooBarBaz
+        shared_examples_for FooBarBaz
+        include_examples FooBarBaz
+        include_examples FooBarBaz, 'foo', 'bar'
+
+        shared_examples FooBarBaz, 'foo', 'bar' do |param|
+          # ...
+        end
+      RUBY
+    end
   end
 
-  it 'does not register an offense when using string title' do
-    expect_no_offenses(<<~RUBY)
-      it_behaves_like 'foo bar baz'
-      it_should_behave_like 'foo bar baz'
-      shared_examples 'foo bar baz'
-      shared_examples_for 'foo bar baz'
-      include_examples 'foo bar baz'
-      include_examples 'foo bar baz', 'foo', 'bar'
+  context 'when using symbol enforced style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symbol' } }
 
-      shared_examples 'foo bar baz', 'foo', 'bar' do |param|
-        # ...
-      end
-    RUBY
-  end
+    it 'registers an offense when using string title' do
+      expect_offense(<<~RUBY)
+        it_behaves_like 'foo bar baz'
+                        ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"foo bar baz"` to symbolize shared examples.
+        it_should_behave_like 'foo bar baz'
+                              ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"foo bar baz"` to symbolize shared examples.
+        shared_examples 'foo bar baz'
+                        ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"foo bar baz"` to symbolize shared examples.
+        shared_examples_for 'foo bar baz'
+                            ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"foo bar baz"` to symbolize shared examples.
+        include_examples 'foo bar baz'
+                         ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"foo bar baz"` to symbolize shared examples.
+        include_examples 'Foo Bar Baz'
+                         ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"Foo Bar Baz"` to symbolize shared examples.
+        include_examples 'foo bar baz', 'foo', 'bar'
+                         ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"foo bar baz"` to symbolize shared examples.
 
-  it 'does not register an offense when using Module/Class title' do
-    expect_no_offenses(<<~RUBY)
-      it_behaves_like FooBarBaz
-      it_should_behave_like FooBarBaz
-      shared_examples FooBarBaz
-      shared_examples_for FooBarBaz
-      include_examples FooBarBaz
-      include_examples FooBarBaz, 'foo', 'bar'
+        shared_examples 'foo bar baz', 'foo', 'bar' do |param|
+                        ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"foo bar baz"` to symbolize shared examples.
+          # ...
+        end
 
-      shared_examples FooBarBaz, 'foo', 'bar' do |param|
-        # ...
-      end
-    RUBY
+        RSpec.shared_examples 'foo bar baz'
+                              ^^^^^^^^^^^^^ Prefer :foo_bar_baz over `"foo bar baz"` to symbolize shared examples.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it_behaves_like :foo_bar_baz
+        it_should_behave_like :foo_bar_baz
+        shared_examples :foo_bar_baz
+        shared_examples_for :foo_bar_baz
+        include_examples :foo_bar_baz
+        include_examples :foo_bar_baz
+        include_examples :foo_bar_baz, 'foo', 'bar'
+
+        shared_examples :foo_bar_baz, 'foo', 'bar' do |param|
+          # ...
+        end
+
+        RSpec.shared_examples :foo_bar_baz
+      RUBY
+    end
+
+    it 'does not register an offense when using symbol' do
+      expect_no_offenses(<<~RUBY)
+        it_behaves_like :foo_bar_baz
+        it_should_behave_like :foo_bar_baz
+        shared_examples :foo_bar_baz
+        shared_examples_for :foo_bar_baz
+        include_examples :foo_bar_baz
+        include_examples :foo_bar_baz, :foo, :bar
+
+        shared_examples :foo_bar_baz, 'foo', 'bar', 'foo bar', 5 do |param|
+          # ...
+        end
+
+        RSpec.shared_examples :foo_bar_baz
+      RUBY
+    end
+
+    it 'does not register an offense when using Module/Class title' do
+      expect_no_offenses(<<~RUBY)
+        it_behaves_like FooBarBaz
+        it_should_behave_like FooBarBaz
+        shared_examples FooBarBaz
+        shared_examples_for FooBarBaz
+        include_examples FooBarBaz
+        include_examples FooBarBaz, 'foo', 'bar'
+
+        shared_examples FooBarBaz, 'foo', 'bar', 'foo bar', 5 do |param|
+          # ...
+        end
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
* Existing check only allows to enforce one style, which is called "titelized" in the error message but really just looks for a string type.
* Enforcing the existing style raises an error when a shared example uses a symbol definition rather than a string.
* But there are some benefits to using symbol types instead, as is discussed here: https://gitlab.com/gitlab-org/gitlab/-/issues/427697
* As a result, some codebases might want to enforce a symbol type instead.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
