### PR TITLE
Ensure PendingWithoutReason can detect violations inside shared groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new `RSpec/RedundantPredicateMatcher` cop. ([@ydah])
 - Add support for correcting "it will" (future tense) for `RSpec/ExampleWording`. ([@jdufresne])
 - Add new `RSpec/RemoveConst` cop. ([@swelther])
+- Ensure `PendingWithoutReason` can detect violations inside shared groups. ([@robinaugh])
 
 ## 2.25.0 (2023-10-27)
 
@@ -902,6 +903,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@rafix02]: https://github.com/Rafix02
 [@redross]: https://github.com/redross
 [@renanborgescampos]: https://github.com/renanborgescampos
+[@robinaugh]: https://github.com/robinaugh
 [@robotdana]: https://github.com/robotdana
 [@rolfschmidt]: https://github.com/rolfschmidt
 [@rrosenblum]: https://github.com/rrosenblum

--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -103,7 +103,7 @@ module RuboCop
           on_pending_by_metadata(node)
           return unless (parent = parent_node(node))
 
-          if example_group?(parent) || block_node_example_group?(node)
+          if spec_group?(parent) || block_node_example_group?(node)
             on_skipped_by_example_method(node)
             on_skipped_by_example_group_method(node)
           elsif example?(parent)

--- a/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason, :ruby27 do
     end
   end
 
+  context 'when pending/skip has a reason inside a shared example group' do
+    it 'registers no offense' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe Foo do
+          shared_examples 'something' do
+            pending 'does something'
+            skip 'does something'
+          end
+        end
+      RUBY
+    end
+  end
+
   context 'when pending/skip by metadata on example with reason' do
     it 'registers no offense' do
       expect_no_offenses(<<~RUBY)
@@ -396,6 +409,20 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason, :ruby27 do
             end
             skip 'does something' do
               _1
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'when skipped inside a shared example group' do
+    it 'registers offense' do
+      expect_offense(<<~RUBY)
+        RSpec.describe Foo do
+          shared_examples 'something' do
+            xit 'something' do
+            ^^^^^^^^^^^^^^^ Give the reason for xit.
             end
           end
         end


### PR DESCRIPTION
This fixes https://github.com/rubocop/rubocop-rspec/issues/1756 by allowing `PendingWithoutReason` to flag violations that are inside shared groups (i.e. `shared_examples`).

I've confirmed that this change can also support the other edge case mentioned in #1756 (using Papertrail's `with_versioning` helper and other arbitrary blocks) if my project configuration is updated to map that helper as if it is a shared group, i.e.

```yml
RSpec:
  Language:
    SharedGroups:
      Examples:
        - with_versioning
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).