### PR TITLE
Use squiggly heredocs wherever possible

### DIFF
--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -32,17 +32,17 @@ module RuboCop
                          'or `%<arg>s.run`.'
 
         # @!method hook_block(node)
-        def_node_matcher :hook_block, <<-PATTERN
+        def_node_matcher :hook_block, <<~PATTERN
           (block (send nil? :around sym ?) (args $...) ...)
         PATTERN
 
         # @!method hook_numblock(node)
-        def_node_matcher :hook_numblock, <<-PATTERN
+        def_node_matcher :hook_numblock, <<~PATTERN
           (numblock (send nil? :around sym ?) ...)
         PATTERN
 
         # @!method find_arg_usage(node)
-        def_node_search :find_arg_usage, <<-PATTERN
+        def_node_search :find_arg_usage, <<~PATTERN
           {(send $... {:call :run}) (send _ _ $...) (yield $...) (block-pass $...)}
         PATTERN
 

--- a/lib/rubocop/cop/rspec/be.rb
+++ b/lib/rubocop/cop/rspec/be.rb
@@ -24,7 +24,7 @@ module RuboCop
         RESTRICT_ON_SEND = Runners.all
 
         # @!method be_without_args(node)
-        def_node_matcher :be_without_args, <<-PATTERN
+        def_node_matcher :be_without_args, <<~PATTERN
           (send _ #Runners.all $(send nil? :be))
         PATTERN
 

--- a/lib/rubocop/cop/rspec/be_eq.rb
+++ b/lib/rubocop/cop/rspec/be_eq.rb
@@ -30,7 +30,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[eq].freeze
 
         # @!method eq_type_with_identity?(node)
-        def_node_matcher :eq_type_with_identity?, <<-PATTERN
+        def_node_matcher :eq_type_with_identity?, <<~PATTERN
           (send nil? :eq {true false nil})
         PATTERN
 

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -44,7 +44,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[to].freeze
 
         # @!method eql_type_with_identity(node)
-        def_node_matcher :eql_type_with_identity, <<-PATTERN
+        def_node_matcher :eql_type_with_identity, <<~PATTERN
           (send _ :to $(send nil? :eql {true false int float sym nil}))
         PATTERN
 

--- a/lib/rubocop/cop/rspec/be_nil.rb
+++ b/lib/rubocop/cop/rspec/be_nil.rb
@@ -33,12 +33,12 @@ module RuboCop
         RESTRICT_ON_SEND = %i[be be_nil].freeze
 
         # @!method be_nil_matcher?(node)
-        def_node_matcher :be_nil_matcher?, <<-PATTERN
+        def_node_matcher :be_nil_matcher?, <<~PATTERN
           (send nil? :be_nil)
         PATTERN
 
         # @!method nil_value_expectation?(node)
-        def_node_matcher :nil_value_expectation?, <<-PATTERN
+        def_node_matcher :nil_value_expectation?, <<~PATTERN
           (send nil? :be nil)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -27,7 +27,7 @@ module RuboCop
         RESTRICT_ON_SEND = Set[:before, :after].freeze
 
         # @!method before_or_after_all(node)
-        def_node_matcher :before_or_after_all, <<-PATTERN
+        def_node_matcher :before_or_after_all, <<~PATTERN
           $(send _ RESTRICT_ON_SEND (sym {:all :context}))
         PATTERN
 

--- a/lib/rubocop/cop/rspec/capybara/feature_methods.rb
+++ b/lib/rubocop/cop/rspec/capybara/feature_methods.rb
@@ -58,12 +58,12 @@ module RuboCop
           }.freeze
 
           # @!method capybara_speak(node)
-          def_node_matcher :capybara_speak, <<-PATTERN
+          def_node_matcher :capybara_speak, <<~PATTERN
             {#{MAP.keys.map(&:inspect).join(' ')}}
           PATTERN
 
           # @!method feature_method(node)
-          def_node_matcher :feature_method, <<-PATTERN
+          def_node_matcher :feature_method, <<~PATTERN
             (block
               $(send #rspec? $#capybara_speak ...)
             ...)

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -66,14 +66,14 @@ module RuboCop
         RESTRICT_ON_SEND = CHANGE_METHODS.freeze
 
         # @!method expect_change_with_arguments(node)
-        def_node_matcher :expect_change_with_arguments, <<-PATTERN
+        def_node_matcher :expect_change_with_arguments, <<~PATTERN
           (send
             $(send nil? CHANGE_METHODS ...) :by
             (int 0))
         PATTERN
 
         # @!method expect_change_with_block(node)
-        def_node_matcher :expect_change_with_block, <<-PATTERN
+        def_node_matcher :expect_change_with_block, <<~PATTERN
           (send
             (block
               $(send nil? CHANGE_METHODS)
@@ -83,7 +83,7 @@ module RuboCop
         PATTERN
 
         # @!method change_nodes(node)
-        def_node_search :change_nodes, <<-PATTERN
+        def_node_search :change_nodes, <<~PATTERN
           $(send nil? CHANGE_METHODS ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/context_method.rb
+++ b/lib/rubocop/cop/rspec/context_method.rb
@@ -30,7 +30,7 @@ module RuboCop
         MSG = 'Use `describe` for testing methods.'
 
         # @!method context_method(node)
-        def_node_matcher :context_method, <<-PATTERN
+        def_node_matcher :context_method, <<~PATTERN
           (block
             (send #rspec? :context
               ${(str #method_name?) (dstr (str #method_name?) ...)}

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -61,7 +61,7 @@ module RuboCop
         MSG = 'Context description should match %<patterns>s.'
 
         # @!method context_wording(node)
-        def_node_matcher :context_wording, <<-PATTERN
+        def_node_matcher :context_wording, <<~PATTERN
           (block (send #rspec? { :context :shared_context } $({str dstr xstr} ...) ...) ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/describe_symbol.rb
+++ b/lib/rubocop/cop/rspec/describe_symbol.rb
@@ -22,7 +22,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[describe].freeze
 
         # @!method describe_symbol?(node)
-        def_node_matcher :describe_symbol?, <<-PATTERN
+        def_node_matcher :describe_symbol?, <<~PATTERN
           (send #rspec? :describe $sym ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -63,7 +63,7 @@ module RuboCop
         MSG             = 'Use `%<replacement>s` instead of `%<src>s`.'
 
         # @!method common_instance_exec_closure?(node)
-        def_node_matcher :common_instance_exec_closure?, <<-PATTERN
+        def_node_matcher :common_instance_exec_closure?, <<~PATTERN
           (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)
         PATTERN
 
@@ -75,7 +75,7 @@ module RuboCop
         def_node_matcher :scope_changing_syntax?, '{def class module}'
 
         # @!method described_constant(node)
-        def_node_matcher :described_constant, <<-PATTERN
+        def_node_matcher :described_constant, <<~PATTERN
           (block (send _ :describe $(const ...) ...) (args) $_)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -60,7 +60,7 @@ module RuboCop
         IT_PREFIX     = /\Ait /i.freeze
 
         # @!method it_description(node)
-        def_node_matcher :it_description, <<-PATTERN
+        def_node_matcher :it_description, <<~PATTERN
           (block (send _ :it ${
             (str $_)
             (dstr (str $_ ) ...)

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -29,7 +29,7 @@ module RuboCop
         MSG = 'Excessive whitespace.'
 
         # @!method example_description(node)
-        def_node_matcher :example_description, <<-PATTERN
+        def_node_matcher :example_description, <<~PATTERN
           (send _ {#Examples.all #ExampleGroups.all} ${
             $str
             $(dstr ({str dstr `sym} ...) ...)

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -38,12 +38,12 @@ module RuboCop
         RESTRICT_ON_SEND = %i[change].freeze
 
         # @!method expect_change_with_arguments(node)
-        def_node_matcher :expect_change_with_arguments, <<-PATTERN
+        def_node_matcher :expect_change_with_arguments, <<~PATTERN
           (send nil? :change $_ ({sym str} $_))
         PATTERN
 
         # @!method expect_change_with_block(node)
-        def_node_matcher :expect_change_with_block, <<-PATTERN
+        def_node_matcher :expect_change_with_block, <<~PATTERN
           (block
             (send nil? :change)
             (args)

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -56,7 +56,7 @@ module RuboCop
         MSG = 'Focused spec found.'
 
         # @!method focusable_selector?(node)
-        def_node_matcher :focusable_selector?, <<-PATTERN
+        def_node_matcher :focusable_selector?, <<~PATTERN
           {
             #ExampleGroups.regular
             #ExampleGroups.skipped
@@ -68,7 +68,7 @@ module RuboCop
         PATTERN
 
         # @!method metadata(node)
-        def_node_matcher :metadata, <<-PATTERN
+        def_node_matcher :metadata, <<~PATTERN
           {(send #rspec? #focusable_selector? <$(sym :focus) ...>)
            (send #rspec? #focusable_selector? ... (hash <$(pair (sym :focus) true) ...>))}
         PATTERN

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -66,12 +66,12 @@ module RuboCop
         EXPLICIT_MSG = 'Use `%<scope>p` for RSpec hooks.'
 
         # @!method scoped_hook(node)
-        def_node_matcher :scoped_hook, <<-PATTERN
+        def_node_matcher :scoped_hook, <<~PATTERN
           ({block numblock} $(send _ #Hooks.all (sym ${:each :example})) ...)
         PATTERN
 
         # @!method unscoped_hook(node)
-        def_node_matcher :unscoped_hook, <<-PATTERN
+        def_node_matcher :unscoped_hook, <<~PATTERN
           ({block numblock} $(send _ #Hooks.all) ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -28,7 +28,7 @@ module RuboCop
         MSG = 'Move `%<hook>s` above the examples in the group.'
 
         # @!method example_or_group?(node)
-        def_node_matcher :example_or_group?, <<-PATTERN
+        def_node_matcher :example_or_group?, <<~PATTERN
           {
             ({block numblock} {
               (send #rspec? #ExampleGroups.all ...)

--- a/lib/rubocop/cop/rspec/implicit_block_expectation.rb
+++ b/lib/rubocop/cop/rspec/implicit_block_expectation.rb
@@ -22,7 +22,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[is_expected should should_not].freeze
 
         # @!method lambda?(node)
-        def_node_matcher :lambda?, <<-PATTERN
+        def_node_matcher :lambda?, <<~PATTERN
           {
             (send (const nil? :Proc) :new)
             (send nil? {:proc :lambda})
@@ -33,7 +33,7 @@ module RuboCop
         def_node_matcher :lambda_subject?, '(block #lambda? ...)'
 
         # @!method implicit_expect(node)
-        def_node_matcher :implicit_expect, <<-PATTERN
+        def_node_matcher :implicit_expect, <<~PATTERN
           $(send nil? {:is_expected :should :should_not} ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -31,7 +31,7 @@ module RuboCop
         RESTRICT_ON_SEND = Runners.all + %i[should should_not]
 
         # @!method implicit_expect(node)
-        def_node_matcher :implicit_expect, <<-PATTERN
+        def_node_matcher :implicit_expect, <<~PATTERN
           {
             (send nil? ${:should :should_not} ...)
             (send (send nil? $:is_expected) #Runners.all ...)

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -78,12 +78,12 @@ module RuboCop
         ].freeze
 
         # @!method explicit_unnamed_subject?(node)
-        def_node_matcher :explicit_unnamed_subject?, <<-PATTERN
+        def_node_matcher :explicit_unnamed_subject?, <<~PATTERN
           (send nil? :expect (send nil? :subject))
         PATTERN
 
         # @!method implicit_subject?(node)
-        def_node_matcher :implicit_subject?, <<-PATTERN
+        def_node_matcher :implicit_subject?, <<~PATTERN
           (send nil? {:should :should_not :is_expected} ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -25,7 +25,7 @@ module RuboCop
               'with `have_received`.'
 
         # @!method null_double(node)
-        def_node_search :null_double, <<-PATTERN
+        def_node_search :null_double, <<~PATTERN
           (lvasgn $_
             (send
               $(send nil? :instance_double
@@ -33,7 +33,7 @@ module RuboCop
         PATTERN
 
         # @!method have_received_usage(node)
-        def_node_search :have_received_usage, <<-PATTERN
+        def_node_search :have_received_usage, <<~PATTERN
           (send
             (send nil? :expect
             (lvar $_)) :to

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -52,12 +52,12 @@ module RuboCop
               'a method call, or a local variable (if possible).'
 
         # @!method dynamic_class?(node)
-        def_node_matcher :dynamic_class?, <<-PATTERN
+        def_node_matcher :dynamic_class?, <<~PATTERN
           (block (send (const nil? :Class) :new ...) ...)
         PATTERN
 
         # @!method custom_matcher?(node)
-        def_node_matcher :custom_matcher?, <<-PATTERN
+        def_node_matcher :custom_matcher?, <<~PATTERN
           (block {
             (send nil? :matcher sym)
             (send (const (const nil? :RSpec) :Matchers) :define sym)

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -21,7 +21,7 @@ module RuboCop
               'of iterating over an array.'
 
         # @!method each?(node)
-        def_node_matcher :each?, <<-PATTERN
+        def_node_matcher :each?, <<~PATTERN
           (block
             (send ... :each)
             (args (arg $_))
@@ -30,14 +30,14 @@ module RuboCop
         PATTERN
 
         # @!method each_numblock?(node)
-        def_node_matcher :each_numblock?, <<-PATTERN
+        def_node_matcher :each_numblock?, <<~PATTERN
           (numblock
             (send ... :each) _ $(...)
           )
         PATTERN
 
         # @!method expectation?(node)
-        def_node_matcher :expectation?, <<-PATTERN
+        def_node_matcher :expectation?, <<~PATTERN
           (send (send nil? :expect (lvar %)) :to ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -36,7 +36,7 @@ module RuboCop
         MSG = 'Move `let` before the examples in the group.'
 
         # @!method example_or_group?(node)
-        def_node_matcher :example_or_group?, <<-PATTERN
+        def_node_matcher :example_or_group?, <<~PATTERN
           {
             (block (send nil? {#ExampleGroups.all #Examples.all} ...) ...)
             (send nil? #Includes.examples ...)

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -37,7 +37,7 @@ module RuboCop
         PATTERN
 
         # @!method let_bang(node)
-        def_node_matcher :let_bang, <<-PATTERN
+        def_node_matcher :let_bang, <<~PATTERN
           {
             (block $(send nil? :let! {(sym $_) (str $_)}) ...)
             $(send nil? :let! {(sym $_) (str $_)} block_pass)

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -33,7 +33,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[to].freeze
 
         # @!method message_expectation(node)
-        def_node_matcher :message_expectation, <<-PATTERN
+        def_node_matcher :message_expectation, <<~PATTERN
           (send $(send nil? {:expect :allow} ...) :to #receive_message?)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/mixin/skip_or_pending.rb
+++ b/lib/rubocop/cop/rspec/mixin/skip_or_pending.rb
@@ -8,7 +8,7 @@ module RuboCop
         extend RuboCop::NodePattern::Macros
 
         # @!method skipped_in_metadata?(node)
-        def_node_matcher :skipped_in_metadata?, <<-PATTERN
+        def_node_matcher :skipped_in_metadata?, <<~PATTERN
           {
             (send _ _ <(sym {:skip :pending}) ...>)
             (send _ _ ... (hash <(pair (sym {:skip :pending}) { true str dstr }) ...>))
@@ -30,7 +30,7 @@ module RuboCop
         #
         #   @param node [RuboCop::AST::Node]
         #   @return [Array<RuboCop::AST::Node>] matching nodes
-        def_node_matcher :skip_or_pending_inside_block?, <<-PATTERN
+        def_node_matcher :skip_or_pending_inside_block?, <<~PATTERN
           (block <(send nil? {:skip :pending} ...) ...>)
         PATTERN
       end

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -70,7 +70,7 @@ module RuboCop
         TRUE = ->(node) { node.true_type? }
 
         # @!method aggregate_failures?(node)
-        def_node_matcher :aggregate_failures?, <<-PATTERN
+        def_node_matcher :aggregate_failures?, <<~PATTERN
           (block {
               (send _ _ <(sym :aggregate_failures) ...>)
               (send _ _ ... (hash <(pair (sym :aggregate_failures) %1) ...>))
@@ -81,7 +81,7 @@ module RuboCop
         def_node_matcher :expect?, '(send nil? #Expectations.all ...)'
 
         # @!method aggregate_failures_block?(node)
-        def_node_matcher :aggregate_failures_block?, <<-PATTERN
+        def_node_matcher :aggregate_failures_block?, <<~PATTERN
           (block (send nil? :aggregate_failures ...) ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -26,7 +26,7 @@ module RuboCop
         end
 
         # @!method predicate_in_actual?(node)
-        def_node_matcher :predicate_in_actual?, <<-PATTERN
+        def_node_matcher :predicate_in_actual?, <<~PATTERN
           (send
             (send nil? :expect {
               (block $(send !nil? #predicate? ...) ...)
@@ -36,12 +36,12 @@ module RuboCop
         PATTERN
 
         # @!method be_bool?(node)
-        def_node_matcher :be_bool?, <<-PATTERN
+        def_node_matcher :be_bool?, <<~PATTERN
           (send nil? {:be :eq :eql :equal} {true false})
         PATTERN
 
         # @!method be_boolthy?(node)
-        def_node_matcher :be_boolthy?, <<-PATTERN
+        def_node_matcher :be_boolthy?, <<~PATTERN
           (send nil? {:be_truthy :be_falsey :be_falsy :a_truthy_value :a_falsey_value :a_falsy_value})
         PATTERN
 
@@ -179,7 +179,7 @@ module RuboCop
         end
 
         # @!method predicate_matcher?(node)
-        def_node_matcher :predicate_matcher?, <<-PATTERN
+        def_node_matcher :predicate_matcher?, <<~PATTERN
           (send
             (send nil? :expect $!nil?)
             #Runners.all
@@ -188,7 +188,7 @@ module RuboCop
         PATTERN
 
         # @!method predicate_matcher_block?(node)
-        def_node_matcher :predicate_matcher_block?, <<-PATTERN
+        def_node_matcher :predicate_matcher_block?, <<~PATTERN
           (block
             (send
               (send nil? :expect $!nil?)

--- a/lib/rubocop/cop/rspec/rails/avoid_setup_hook.rb
+++ b/lib/rubocop/cop/rspec/rails/avoid_setup_hook.rb
@@ -23,7 +23,7 @@ module RuboCop
           MSG = 'Use `before` instead of `setup`.'
 
           # @!method setup_call(node)
-          def_node_matcher :setup_call, <<-PATTERN
+          def_node_matcher :setup_call, <<~PATTERN
             (block
               $(send nil? :setup)
               (args) _)

--- a/lib/rubocop/cop/rspec/rails/have_http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/have_http_status.rb
@@ -25,7 +25,7 @@ module RuboCop
           RESTRICT_ON_SEND = RUNNERS
 
           # @!method match_status(node)
-          def_node_matcher :match_status, <<-PATTERN
+          def_node_matcher :match_status, <<~PATTERN
             (send
               (send nil? :expect
                 $(send (send nil? :response) {:status :code})

--- a/lib/rubocop/cop/rspec/rails/http_status.rb
+++ b/lib/rubocop/cop/rspec/rails/http_status.rb
@@ -60,7 +60,7 @@ module RuboCop
           RESTRICT_ON_SEND = %i[have_http_status].freeze
 
           # @!method http_status(node)
-          def_node_matcher :http_status, <<-PATTERN
+          def_node_matcher :http_status, <<~PATTERN
             (send nil? :have_http_status ${int sym str})
           PATTERN
 

--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -25,7 +25,7 @@ module RuboCop
 
           # @!method minitest_assertion(node)
           def_node_matcher :minitest_assertion, <<~PATTERN
-          (send nil? {:assert_equal :refute_equal} $_ $_ $_?)
+            (send nil? {:assert_equal :refute_equal} $_ $_ $_?)
           PATTERN
 
           def on_send(node)

--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -24,7 +24,7 @@ module RuboCop
           RESTRICT_ON_SEND = %i[assert_equal refute_equal].freeze
 
           # @!method minitest_assertion(node)
-          def_node_matcher :minitest_assertion, <<-PATTERN
+          def_node_matcher :minitest_assertion, <<~PATTERN
           (send nil? {:assert_equal :refute_equal} $_ $_ $_?)
           PATTERN
 

--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -30,7 +30,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[times].freeze
 
         # @!method receive_counts(node)
-        def_node_matcher :receive_counts, <<-PATTERN
+        def_node_matcher :receive_counts, <<~PATTERN
           (send $(send _ {:exactly :at_least :at_most} (int {1 2})) :times)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/repeated_example_group_body.rb
+++ b/lib/rubocop/cop/rspec/repeated_example_group_body.rb
@@ -48,7 +48,7 @@ module RuboCop
         MSG = 'Repeated %<group>s block body on line(s) %<loc>s'
 
         # @!method several_example_groups?(node)
-        def_node_matcher :several_example_groups?, <<-PATTERN
+        def_node_matcher :several_example_groups?, <<~PATTERN
           (begin <#example_group_with_body? #example_group_with_body? ...>)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/repeated_example_group_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_example_group_description.rb
@@ -48,12 +48,12 @@ module RuboCop
         MSG = 'Repeated %<group>s block description on line(s) %<loc>s'
 
         # @!method several_example_groups?(node)
-        def_node_matcher :several_example_groups?, <<-PATTERN
+        def_node_matcher :several_example_groups?, <<~PATTERN
           (begin <#example_group? #example_group? ...>)
         PATTERN
 
         # @!method doc_string_and_metadata(node)
-        def_node_matcher :doc_string_and_metadata, <<-PATTERN
+        def_node_matcher :doc_string_and_metadata, <<~PATTERN
           (block (send _ _ $_ $...) ...)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/repeated_include_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_include_example.rb
@@ -50,7 +50,7 @@ module RuboCop
               'on line(s) %<repeat>s'
 
         # @!method several_include_examples?(node)
-        def_node_matcher :several_include_examples?, <<-PATTERN
+        def_node_matcher :several_include_examples?, <<~PATTERN
           (begin <#include_examples? #include_examples? ...>)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -48,7 +48,7 @@ module RuboCop
         def_node_matcher :stub_with_block?, '(block #contains_stub? ...)'
 
         # @!method and_return_value(node)
-        def_node_search :and_return_value, <<-PATTERN
+        def_node_search :and_return_value, <<~PATTERN
           $(send _ :and_return $(...))
         PATTERN
 

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -62,7 +62,7 @@ module RuboCop
         PATTERN
 
         # @!method context?(node)
-        def_node_search :context?, <<-PATTERN
+        def_node_search :context?, <<~PATTERN
           (send nil?
             {#Subjects.all #Helpers.all #Includes.context #Hooks.all} ...
           )

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -24,7 +24,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[receive_message_chain stub_chain].freeze
 
         # @!method message_chain(node)
-        def_node_matcher :message_chain, <<-PATTERN
+        def_node_matcher :message_chain, <<~PATTERN
           (send _ {:receive_message_chain :stub_chain} $_)
         PATTERN
 

--- a/lib/rubocop/cop/rspec/stubbed_mock.rb
+++ b/lib/rubocop/cop/rspec/stubbed_mock.rb
@@ -31,7 +31,7 @@ module RuboCop
         #
         #   @param node [RuboCop::AST::Node]
         #   @return [Array<RuboCop::AST::Node>] matching nodes
-        def_node_matcher :message_expectation?, <<-PATTERN
+        def_node_matcher :message_expectation?, <<~PATTERN
           {
             (send nil? { :receive :receive_message_chain } ...)  # receive(:foo)
             (send (send nil? :receive ...) :with ...)            # receive(:foo).with('bar')

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -68,7 +68,7 @@ module RuboCop
         #   @param node [RuboCop::AST::Node]
         #
         #   @yield [Symbol] subject name
-        def_node_matcher :subject?, <<-PATTERN
+        def_node_matcher :subject?, <<~PATTERN
           (block
             (send nil?
               { #Subjects.all (sym $_) | $#Subjects.all }
@@ -77,7 +77,7 @@ module RuboCop
 
         # @!method let?(node)
         #   Find a memoized helper
-        def_node_matcher :let?, <<-PATTERN
+        def_node_matcher :let?, <<~PATTERN
           (block
             (send nil? :let (sym $_)
             ) args ...)
@@ -94,7 +94,7 @@ module RuboCop
         #     expect(foo).to receive(:bar).with(1)
         #     expect(foo).to receive(:bar).with(1).and_return(2)
         #
-        def_node_matcher :message_expectation?, <<-PATTERN
+        def_node_matcher :message_expectation?, <<~PATTERN
           (send
             {
               (send nil? { :expect :allow } (send nil? %))
@@ -106,7 +106,7 @@ module RuboCop
         PATTERN
 
         # @!method message_expectation_matcher?(node)
-        def_node_search :message_expectation_matcher?, <<-PATTERN
+        def_node_search :message_expectation_matcher?, <<~PATTERN
           (send nil? {
             :receive :receive_messages :receive_message_chain :have_received
             } ...)

--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -35,7 +35,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[to].freeze
 
         # @!method empty_raise_error_or_exception(node)
-        def_node_matcher :empty_raise_error_or_exception, <<-PATTERN
+        def_node_matcher :empty_raise_error_or_exception, <<~PATTERN
           (send
             (block
                 (send nil? :expect) ...)

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -28,7 +28,7 @@ module RuboCop
         RESTRICT_ON_SEND = %i[double spy].freeze
 
         # @!method unverified_double(node)
-        def_node_matcher :unverified_double, <<-PATTERN
+        def_node_matcher :unverified_double, <<~PATTERN
           {(send nil? {:double :spy} $...)}
         PATTERN
 

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -18,12 +18,12 @@ module RuboCop
         RESTRICT_ON_SEND = %i[expect].freeze
 
         # @!method expect?(node)
-        def_node_matcher :expect?, <<-PATTERN
+        def_node_matcher :expect?, <<~PATTERN
           (send nil? :expect ...)
         PATTERN
 
         # @!method expect_block?(node)
-        def_node_matcher :expect_block?, <<-PATTERN
+        def_node_matcher :expect_block?, <<~PATTERN
           (block #expect? (args) _body)
         PATTERN
 

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -51,10 +51,10 @@ module RuboCop
 
       # @!method hook?(node)
       def_node_matcher :hook?, <<~PATTERN
-      {
-        (numblock (send nil? #Hooks.all ...) ...)
-        (block (send nil? #Hooks.all ...) ...)
-      }
+        {
+          (numblock (send nil? #Hooks.all ...) ...)
+          (block (send nil? #Hooks.all ...) ...)
+        }
       PATTERN
 
       # @!method let?(node)

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -42,7 +42,7 @@ module RuboCop
       PATTERN
 
       # @!method example_group_with_body?(node)
-      def_node_matcher :example_group_with_body?, <<-PATTERN
+      def_node_matcher :example_group_with_body?, <<~PATTERN
         (block (send #rspec? #ExampleGroups.all ...) args !nil?)
       PATTERN
 
@@ -50,7 +50,7 @@ module RuboCop
       def_node_matcher :example?, '(block (send nil? #Examples.all ...) ...)'
 
       # @!method hook?(node)
-      def_node_matcher :hook?, <<-PATTERN
+      def_node_matcher :hook?, <<~PATTERN
       {
         (numblock (send nil? #Hooks.all ...) ...)
         (block (send nil? #Hooks.all ...) ...)
@@ -58,7 +58,7 @@ module RuboCop
       PATTERN
 
       # @!method let?(node)
-      def_node_matcher :let?, <<-PATTERN
+      def_node_matcher :let?, <<~PATTERN
         {
           (block (send nil? #Helpers.all ...) ...)
           (send nil? #Helpers.all _ block_pass)
@@ -66,7 +66,7 @@ module RuboCop
       PATTERN
 
       # @!method include?(node)
-      def_node_matcher :include?, <<-PATTERN
+      def_node_matcher :include?, <<~PATTERN
         {
           (block (send nil? #Includes.all ...) ...)
           (send nil? #Includes.all ...)

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -6,7 +6,7 @@ require 'rubocop/rspec/version'
 Gem::Specification.new do |spec|
   spec.name = 'rubocop-rspec'
   spec.summary = 'Code style checking for RSpec files'
-  spec.description = <<-DESCRIPTION
+  spec.description = <<~DESCRIPTION
     Code style checking for RSpec files.
     A plugin for the RuboCop code style enforcing & linting tool.
   DESCRIPTION

--- a/spec/rubocop/cli/autocorrect_spec.rb
+++ b/spec/rubocop/cli/autocorrect_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect' do # rubocop:disable RSpec/DescribeC
           EnforcedStyleForMultiline: 'comma'
       YAML
 
-      create_file('spec/example.rb', <<-RUBY)
+      create_file('spec/example.rb', <<~RUBY)
         expect(page.current_path).to eq(
           some_path(
             id: id
@@ -39,7 +39,7 @@ RSpec.describe 'RuboCop::CLI --autocorrect' do # rubocop:disable RSpec/DescribeC
                'RSpec/Capybara/CurrentPathExpectation,' \
                'Style/TrailingCommaInArguments'])
 
-      expect(File.read('spec/example.rb')).to eq(<<-RUBY)
+      expect(File.read('spec/example.rb')).to eq(<<~RUBY)
         expect(page).to have_current_path(
           some_path(
             id: id,

--- a/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
   # rubocop:disable RSpec/ExampleLength
   it 'registers offense for unaligned braces' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       let(:foo) { bar }
                 ^ Align left let brace
       let(:hi) { baz }
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       let(:foo)      { bar }
       let(:hi)       { baz }
       let(:blahblah) { baz }
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
   # rubocop:enable RSpec/ExampleLength
 
   it 'does not register an offense for let with proc argument' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       let(:user, &args[:build_user])
     RUBY
   end

--- a/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
   # rubocop:disable RSpec/ExampleLength
   it 'registers offense for unaligned braces' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       let(:foo)      { a }
                          ^ Align right let brace
       let(:hi)       { ab }
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       let(:foo)      { a    }
       let(:hi)       { ab   }
       let(:blahblah) { abcd }
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
   # rubocop:enable RSpec/ExampleLength
 
   it 'does not register an offense for let with proc argument' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       let(:user, &args[:build_user])
     RUBY
   end

--- a/spec/rubocop/cop/rspec/any_instance_spec.rb
+++ b/spec/rubocop/cop/rspec/any_instance_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
   it 'finds `allow_any_instance_of` instead of an instance double' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before do
         allow_any_instance_of(Object).to receive(:foo)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `allow_any_instance_of`.
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
   end
 
   it 'finds `expect_any_instance_of` instead of an instance double' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before do
         expect_any_instance_of(Object).to receive(:foo)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `expect_any_instance_of`.
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::AnyInstance do
   end
 
   it 'finds old `any_instance` syntax instead of an instance double' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before do
         Object.any_instance.should_receive(:foo)
         ^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `any_instance`.

--- a/spec/rubocop/cop/rspec/around_block_spec.rb
+++ b/spec/rubocop/cop/rspec/around_block_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
   context 'when no value is yielded' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         around do
         ^^^^^^^^^ Test object should be passed to around block.
           do_something
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when the hook is scoped with a symbol' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         around(:each) do
         ^^^^^^^^^^^^^^^^ Test object should be passed to around block.
           do_something
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when the yielded value is unused' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         around do |test|
                    ^^^^ You should call `test.call` or `test.run`.
           do_something
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when two values are yielded and the first is unused' do
     it 'registers an offense for the first argument' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         around do |test, unused|
                    ^^^^ You should call `test.call` or `test.run`.
           unused.run
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when the yielded value is referenced but not used' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         around do |test|
                    ^^^^ You should call `test.call` or `test.run`.
           test
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when a method other than #run or #call is called' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         around do |test|
                    ^^^^ You should call `test.call` or `test.run`.
           test.inspect
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when #run is called' do
     it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         around do |test|
           test.run
         end
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when #call is called' do
     it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         around do |test|
           test.call
         end
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when used as a block arg' do
     it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         around do |test|
           1.times(&test)
         end
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when passed to another method' do
     it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         around do |test|
           something_that_might_run_test(test, another_arg)
         end
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
   context 'when yielded to another block' do
     it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         around do |test|
           foo { yield(some_arg, test) }
         end
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
   context 'when Ruby 2.7', :ruby27 do
     context 'when the yielded value is unused' do
       it 'registers an offense' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           around { _1 }
                    ^^ You should call `_1.call` or `_1.run`.
         RUBY
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
     context 'when a method other than #run or #call is called' do
       it 'registers an offense' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           around do
             _1.inspect
             ^^^^^^^^^^ You should call `_1.call` or `_1.run`.
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
     context 'when #run is called' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           around do
             _1.run
           end
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
     context 'when #call is called' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           around do
             _1.call
           end
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
     context 'when used as a block arg' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           around do
             1.times(&_1)
           end
@@ -170,7 +170,7 @@ RSpec.describe RuboCop::Cop::RSpec::AroundBlock do
 
     context 'when passed to another method' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           around do
             something_that_might_run_test(_1, another_arg)
           end

--- a/spec/rubocop/cop/rspec/base_spec.rb
+++ b/spec/rubocop/cop/rspec/base_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe RuboCop::Cop::RSpec::Base do
 
   context 'when the source path ends with `_spec.rb`' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, 'foo_spec.rb')
+      expect_offense(<<~RUBY, 'foo_spec.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
     end
 
     it 'ignores the file if it is ignored' do
-      expect_no_offenses(<<-RUBY, 'bar_spec.rb')
+      expect_no_offenses(<<~RUBY, 'bar_spec.rb')
         foo(1)
       RUBY
     end
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::Base do
 
   context 'when the source path contains `/spec/`' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, '/spec/support/thing.rb')
+      expect_offense(<<~RUBY, '/spec/support/thing.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::RSpec::Base do
 
   context 'when the source path starts with `spec/`' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY, 'spec/support/thing.rb')
+      expect_offense(<<~RUBY, 'spec/support/thing.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY
@@ -48,13 +48,13 @@ RSpec.describe RuboCop::Cop::RSpec::Base do
 
   context 'when the file is a source file without "spec" in the name' do
     it 'ignores the source when the path is not a spec file' do
-      expect_no_offenses(<<-RUBY, 'foo.rb')
+      expect_no_offenses(<<~RUBY, 'foo.rb')
         foo(1)
       RUBY
     end
 
     it 'ignores the source when the path is not a specified pattern' do
-      expect_no_offenses(<<-RUBY, 'foo_test.rb')
+      expect_no_offenses(<<~RUBY, 'foo_test.rb')
         foo(1)
       RUBY
     end
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::RSpec::Base do
     end
 
     it 'registers offenses when the path matches a custom specified pattern' do
-      expect_offense(<<-RUBY, 'foo_test.rb')
+      expect_offense(<<~RUBY, 'foo_test.rb')
         foo(1)
         ^^^^^^ I flag everything
       RUBY

--- a/spec/rubocop/cop/rspec/be_eq_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eq_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::BeEq do
   it 'registers an offense for `eq` when argument is a boolean' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).to eq(true) }
                           ^^ Prefer `be` over `eq`.
       it { expect(foo).not_to eq(true) }
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeEq do
                               ^^ Prefer `be` over `eq`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { expect(foo).to be(true) }
       it { expect(foo).not_to be(true) }
       it { expect(foo).to_not be(true) }
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeEq do
   end
 
   it 'registers an offense for `eq` when argument is nil' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).to eq(nil) }
                           ^^ Prefer `be` over `eq`.
       it { expect(foo).not_to eq(nil) }
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeEq do
                               ^^ Prefer `be` over `eq`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { expect(foo).to be(nil) }
       it { expect(foo).not_to be(nil) }
       it { expect(foo).to_not be(nil) }
@@ -45,27 +45,27 @@ RSpec.describe RuboCop::Cop::RSpec::BeEq do
   end
 
   it 'does not register an offense for `eq` when argument is an integer' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { expect(foo).to eq(0) }
       it { expect(foo).to eq(123) }
     RUBY
   end
 
   it 'does not register an offense for `eq` when argument is a float' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { expect(foo).to eq(1.0) }
       it { expect(foo).to eq(1.23) }
     RUBY
   end
 
   it 'does not register an offense for `eq` when argument is a symbol' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { expect(foo).to eq(:foo) }
     RUBY
   end
 
   it 'does not register an offense for `eq` when argument is a string' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { expect(foo).to eq('foo') }
     RUBY
   end

--- a/spec/rubocop/cop/rspec/be_eql_spec.rb
+++ b/spec/rubocop/cop/rspec/be_eql_spec.rb
@@ -2,77 +2,77 @@
 
 RSpec.describe RuboCop::Cop::RSpec::BeEql do
   it 'registers an offense for `eql` when argument is a boolean' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).to eql(true) }
                           ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(false) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { expect(foo).to be(true) }
       it { expect(foo).to be(false) }
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is an integer' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).to eql(0) }
                           ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(123) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { expect(foo).to be(0) }
       it { expect(foo).to be(123) }
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is a float' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).to eql(1.0) }
                           ^^^ Prefer `be` over `eql`.
       it { expect(foo).to eql(1.23) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { expect(foo).to be(1.0) }
       it { expect(foo).to be(1.23) }
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is a symbol' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).to eql(:foo) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { expect(foo).to be(:foo) }
     RUBY
   end
 
   it 'registers an offense for `eql` when argument is nil' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).to eql(nil) }
                           ^^^ Prefer `be` over `eql`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { expect(foo).to be(nil) }
     RUBY
   end
 
   it 'does not register an offense for `eql` when argument is a string' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { expect(foo).to eql('foo') }
     RUBY
   end
 
   it 'does not register an offense for `eql` when expectation is negated' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { expect(foo).to_not eql(1) }
     RUBY
   end

--- a/spec/rubocop/cop/rspec/be_spec.rb
+++ b/spec/rubocop/cop/rspec/be_spec.rb
@@ -2,14 +2,14 @@
 
 RSpec.describe RuboCop::Cop::RSpec::Be do
   it 'registers an offense for `be` without an argument' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).to be }
                           ^^ Don't use `be` without an argument.
     RUBY
   end
 
   it 'registers an offense for not_to be' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { expect(foo).not_to be }
                               ^^ Don't use `be` without an argument.
       it { expect(foo).to_not be }
@@ -18,14 +18,14 @@ RSpec.describe RuboCop::Cop::RSpec::Be do
   end
 
   it 'allows `be` with an argument' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { expect(foo).to be(1) }
       it { expect(foo).not_to be(0) }
     RUBY
   end
 
   it 'allows specific `be_` matchers' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { expect(foo).to be_truthy }
       it { expect(foo).not_to be_falsy }
     RUBY

--- a/spec/rubocop/cop/rspec/before_after_all_spec.rb
+++ b/spec/rubocop/cop/rspec/before_after_all_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll do
 
   context 'when using before all' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before(:all) { do_something }
         ^^^^^^^^^^^^ #{message('before(:all)')}
         before(:context) { do_something }
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll do
 
   context 'when using after all' do
     it 'registers an offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         after(:all) { do_something }
         ^^^^^^^^^^^ #{message('after(:all)')}
         after(:context) { do_something }
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll do
 
   context 'when using before each' do
     it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before(:each) { do_something }
         before(:example) { do_something }
       RUBY
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::BeforeAfterAll do
 
   context 'when using after each' do
     it 'does not register an offense' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         after(:each) { do_something }
         after(:example) { do_something }
       RUBY

--- a/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
+++ b/spec/rubocop/cop/rspec/capybara/feature_methods_spec.rb
@@ -2,14 +2,14 @@
 
 RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   it 'flags offenses for `background`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'some feature' do
         background do; end
         ^^^^^^^^^^ Use `before` instead of `background`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe 'some feature' do
         before do; end
       end
@@ -17,14 +17,14 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   end
 
   it 'flags offenses for `scenario`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe 'some feature' do
         scenario 'Foo' do; end
         ^^^^^^^^ Use `it` instead of `scenario`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe 'some feature' do
         it 'Foo' do; end
       end
@@ -32,14 +32,14 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   end
 
   it 'flags offenses for `xscenario`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'Foo' do
         RSpec.xscenario 'Baz' do; end
               ^^^^^^^^^ Use `xit` instead of `xscenario`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe 'Foo' do
         RSpec.xit 'Baz' do; end
       end
@@ -47,14 +47,14 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   end
 
   it 'flags offenses for `given`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe 'Foo' do
         given(:foo) { :foo }
         ^^^^^ Use `let` instead of `given`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe 'Foo' do
         let(:foo) { :foo }
       end
@@ -62,14 +62,14 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   end
 
   it 'flags offenses for `given!`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'Foo' do
         given!(:foo) { :foo }
         ^^^^^^ Use `let!` instead of `given!`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe 'Foo' do
         let!(:foo) { :foo }
       end
@@ -77,25 +77,25 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   end
 
   it 'flags offenses for `feature`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.feature 'Foo' do; end
             ^^^^^^^ Use `describe` instead of `feature`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe 'Foo' do; end
     RUBY
   end
 
   it 'flags offenses inside shared groups' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.shared_examples_for 'common scenarios' do
         feature 'Foo' do; end
         ^^^^^^^ Use `describe` instead of `feature`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.shared_examples_for 'common scenarios' do
         describe 'Foo' do; end
       end
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   end
 
   it 'ignores variables inside examples' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'is valid code' do
         given(feature)
         assign(background)
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   end
 
   it 'ignores feature calls outside spec' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       FactoryBot.define do
         factory :company do
           feature { "a company" }
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
   end
 
   it 'allows includes before the spec' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       require 'rails_helper'
 
       RSpec.feature 'Foo' do; end
@@ -136,13 +136,13 @@ RSpec.describe RuboCop::Cop::RSpec::Capybara::FeatureMethods do
     let(:cop_config) { { 'EnabledMethods' => %w[feature] } }
 
     it 'ignores usage of the enabled method' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.feature 'feature is enabled' do; end
       RUBY
     end
 
     it 'flags other methods' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.feature 'feature is enabled' do
           given(:foo) { :foo }
           ^^^^^ Use `let` instead of `given`.

--- a/spec/rubocop/cop/rspec/change_by_zero_spec.rb
+++ b/spec/rubocop/cop/rspec/change_by_zero_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
   it 'registers an offense when using `change` and argument to `by` is zero' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it do
         expect { foo }.to change(Foo, :bar).by(0)
                           ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_to change` over `to change.by(0)`.
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it do
         expect { foo }.not_to change(Foo, :bar)
         expect { foo }.not_to change(::Foo, :bar)
@@ -27,14 +27,14 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
   it 'registers an offense when using `a_block_changing` ' \
      'and argument to `by` is zero' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it do
         expect { foo }.to a_block_changing(Foo, :bar).by(0)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_to change` over `to a_block_changing.by(0)`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it do
         expect { foo }.not_to change(Foo, :bar)
       end
@@ -43,14 +43,14 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
   it 'registers an offense when using `changing` ' \
      'and argument to `by` is zero' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it do
         expect { foo }.to changing(Foo, :bar).by(0)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_to change` over `to changing.by(0)`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it do
         expect { foo }.not_to change(Foo, :bar)
       end
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
   context 'when `NegatedMatcher` is not defined (default)' do
     it 'registers an offense when the argument to `by` is zero ' \
        'with compound expectations by `and`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0).and change(Foo, :baz).by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
     it 'registers an offense when the argument to `by` is zero ' \
        'with compound expectations by `&`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0) & change(Foo, :baz).by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
@@ -92,7 +92,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
     it 'registers an offense when the argument to `by` is zero ' \
        'with compound expectations by `or`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0).or change(Foo, :baz).by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
@@ -108,7 +108,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
     it 'registers an offense when the argument to `by` is zero ' \
        'with compound expectations by `|`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0) | change(Foo, :baz).by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
@@ -125,7 +125,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
     context 'when with a line break' do
       it 'registers an offense when the argument to `by` is zero ' \
          'with compound expectations by `and`' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it do
             expect { foo }
               .to change(Foo, :bar).by(0)
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
       it 'registers an offense when the argument to `by` is zero ' \
          'with compound expectations by `&`' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it do
             expect { foo }
               .to change(Foo, :bar).by(0) &
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
       it 'registers an offense when the argument to `by` is zero ' \
          'with compound expectations by `or`' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it do
             expect { foo }
               .to change(Foo, :bar).by(0)
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
       it 'registers an offense when the argument to `by` is zero ' \
          'with compound expectations by `|`' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it do
             expect { foo }
               .to change(Foo, :bar).by(0) |
@@ -210,7 +210,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
 
     it 'registers an offense and autocorrect when ' \
        'the argument to `by` is zero with compound expectations' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { foo }.to change(Foo, :bar).by(0).and change(Foo, :baz).by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
@@ -221,7 +221,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { foo }.to not_change(Foo, :bar).and not_change(Foo, :baz)
           expect { foo }.to not_change { Foo.bar }.and not_change { Foo.baz }
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
     it 'registers an offense and autocorrect when ' \
        'the argument to `by` is zero with compound expectations ' \
        'with line break' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { foo }
             .to change(Foo, :bar).by(0)
@@ -247,7 +247,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { foo }
             .to not_change(Foo, :bar)
@@ -261,7 +261,7 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
   end
 
   it 'does not register an offense when the argument to `by` is not zero' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it do
         expect { foo }.to change(Foo, :bar).by(1)
         expect { foo }.to change { Foo.bar }.by(1)

--- a/spec/rubocop/cop/rspec/contain_exactly_spec.rb
+++ b/spec/rubocop/cop/rspec/contain_exactly_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ContainExactly do
   it 'flags `contain_exactly` with only splat arguments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { is_expected.to contain_exactly(*array1, *array2) }
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `match_array` when matching array values.
       it { is_expected.to contain_exactly(*[1,2,3]) }
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContainExactly do
                           ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `match_array` when matching array values.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { is_expected.to match_array(array1 + array2) }
       it { is_expected.to match_array([1,2,3]) }
       it { is_expected.to match_array(a.merge(b)) }
@@ -22,24 +22,24 @@ RSpec.describe RuboCop::Cop::RSpec::ContainExactly do
   end
 
   it 'flags `contain_exactly` with a splatted percent literal array' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { is_expected.to contain_exactly(*%w(a b)) }
                           ^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `match_array` when matching array values.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { is_expected.to match_array(%w(a b)) }
     RUBY
   end
 
   it 'does not flag `match_array`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { is_expected.to match_array(array1 + array2) }
     RUBY
   end
 
   it 'does not flag `contain_exactly` with mixed arguments' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { is_expected.to contain_exactly(content, *array) }
       it { is_expected.to contain_exactly(*array, content) }
     RUBY
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContainExactly do
 
   # Don't do the work of RSpec/BeEmpty
   it 'does not flag `contain_exactly` with no arguments' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { is_expected.to contain_exactly }
       it { is_expected.to contain_exactly() }
     RUBY

--- a/spec/rubocop/cop/rspec/context_method_spec.rb
+++ b/spec/rubocop/cop/rspec/context_method_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ContextMethod do
   it 'ignores describe blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe '.foo_bar' do
       end
 
@@ -12,47 +12,47 @@ RSpec.describe RuboCop::Cop::RSpec::ContextMethod do
   end
 
   it 'ignores context without `.` or `#` at the beginning' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context "when it's sunny" do
       end
     RUBY
   end
 
   it 'flags context with `.` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context '.foo_bar' do
               ^^^^^^^^^^ Use `describe` for testing methods.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe '.foo_bar' do
       end
     RUBY
   end
 
   it 'flags context with `#` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context '#foo_bar' do
               ^^^^^^^^^^ Use `describe` for testing methods.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe '#foo_bar' do
       end
     RUBY
   end
 
   it 'flags multi-line context with `#` at the beginning' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       context '#foo_bar' \
               ^^^^^^^^^^^^ Use `describe` for testing methods.
               '.baz'do
       end
     RUBY
 
-    expect_correction(<<-'RUBY')
+    expect_correction(<<~'RUBY')
       describe '#foo_bar' \
               '.baz'do
       end

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
   end
 
   it 'skips describe blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'the display name not present' do
       end
     RUBY
   end
 
   it 'finds context without `when` at the beginning' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       context 'the display name not present' do
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
       end
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
   end
 
   it 'finds context without `when` at the beginning and contains `#{}`' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       context "the #{display} name not present" do
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
       end
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
   it 'finds context without `when` at the beginning ' \
      'and command surrounded by back ticks' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       context `pwd` do
               ^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
       end
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
   end
 
   it 'finds shared_context without `when` at the beginning' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       shared_context 'the display name not present' do
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
       end
@@ -46,21 +46,21 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
   end
 
   it "skips descriptions beginning with 'when'" do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context 'when the display name is not present' do
       end
     RUBY
   end
 
   it "skips descriptions beginning with 'when,'" do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context 'when, for some inexplicable reason, you inject a subordinate clause' do
       end
     RUBY
   end
 
   it 'finds context without separate `when` at the beginning' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       context 'whenever you do' do
               ^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
       end
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
   context 'with metadata hash' do
     it 'finds context without separate `when` at the beginning' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context 'whenever you do', legend: true do
                 ^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
         end
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
   context 'with symbol metadata' do
     it 'finds context without separate `when` at the beginning' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context 'whenever you do', :legend do
                 ^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
         end
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
   context 'with mixed metadata' do
     it 'finds context without separate `when` at the beginning' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context 'whenever you do', :legend, myth: true do
                 ^^^^^^^^^^^^^^^^^ Context description should match /^when\b/, /^with\b/, or /^without\b/.
         end
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
     let(:cop_config) { { 'Prefixes' => %w[if], 'AllowedPatterns' => [] } }
 
     it 'finds context without allowed prefixes at the beginning' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context 'when display name is present' do
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /^if\b/.
         end
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
     end
 
     it 'skips descriptions with allowed prefixes at the beginning' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         context 'if display name is present' do
         end
       RUBY
@@ -121,7 +121,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       end
 
       it 'skips descriptions with allowed multi-word prefixes' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           context 'assuming that display name is present' do
           end
         RUBY
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       let(:cop_config) { { 'Prefixes' => ['a$b\d'], 'AllowedPatterns' => [] } }
 
       it 'matches the full prefix' do
-        expect_offense(<<-'RUBY')
+        expect_offense(<<~'RUBY')
           context 'a' do
                   ^^^ Context description should match /^a\$b\\d\b/.
           end
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       end
 
       it 'matches special characters' do
-        expect_no_offenses(<<-'RUBY')
+        expect_no_offenses(<<~'RUBY')
           context 'a$b\d something' do
           end
         RUBY
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       end
 
       it 'finds context without `とき` at the ending' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           context '条件を満たす' do
                   ^^^^^^^^ Context description should match /とき$/.
           end
@@ -161,7 +161,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       end
 
       it 'finds shared_context without `とき` at the ending' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           shared_context '条件を満たす' do
                          ^^^^^^^^ Context description should match /とき$/.
           end
@@ -169,7 +169,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       end
 
       it "skips descriptions ending with 'とき'" do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           context '条件を満たすとき' do
           end
         RUBY
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
       it 'finds context without `when` at the beginning and not included ' \
          '`/patterns/`' do
-        expect_offense(<<-'RUBY')
+        expect_offense(<<~'RUBY')
           context 'this is an incorrect context' do
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /patterns/, or /^when\b/.
           end
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
 
       it 'finds shared_context without `when` at the beginning and ' \
          'not included `/patterns/`' do
-        expect_offense(<<-'RUBY')
+        expect_offense(<<~'RUBY')
           shared_context 'this is an incorrect context' do
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Context description should match /patterns/, or /^when\b/.
           end
@@ -200,14 +200,14 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       end
 
       it "skips descriptions beginning with 'when'" do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           context 'when this is valid context' do
           end
         RUBY
       end
 
       it "skips descriptions include with 'patterns'" do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           context 'this is valid patterns context' do
           end
         RUBY

--- a/spec/rubocop/cop/rspec/describe_class_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_class_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   it 'checks first-line describe statements' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe "bad describe" do
                ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
       end
@@ -10,21 +10,21 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'supports RSpec.describe' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
       end
     RUBY
   end
 
   it 'supports ::RSpec.describe' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       ::RSpec.describe Foo do
       end
     RUBY
   end
 
   it 'checks describe statements after a require' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       require 'spec_helper'
       describe "bad describe" do
                ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'checks highlights the first argument of a describe' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe "bad describe", "blah blah" do
                ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
       end
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores nested describe statements' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Some::Class do
         describe "bad describe" do
         end
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
 
   context 'when argument is a String literal' do
     it 'ignores class without namespace' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe 'Thing' do
           subject { Object.const_get(self.class.description) }
         end
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
 
     it 'ignores class with namespace' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe 'Some::Thing' do
           subject { Object.const_get(self.class.description) }
         end
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
 
     it 'ignores value constants' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe 'VERSION' do
           subject { Object.const_get(self.class.description) }
         end
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
 
     it 'ignores value constants with namespace' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe 'Some::VERSION' do
           subject { Object.const_get(self.class.description) }
         end
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
 
     it 'ignores top-level constants with `::` at start' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe '::Some::VERSION' do
           subject { Object.const_get(self.class.description) }
         end
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
 
     it 'checks `camelCase`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe 'activeRecord' do
                  ^^^^^^^^^^^^^^ The first argument to describe should be the class or module being tested.
           subject { Object.const_get(self.class.description) }
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
 
     it 'checks numbers at start' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '2Thing' do
                  ^^^^^^^^ The first argument to describe should be the class or module being tested.
           subject { Object.const_get(self.class.description) }
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
 
     it 'checks empty strings' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '' do
                  ^^ The first argument to describe should be the class or module being tested.
           subject { Object.const_get(self.class.description) }
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores an empty describe' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe do
       end
 
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it "doesn't flag top level describe in a shared example" do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       shared_examples 'Common::Interface' do
         describe '#public_interface' do
           it 'conforms to interface' do
@@ -141,7 +141,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it "doesn't flag top level describe in a shared context" do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.shared_context 'Common::Interface' do
         describe '#public_interface' do
           it 'conforms to interface' do
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it "doesn't flag top level describe in an unnamed shared context" do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       shared_context do
         describe '#public_interface' do
           it 'conforms to interface' do
@@ -165,14 +165,14 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores `type` metadata ignored by default' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'widgets/index', type: :view do
       end
     RUBY
   end
 
   it 'flags specs with non `type` metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'foo bar', foo: :bar do
                ^^^^^^^^^ The first argument to describe should be the class or module being tested.
       end
@@ -180,14 +180,14 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
   end
 
   it 'ignores feature specs - also with complex options' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'my new feature', :test, foo: :bar, type: :feature do
       end
     RUBY
   end
 
   it 'flags non-ignored `type` metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'wow', blah, type: :wow do
                ^^^^^ The first argument to describe should be the class or module being tested.
       end
@@ -202,14 +202,14 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeClass do
     end
 
     it 'ignores configured metadata' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe 'foo bar', foo: :bar do
         end
       RUBY
     end
 
     it 'ignores configured `type` metadata' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe 'my new system test', type: :wow do
         end
       RUBY

--- a/spec/rubocop/cop/rspec/describe_method_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_method_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'enforces non-method names' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Some::Class, 'nope', '.incorrect_usage' do
                             ^^^^^^ The second argument to describe should be the method being tested. '#instance' or '.class'.
       end
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'enforces non-method names with multi-line describe' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       describe Some::Class, "foo" \
                             ^^^^^^^ The second argument to describe should be the method being tested. '#instance' or '.class'.
         "bar" do
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'skips methods starting with a . or #' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Some::Class, '.asdf' do
       end
 
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'skips methods starting with a . or # with multi-line describe' do
-    expect_no_offenses(<<-'RUBY')
+    expect_no_offenses(<<~'RUBY')
       describe Some::Class, ".foo" \
         "bar" do
       end
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribeMethod do
   end
 
   it 'skips specs not having a string second argument' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Some::Class, :config do
       end
     RUBY

--- a/spec/rubocop/cop/rspec/describe_symbol_spec.rb
+++ b/spec/rubocop/cop/rspec/describe_symbol_spec.rb
@@ -2,28 +2,28 @@
 
 RSpec.describe RuboCop::Cop::RSpec::DescribeSymbol do
   it 'flags offenses for `describe :symbol`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe(:some_method) { }
                ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
   it 'flags offenses for `describe :symbol` with multiple arguments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe(:some_method, "description") { }
                ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
   it 'flags offenses for `RSpec.describe :symbol`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe(:some_method, "description") { }
                      ^^^^^^^^^^^^ Avoid describing symbols.
     RUBY
   end
 
   it 'flags offenses for a nested `describe`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         describe :to_s do
                  ^^^^^ Avoid describing symbols.

--- a/spec/rubocop/cop/rspec/described_class_module_wrapping_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_module_wrapping_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping, :ruby27 do
   it 'allows a describe block in the outermost scope' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe MyClass do
         subject { "MyClass" }
       end
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping, :ruby27 do
 
   it 'registers an offense when RSpec.describe block is nested ' \
      'within a module' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       module MyModule
       ^^^^^^^^^^^^^^^ Avoid opening modules and defining specs within them.
         RSpec.describe MyClass do
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping, :ruby27 do
 
   it 'registers an offense when RSpec.describe numblock is nested ' \
      'within a module' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       module MyModule
       ^^^^^^^^^^^^^^^ Avoid opening modules and defining specs within them.
         RSpec.describe MyClass do
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping, :ruby27 do
 
   it 'registers an offense when RSpec.describe block is nested ' \
      'within two modules' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       module MyFirstModule
       ^^^^^^^^^^^^^^^^^^^^ Avoid opening modules and defining specs within them.
         module MySecondModule
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClassModuleWrapping, :ruby27 do
   end
 
   it 'allows a module that does not contain RSpec.describe block' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       module MyModule
         def some_method
         end

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     let(:cop_config) { { 'SkipBlocks' => true } }
 
     it 'ignores offenses within non-rspec blocks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           controller(ApplicationController) do
             bar = MyClass
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
 
   context 'when SkipBlocks is `false`' do
     it 'flags offenses within all blocks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           controller(ApplicationController) do
             bar = MyClass
@@ -53,7 +53,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     let(:cop_config) { { 'EnforcedStyle' => :described_class } }
 
     it 'flags for the use of the described class' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           include MyClass
                   ^^^^^^^ Use `described_class` instead of `MyClass`.
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe MyClass do
           include described_class
 
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'flags with metadata' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass, some: :metadata do
           subject { MyClass }
                     ^^^^^^^ Use `described_class` instead of `MyClass`.
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores described class as string' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyClass do
           subject { "MyClass" }
         end
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores describe that do not reference to a class' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe "MyClass" do
           subject { "MyClass" }
         end
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores class if the scope is changing' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyClass do
           Class.new  { foo = MyClass }
           Module.new { bar = MyClass }
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'takes class from innermost describe' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           describe MyClass::Foo do
             subject { MyClass::Foo }
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores subclasses' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyClass do
           subject { MyClass::SubClass }
         end
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores non-matching namespace defined on `describe` level' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyNamespace::MyClass do
           subject { ::MyClass }
           let(:foo) { MyClass }
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores non-matching namespace' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         module MyNamespace
           describe MyClass do
             subject { ::MyClass }
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'flags the use of described class with namespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyNamespace::MyClass do
           subject { MyNamespace::MyClass }
                     ^^^^^^^^^^^^^^^^^^^^ Use `described_class` instead of `MyNamespace::MyClass`.
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores non-matching namespace in usages' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         module UnrelatedNamespace
           describe MyClass do
             subject { MyNamespace::MyClass }
@@ -195,7 +195,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores offenses within a class scope change' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyNamespace::MyClass do
           before do
             class Foo
@@ -207,7 +207,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores offenses within a hook scope change' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe do
           before do
             MyNamespace::MyClass.new
@@ -217,7 +217,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'flags the use of described class with module' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         module MyNamespace
           describe MyClass do
             subject { MyNamespace::MyClass }
@@ -226,7 +226,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         module MyNamespace
           describe MyClass do
             subject { described_class }
@@ -236,7 +236,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'flags the use of described class with nested namespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         module A
           class B::C
             module D
@@ -259,14 +259,14 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'accepts an empty block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyClass do
         end
       RUBY
     end
 
     it 'ignores if a local variable is part of the namespace' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Broken do
           [Foo, Bar].each do |klass|
             describe klass::Baz.name do
@@ -278,7 +278,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores if `described_class` is a part of the constant' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         module SomeGem
           describe VERSION do
             it 'returns proper version string' do
@@ -294,7 +294,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     let(:cop_config) { { 'EnforcedStyle' => :explicit } }
 
     it 'flags the use of the described_class' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           include described_class
                   ^^^^^^^^^^^^^^^ Use `MyClass` instead of `described_class`.
@@ -307,7 +307,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe MyClass do
           include MyClass
 
@@ -319,7 +319,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores described_class as string' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyClass do
           subject { "described_class" }
         end
@@ -327,7 +327,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores describe that do not reference to a class' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe "MyClass" do
           subject { described_class }
         end
@@ -335,7 +335,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores offenses within a class scope change' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyNamespace::MyClass do
           before do
             class Foo
@@ -347,7 +347,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'ignores offenses within a hook scope change' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe do
           before do
             described_class.new
@@ -357,14 +357,14 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
     end
 
     it 'autocorrects corresponding' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe(Foo) { include described_class }
                                 ^^^^^^^^^^^^^^^ Use `Foo` instead of `described_class`.
         describe(Bar) { include described_class }
                                 ^^^^^^^^^^^^^^^ Use `Bar` instead of `described_class`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe(Foo) { include Foo }
         describe(Bar) { include Bar }
       RUBY

--- a/spec/rubocop/cop/rspec/dialect_spec.rb
+++ b/spec/rubocop/cop/rspec/dialect_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe RuboCop::Cop::RSpec::Dialect do
   end
 
   it 'allows describe blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'display name presence' do
       end
     RUBY
   end
 
   it 'allows calling methods named context in examples' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'tests common context invocations' do
         expect(request.context).to be_empty?
       end
@@ -25,20 +25,20 @@ RSpec.describe RuboCop::Cop::RSpec::Dialect do
   end
 
   it 'registers an offense for context blocks' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context 'display name presence' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `describe` over `context`.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe 'display name presence' do
       end
     RUBY
   end
 
   it 'registers an offense for RSpec.context blocks' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.context 'context' do
       ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `describe` over `context`.
         it 'tests common context invocations' do
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::Dialect do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe 'context' do
         it 'tests common context invocations' do
           expect(request.context).to be_empty?
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::RSpec::Dialect do
     end
 
     it 'allows all methods blocks' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         context 'is important' do
           specify 'for someone to work' do
             everyone.should have_some_leeway

--- a/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_group_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   it 'checks for empty line after describe' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         describe '#bar' do
         end
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         describe '#bar' do
         end
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'highlights single line formulations correctly' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         describe('#bar') { }
         ^^^^^^^^^^^^^^^^^^^^ Add an empty line after `describe`.
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         describe('#bar') { }
 
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'checks for empty line after context' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.context 'foo' do
         context 'bar' do
         end
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.context 'foo' do
         context 'bar' do
         end
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'checks for empty line after shared groups' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.context 'foo' do
         shared_examples 'bar' do
         end
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.context 'foo' do
         shared_examples 'bar' do
         end
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'approves empty line after describe' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
         describe '#bar' do
         end
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'approves empty line after context' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.context 'foo' do
         context 'bar' do
         end
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'handles describes in an if block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       if RUBY_VERSION < 2.3
         describe 'skips checks under old ruby' do
         end
@@ -131,7 +131,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       if RUBY_VERSION < 2.3
         describe 'skips checks under old ruby' do
         end
@@ -146,7 +146,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'does not register an offense for a comment followed by an empty line' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
         describe 'bar' do
         end
@@ -159,7 +159,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'flags a missing empty line before a comment' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         describe 'bar' do
         end
@@ -170,7 +170,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         describe 'bar' do
         end
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'flags a missing empty line before a multiline comment' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         describe 'bar' do
         end
@@ -195,7 +195,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         describe 'bar' do
         end
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'flags a missing empty line after a `rubocop:enable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo
         describe 'bar' do
@@ -221,7 +221,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo
         describe 'bar' do
@@ -235,7 +235,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
   end
 
   it 'flags a missing empty line before a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         describe 'bar' do
         end
@@ -247,7 +247,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         describe 'bar' do
         end
@@ -262,7 +262,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
 
   it 'flags a missing empty line after a `rubocop:enable` directive ' \
      'when it is followed by a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo
         describe 'bar' do
@@ -276,7 +276,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExampleGroup do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo
         describe 'bar' do

--- a/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   it 'flags a missing empty line after `it`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'flags one-line examples' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         it { }
         ^^^^^^ Add an empty line after `it`.
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         it { }
 
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'flags a missing empty line after `specify`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.context 'foo' do
         specify do
         end
@@ -54,7 +54,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.context 'foo' do
         specify do
         end
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'ignores when an empty line is present' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'ignores consecutive one-liners' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
         it { one }
         it { two }
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'flags mixed one-line and multi-line examples' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.context 'foo' do
         it { }
         it { }
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'does not register an offense for a comment followed by an empty line' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'flags a missing empty line before a comment' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -126,7 +126,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -139,7 +139,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'flags a missing empty line before a multiline comment' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -165,7 +165,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'flags a missing empty line after a `rubocop:enable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo
         it 'does this' do
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo
         it 'does this' do
@@ -191,7 +191,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
   end
 
   it 'flags a missing empty line before a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -203,7 +203,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         it 'does this' do
         end
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
 
   it 'flags a missing empty line after a `rubocop:enable` directive ' \
      'when it is followed by a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo
         it 'does this' do
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         # rubocop:disable RSpec/Foo
         it 'does this' do
@@ -251,7 +251,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
     let(:cop_config) { { 'AllowConsecutiveOneLiners' => false } }
 
     it 'ignores consecutive one-liners' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe Foo do
           it { one }
           ^^^^^^^^^^ Add an empty line after `it`.

--- a/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_final_let_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   it 'registers an offense for empty line after last let' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -22,7 +22,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'registers an offense for empty line after the last `let!`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let!(:b) do
@@ -33,7 +33,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let!(:b) do
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'registers an offense for empty line after let with proc argument' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:user, &args[:build_user])
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:user, &args[:build_user])
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'does not register an offense for empty line after let' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
 
   it 'does not register an offense for comment ' \
      'followed by an empty line after let' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'flags a missing empty line before a comment' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'flags a missing empty line before a multiline comment' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'flags a missing empty line after a `rubocop:enable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo
         let(:a) { a }
@@ -147,7 +147,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo
         let(:a) { a }
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'flags a missing empty line before a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
 
   it 'flags a missing empty line after a `rubocop:enable` directive ' \
      'when it is followed by a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo
         let(:a) { a }
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo
         let(:a) { a }
@@ -213,7 +213,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'does not register an offense for empty lines between the lets' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
 
@@ -227,7 +227,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'does not register an offense for let in tests' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         # This shouldn't really ever happen in a sane codebase but I still
         # want to avoid false positives
@@ -240,7 +240,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'does not register an offense for multiline let block' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) do
@@ -253,7 +253,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'does not register an offense for let being the latest node' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -262,7 +262,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'does not register an offense for HEREDOC for let' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:foo) do
           <<-BAR
@@ -279,7 +279,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'does not register an offense for silly HEREDOC syntax for let' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe 'silly heredoc syntax' do
         let(:foo) { <<-BAR }
         hello
@@ -294,7 +294,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
   end
 
   it 'registers an offense for silly HEREDOC offense' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe 'silly heredoc syntax' do
         let(:foo) { <<-BAR }
         hello
@@ -307,7 +307,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterFinalLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe 'silly heredoc syntax' do
         let(:foo) { <<-BAR }
         hello

--- a/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_hook_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
   shared_examples_for 'always require empty line after hook groups' do
     it 'registers an offense for multiline blocks without empty line before' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something_else }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something_else }
 
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'registers an offense for empty line after `before` hook' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
 
@@ -47,7 +47,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'registers an offense for empty line after `after` hook' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           after { do_something }
           ^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `after`.
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           after { do_something }
 
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'registers an offense for empty line after `around` hook' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           around { |test| test.run }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `around`.
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           around { |test| test.run }
 
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for empty line after `before` hook' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           before { do_something }
 
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for empty line after `after` hook' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           after { do_something }
 
@@ -103,7 +103,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for empty line after `around` hook' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           around { |test| test.run }
 
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for multiline `before` block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           before do
             do_something
@@ -125,7 +125,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for multiline `after` block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           after do
             do_something
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for multiline `around` block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           around do |test|
             test.run
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for `before` being the latest node' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           before { do_something }
         end
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for a comment followed by an empty line' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           # comment
@@ -168,7 +168,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'flags a missing empty line before a comment' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
 
@@ -188,7 +188,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'flags a missing empty line before a multiline comment' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
 
@@ -210,7 +210,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'flags a missing empty line after a `rubocop:enable` directive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           # rubocop:disable RSpec/Foo
           before { do_something }
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           # rubocop:disable RSpec/Foo
           before { do_something }
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'flags a missing empty line before a `rubocop:disable` directive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
@@ -242,7 +242,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
 
@@ -255,7 +255,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
 
     it 'flags a missing empty line after a `rubocop:enable` directive ' \
        'when it is followed by a `rubocop:disable` directive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           # rubocop:disable RSpec/Foo
           before { do_something }
@@ -267,7 +267,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           # rubocop:disable RSpec/Foo
           before { do_something }
@@ -283,7 +283,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
 
   shared_examples_for 'never allows consecutive multiline blocks' do
     it 'registers an offense for multiline blocks without empty line after' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before do
             do_something
@@ -295,7 +295,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before do
             do_something
@@ -314,7 +314,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     include_examples 'never allows consecutive multiline blocks'
 
     it 'allows multiple one-liner blocks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           before { do_something_else }
@@ -323,7 +323,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           before { do_something_else }
@@ -334,7 +334,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'allows multiple one-liner blocks with comments' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           # this is a comment
@@ -344,7 +344,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           # this is a comment
@@ -356,7 +356,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'does not register an offense for chained one-liner `before` hooks' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           before { do_something_else }
@@ -367,7 +367,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'allows chained one-liner with different hooks' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           before { do_something_else }
           after { do_something_else }
@@ -385,7 +385,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     include_examples 'never allows consecutive multiline blocks'
 
     it 'registers an offense for multiple one-liner same hook blocks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
@@ -395,7 +395,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
 
@@ -407,7 +407,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'registers an offense for multiple one-liner blocks with comments' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
@@ -418,7 +418,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
 
@@ -431,7 +431,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
     end
 
     it 'registers an offense for multiple one-liner different hook blocks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           before { do_something }
           ^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `before`.
@@ -441,7 +441,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           before { do_something }
 
@@ -454,7 +454,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
 
     context 'when Ruby 2.7', :ruby27 do
       it 'registers an offense for empty line after `around` hook' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           RSpec.describe User do
             around { _1.run }
             ^^^^^^^^^^^^^^^^^ Add an empty line after `around`.
@@ -462,7 +462,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
           end
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           RSpec.describe User do
             around { _1.run }
 
@@ -472,7 +472,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterHook do
       end
 
       it 'does not register an offense for multiline `around` block' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           RSpec.describe User do
             around do
               _1.run

--- a/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_subject_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   it 'registers an offense for empty line after subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
 
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'registers an offense for empty line after subject!' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         subject! { described_class.new }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject!`.
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject! { described_class.new }
 
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'does not register an offense for empty line after subject' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
 
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'does not register an offense for empty line after subject!' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         subject! { described_class.new }
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'does not register an offense for multiline subject block' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         subject do
           described_class.new
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'does not register an offense for subject being the latest node' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         subject { described_user }
       end
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'does not register an offense for a comment followed by an empty line' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
         subject { described_user }
         # comment
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'flags a missing empty line before a comment' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         subject { described_user }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
@@ -100,7 +100,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         subject { described_user }
 
@@ -112,7 +112,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'flags a missing empty line before a multiline comment' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         subject { described_user }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         subject { described_user }
 
@@ -136,7 +136,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'flags a missing empty line after a `rubocop:enable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo
         subject { described_user }
@@ -147,7 +147,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo
         subject { described_user }
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
   end
 
   it 'flags a missing empty line before a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         subject { described_user }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Add an empty line after `subject`.
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe Foo do
         subject { described_user }
 
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
 
   it 'flags a missing empty line after a `rubocop:enable` directive ' \
      'when it is followed by a `rubocop:disable` directive' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo
         subject { described_user }
@@ -198,7 +198,7 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         # rubocop:disable RSpec/Foo
         subject { described_user }

--- a/spec/rubocop/cop/rspec/example_length_spec.rb
+++ b/spec/rubocop/cop/rspec/example_length_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
   let(:cop_config) { { 'Max' => 3 } }
 
   it 'ignores non-spec blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       foo do
         line 1
         line 2
@@ -15,14 +15,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
   end
 
   it 'allows an empty example' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it do
       end
     RUBY
   end
 
   it 'allows a short example' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it do
         line 1
         line 2
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
   end
 
   it 'ignores comments' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it do
         line 1
         line 2
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
 
   context 'when inspecting large examples' do
     it 'flags the example' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
         ^^^^^ Example has too many lines. [4/3]
           line 1
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleLength do
     end
 
     it 'flags the example' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
         ^^^^^ Example has too many lines. [4/3]
           line 1

--- a/spec/rubocop/cop/rspec/example_without_description_spec.rb
+++ b/spec/rubocop/cop/rspec/example_without_description_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
     let(:enforced_style) { 'always_allow' }
 
     it 'flags empty strings for description' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it '' do
            ^^ Omit the argument when you want to have auto-generated description.
           expect(subject).to be_good
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
     end
 
     it 'ignores `it` with a description' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'is good' do
           expect(subject).to be_good
         end
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
     end
 
     it 'ignores `it` without an argument' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           expect(subject).to be_good
         end
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
     let(:enforced_style) { 'single_line_only' }
 
     it 'flags missing description in multi-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
         ^^ Add a description.
           expect(subject).to be_good
@@ -47,13 +47,13 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
     end
 
     it 'ignores missing description in single-line examples' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { expect(subject).to be_good }
       RUBY
     end
 
     it 'flags example with an empty string for description' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it('') { expect(subject).to be_good }
            ^^ Omit the argument when you want to have auto-generated description.
       RUBY
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
     let(:enforced_style) { 'disallow' }
 
     it 'flags missing description in multi-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
         ^^ Add a description.
           expect(subject).to be_good
@@ -73,14 +73,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
     end
 
     it 'flags missing description in single-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { expect(subject).to be_good }
         ^^ Add a description.
       RUBY
     end
 
     it 'ignores `it` with a description' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'is good' do
           expect(subject).to be_good
         end

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -6,284 +6,284 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'finds description with `should` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'should do something' do
           ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it 'does something' do
       end
     RUBY
   end
 
   it 'finds interpolated description with `should` at the beginning' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       it "should do #{:stuff}" do
           ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-'RUBY')
+    expect_correction(<<~'RUBY')
       it "does #{:stuff}" do
       end
     RUBY
   end
 
   it 'finds description with `Should` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'Should do something' do
           ^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it 'does something' do
       end
     RUBY
   end
 
   it "finds description with `shouldn't` at the beginning" do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "shouldn't do something" do
           ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it "does not do something" do
       end
     RUBY
   end
 
   it "finds description with `SHOULDN'T` at the beginning" do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "SHOULDN'T do something" do
           ^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it "DOES NOT do something" do
       end
     RUBY
   end
 
   it 'flags a lone should' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'should' do
           ^^^^^^ Do not use should when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it '' do
       end
     RUBY
   end
 
   it 'flags a lone should not' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'should not' do
           ^^^^^^^^^^ Do not use should when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it 'does not' do
       end
     RUBY
   end
 
   it 'finds description with `will` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'will do something' do
           ^^^^^^^^^^^^^^^^^ Do not use the future tense when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it 'does something' do
       end
     RUBY
   end
 
   it 'finds interpolated description with `will` at the beginning' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       it "will do #{:stuff}" do
           ^^^^^^^^^^^^^^^^^ Do not use the future tense when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-'RUBY')
+    expect_correction(<<~'RUBY')
       it "does #{:stuff}" do
       end
     RUBY
   end
 
   it 'finds description with `Will` at the beginning' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'Will do something' do
           ^^^^^^^^^^^^^^^^^ Do not use the future tense when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it 'does something' do
       end
     RUBY
   end
 
   it "finds description with `won't` at the beginning" do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "won't do something" do
           ^^^^^^^^^^^^^^^^^^ Do not use the future tense when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it "does not do something" do
       end
     RUBY
   end
 
   it "finds description with `WON'T` at the beginning" do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "WON'T do something" do
           ^^^^^^^^^^^^^^^^^^ Do not use the future tense when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it "DOES NOT do something" do
       end
     RUBY
   end
 
   it 'flags a lone will' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'will' do
           ^^^^ Do not use the future tense when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it '' do
       end
     RUBY
   end
 
   it 'flags a lone will not' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'will not' do
           ^^^^^^^^ Do not use the future tense when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it 'does not' do
       end
     RUBY
   end
 
   it "flags a lone won't" do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "won't" do
           ^^^^^ Do not use the future tense when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it "does not" do
       end
     RUBY
   end
 
   it 'finds leading its' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "it does something" do
           ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it "does something" do
       end
     RUBY
   end
 
   it 'finds leading it in interpolated description' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       it "it does #{action}" do
           ^^^^^^^^^^^^^^^^^ Do not repeat 'it' when describing your tests.
       end
     RUBY
 
-    expect_correction(<<-'RUBY')
+    expect_correction(<<~'RUBY')
       it "does #{action}" do
       end
     RUBY
   end
 
   it "skips words beginning with 'it'" do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'itemizes items' do
       end
     RUBY
   end
 
   it 'skips descriptions without `should` at the beginning' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'finds no should here' do
       end
     RUBY
   end
 
   it 'skips descriptions starting with words that begin with `should`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'shoulders the burden' do
       end
     RUBY
   end
 
   it 'skips interpolated description without literal `should` at the start' do
-    expect_no_offenses(<<-'RUBY')
+    expect_no_offenses(<<~'RUBY')
       it "#{should} not be here" do
       end
     RUBY
   end
 
   it 'flags \-separated multiline strings' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       it 'should do something ' \
           ^^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
           'and correctly fix' do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it 'does something and correctly fix' do
       end
     RUBY
   end
 
   it 'flags \-separated multiline interpolated strings' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       it "should do something " \
           ^^^^^^^^^^^^^^^^^^^^^^^ Do not use should when describing your tests.
           "with #{object}" do
       end
     RUBY
 
-    expect_correction(<<-'RUBY')
+    expect_correction(<<~'RUBY')
       it "does something with #{object}" do
       end
     RUBY
   end
 
   it 'ignores heredocs' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it <<~DESC do
           ^^^^^ Do not use should when describing your tests.
         should not start with this word
@@ -293,7 +293,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'flags an unclear description' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "works" do
           ^^^^^ Your example description is insufficient.
       end
@@ -301,7 +301,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'flags an unclear description despite extra spaces' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "  works    " do
           ^^^^^^^^^^^ Your example description is insufficient.
       end
@@ -309,7 +309,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
   end
 
   it 'flags an unclear description despite uppercase and lowercase strings' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "WOrKs " do
           ^^^^^^ Your example description is insufficient.
       end
@@ -320,7 +320,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     let(:cop_config) { { 'DisallowedExamples' => ['Workz'] } }
 
     it 'finds a valid sentence across two lines' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<~'RUBY')
         it "workz " \
           "totally fine " do
         end
@@ -328,7 +328,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     end
 
     it 'finds an invalid example across two lines' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         it "workz" \
             ^^^^^^^^ Your example description is insufficient.
           " " do
@@ -337,7 +337,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     end
 
     it 'flags an unclear description' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it "workz" do
             ^^^^^ Your example description is insufficient.
         end
@@ -345,7 +345,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
     end
 
     it 'flags an unclear description despite uppercase and lowercase strings' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it "WOrKz " do
             ^^^^^^ Your example description is insufficient.
         end

--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -7,177 +7,177 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
   context 'when using `describe`' do
     it 'skips blocks without text' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe do
         end
       RUBY
     end
 
     it 'finds description with leading whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '  #mymethod' do
                   ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod' do
         end
       RUBY
     end
 
     it 'finds description with leading em space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '\u3000\u3000#mymethod' do
                   ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod' do
         end
       RUBY
     end
 
     it 'finds description with leading non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '\u00a0#mymethod' do
                   ^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod' do
         end
       RUBY
     end
 
     it 'finds interpolated description with leading whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         describe "  ##{:stuff}" do
                   ^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         describe "##{:stuff}" do
         end
       RUBY
     end
 
     it 'finds description with trailing whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '#mymethod  ' do
                   ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod' do
         end
       RUBY
     end
 
     it 'finds description with trailing em space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '#mymethod\u3000\u3000' do
                   ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod' do
         end
       RUBY
     end
 
     it 'finds description with trailing non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '#mymethod\u00a0' do
                   ^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod' do
         end
       RUBY
     end
 
     it 'finds description with leading and trailing non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '\u00a0#mymethod\u00a0' do
                   ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod' do
         end
       RUBY
     end
 
     it 'finds interpolated description with trailing whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         describe "##{:stuff}  " do
                   ^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         describe "##{:stuff}" do
         end
       RUBY
     end
 
     it 'flags lone whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '   ' do
                   ^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '' do
         end
       RUBY
     end
 
     it 'skips descriptions without any excessive whitespace' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe '#mymethod' do
         end
       RUBY
     end
 
     it 'skips interpolated description without leading whitespace' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<~'RUBY')
         describe "##{should}" do
         end
       RUBY
     end
 
     it 'finds descriptions with inner extra whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '#mymethod   (is cool)' do
                   ^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod (is cool)' do
         end
       RUBY
     end
 
     it 'finds descriptions with multiple inner extra whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe '#mymethod      (  is     cool  )' do
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod ( is cool )' do
         end
       RUBY
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'skips \-separated multiline strings whose trailing whitespace ' \
        'makes sense' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<~'RUBY')
         describe '#mymethod ' \
             '(is cool)' do
         end
@@ -194,14 +194,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline strings whose trailing whitespace ' \
        'does not make sense' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         describe '#mymethod   ' \
                   ^^^^^^^^^^^^^^^ Excessive whitespace.
             '(is cool)' do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         describe '#mymethod (is cool)' do
         end
       RUBY
@@ -209,14 +209,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline interpolated strings with ' \
        'leading whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         describe "  ##{object} " \
                   ^^^^^^^^^^^^^^^^ Excessive whitespace.
             "(is cool)" do
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         describe "##{object} (is cool)" do
         end
       RUBY
@@ -225,98 +225,98 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
   context 'when using `context`' do
     it 'skips blocks without text' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         context do
         end
       RUBY
     end
 
     it 'finds description with leading whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         context '  when doing something' do
                  ^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context 'when doing something' do
         end
       RUBY
     end
 
     it 'finds description with leading non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         context '\u00a0#mymethod' do
                  ^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context '#mymethod' do
         end
       RUBY
     end
 
     it 'finds interpolated description with leading whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context "  when doing something #{:stuff}" do
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         context "when doing something #{:stuff}" do
         end
       RUBY
     end
 
     it 'finds description with trailing whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         context 'when doing something  ' do
                  ^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context 'when doing something' do
         end
       RUBY
     end
 
     it 'finds description with trailing non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         context '#mymethod\u00a0' do
                  ^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context '#mymethod' do
         end
       RUBY
     end
 
     it 'finds description with leading and trailing non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         context '\u00a0#mymethod\u00a0' do
                  ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context '#mymethod' do
         end
       RUBY
     end
 
     it 'finds interpolated description with trailing whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context "when doing #{:stuff}  " do
                  ^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         context "when doing #{:stuff}" do
         end
       RUBY
@@ -324,66 +324,66 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'finds interpolated description with both trailing and leading ' \
        'whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context "  when doing #{:stuff}  " do
                  ^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         context "when doing #{:stuff}" do
         end
       RUBY
     end
 
     it 'flags lone whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         context '   ' do
                  ^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context '' do
         end
       RUBY
     end
 
     it 'skips descriptions without any excessive whitespace' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         context 'when doing something' do
         end
       RUBY
     end
 
     it 'skips interpolated description without leading whitespace' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<~'RUBY')
         context "#{should} the value be incorrect" do
         end
       RUBY
     end
 
     it 'finds descriptions with inner extra whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         context 'when   something' do
                  ^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context 'when something' do
         end
       RUBY
     end
 
     it 'finds descriptions with multiple inner extra whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         context 'when     something    cool happens!' do
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context 'when something cool happens!' do
         end
       RUBY
@@ -391,7 +391,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'skips \-separated multiline strings whose trailing whitespace ' \
        'makes sense' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<~'RUBY')
         context 'when doing something ' \
             'like this' do
         end
@@ -400,14 +400,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline strings whose trailing whitespace ' \
        'does not make sense' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context 'when doing something   ' \
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             'like this' do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         context 'when doing something like this' do
         end
       RUBY
@@ -415,14 +415,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline interpolated strings with leading ' \
        'whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         context "  when doing something " \
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             "like #{object}" do
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         context "when doing something like #{object}" do
         end
       RUBY
@@ -431,190 +431,190 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
   context 'when using `it`' do
     it 'skips blocks without text' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
         end
       RUBY
     end
 
     it 'finds description with leading whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it '  does something' do
             ^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'does something' do
         end
       RUBY
     end
 
     it 'finds description with leading non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it '\u00a0does something' do
             ^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'does something' do
         end
       RUBY
     end
 
     it 'finds interpolated description with leading whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         it "  does something #{:stuff}" do
             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         it "does something #{:stuff}" do
         end
       RUBY
     end
 
     it 'finds description with trailing whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'does something  ' do
             ^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'does something' do
         end
       RUBY
     end
 
     it 'finds description with trailing non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'does something\u00a0' do
             ^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'does something' do
         end
       RUBY
     end
 
     it 'finds description with leading and trailing non-breaking space' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it '\u00a0does something\u00a0' do
             ^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'does something' do
         end
       RUBY
     end
 
     it 'finds interpolated description with trailing whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         it "does something #{:stuff}  " do
             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         it "does something #{:stuff}" do
         end
       RUBY
     end
 
     it 'handles one-word descriptions' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it "tests  " do
             ^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it "tests" do
         end
       RUBY
     end
 
     it 'handles interpolated one-word descriptions' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         it "#{:stuff}  " do
             ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         it "#{:stuff}" do
         end
       RUBY
     end
 
     it 'handles descriptions starting with an interpolated value' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         it "#{:stuff} something   " do
             ^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         it "#{:stuff} something" do
         end
       RUBY
     end
 
     it 'flags lone whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it '   ' do
             ^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it '' do
         end
       RUBY
     end
 
     it 'skips descriptions without any excessive whitespace' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'finds no should here' do
         end
       RUBY
     end
 
     it 'skips interpolated description without leading whitespace' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<~'RUBY')
         it "#{should} not be here" do
         end
       RUBY
     end
 
     it 'finds descriptions with inner extra whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'does   something' do
             ^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'does something' do
         end
       RUBY
     end
 
     it 'finds descriptions with multiple inner extra whitespace' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'does  something      cool!' do
             ^^^^^^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'does something cool!' do
         end
       RUBY
@@ -622,7 +622,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'skips \-separated multiline strings whose trailing whitespace ' \
        'makes sense' do
-      expect_no_offenses(<<-'RUBY')
+      expect_no_offenses(<<~'RUBY')
         it 'should do something ' \
             'and correctly fix' do
         end
@@ -631,14 +631,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline strings whose trailing whitespace ' \
        'does not make sense' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         it 'does something   ' \
             ^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             'and correctly fix' do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'does something and correctly fix' do
         end
       RUBY
@@ -646,14 +646,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
     it 'flags \-separated multiline interpolated strings with leading ' \
        'whitespace' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         it "  does something " \
             ^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             "with #{object}" do
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         it "does something with #{object}" do
         end
       RUBY
@@ -662,71 +662,71 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
 
   context 'when using other common example groups' do
     it 'supports `xcontext`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         xcontext "when testing  " do
                   ^^^^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         xcontext "when testing" do
         end
       RUBY
     end
 
     it 'supports `feature`' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         feature "  #{:stuff}" do
                  ^^^^^^^^^^^ Excessive whitespace.
         end
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         feature "#{:stuff}" do
         end
       RUBY
     end
 
     it 'supports `its`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         its("  length  ") { should eq(1) }
              ^^^^^^^^^^ Excessive whitespace.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         its("length") { should eq(1) }
       RUBY
     end
 
     it 'supports `skip` (with a block)' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         skip '  this   please   ' \
               ^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             '  and thank you  !' do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         skip 'this please and thank you !' do
         end
       RUBY
     end
 
     it 'supports `skip` (without a block)' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         skip '  this   please   ' \
               ^^^^^^^^^^^^^^^^^^^^^ Excessive whitespace.
             '  and thank you  !'
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         skip 'this please and thank you !'
       RUBY
     end
   end
 
   it 'does not consider indented whitespace excessive' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context "some context" do
         [].each do |i|
           it "does something, lala1: #\{i[:a].first} - #\{i[:a].last},
@@ -741,7 +741,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
   end
 
   it 'ignores heredocs' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it <<~DESC do
         does not remove
           another comments reports,

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   it 'flags numeric literal values within expect(...)' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(123).to eq(bar)
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eq(123)
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags boolean literal values within expect(...)' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(true).to eq(bar)
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eq(true)
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags string and symbol literal values within expect(...)' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect("foo").to eq(bar)
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eq("foo")
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags literal nil value within expect(...)' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(nil).to eq(bar)
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eq(nil)
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'does not flag dynamic values within expect(...)' do
-    expect_no_offenses(<<-'RUBY')
+    expect_no_offenses(<<~'RUBY')
       describe Foo do
         it 'uses expect correctly' do
           expect(foo).to eq(bar)
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags arrays containing only literal values within expect(...)' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect([123]).to eq(bar)
@@ -116,7 +116,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eq([123])
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags hashes containing only literal values within expect(...)' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(foo: 1, bar: 2).to eq(bar)
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eq(foo: 1, bar: 2)
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags ranges containing only literal values within expect(...)' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1..2).to eq(bar)
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eq(1..2)
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags regexps containing only literal values within expect(...)' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(/foo|bar/).to eq(bar)
@@ -180,7 +180,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eq(/foo|bar/)
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'does not flag complex values with dynamic parts within expect(...)' do
-    expect_no_offenses(<<-'RUBY')
+    expect_no_offenses(<<~'RUBY')
       describe Foo do
         it 'uses expect incorrectly' do
           expect.to eq(bar)
@@ -254,7 +254,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags with `eql` matcher' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1).to eql(bar)
@@ -263,7 +263,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to eql(1)
@@ -273,7 +273,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags with `equal` matcher' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(1).to equal(bar)
@@ -282,7 +282,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect(bar).to equal(1)
@@ -292,7 +292,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags but does not autocorrect offenses for other matchers' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect([1,2,3]).to include(a)
@@ -305,7 +305,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
   end
 
   it 'flags but does not autocorrect when the actual value is also a literal' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses expect incorrectly' do
           expect([1,2,3]).to eq([1, 2, 3])

--- a/spec/rubocop/cop/rspec/expect_change_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_change_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     let(:enforced_style) { 'method_call' }
 
     it 'flags blocks that contain simple message sending' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change { User.count }.by(1)
                             ^^^^^^^^^^^^^^^^^^^^^ Prefer `change(User, :count)`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change(User, :count).by(1)
         end
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'ignores blocks when the method is called with arguments' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           expect { run }.to change { User.sum(:points) }
         end
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'ignores when not an expectation' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           Record.change { User.count }
         end
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags implicit block expectation syntax' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect(run).to change { User.count }.by(1)
                          ^^^^^^^^^^^^^^^^^^^^^ Prefer `change(User, :count)`.
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'ignores the usage that adheres to the enforced style' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           expect { run }.to change(User, :count).by(1)
         end
@@ -57,14 +57,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags when the received is a namespaced constant' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change { User::Token::Auth.count }.by(1)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `change(User::Token::Auth, :count)`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change(User::Token::Auth, :count).by(1)
         end
@@ -72,14 +72,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags when the receiver is a top-level constant' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change { ::User.count }.by(1)
                             ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `change(::User, :count)`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change(::User, :count).by(1)
         end
@@ -87,14 +87,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags a method call on an object' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change { user.name }.to('Jack')
                             ^^^^^^^^^^^^^^^^^^^^ Prefer `change(user, :name)`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change(user, :name).to('Jack')
         end
@@ -102,7 +102,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'ignores multiple chained method calls' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           expect { run }.to change { user.reload.name }
         end
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'ignores a variable/method' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           expect { run }.to change { results }.to([])
         end
@@ -122,14 +122,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     let(:enforced_style) { 'block' }
 
     it 'flags change matcher without block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change(User, :count).by(1)
                             ^^^^^^^^^^^^^^^^^^^^ Prefer `change { User.count }`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change { User.count }.by(1)
         end
@@ -137,14 +137,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags change matcher when receiver is a namespaced constant' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change(User::Token::Auth, :count).by(1)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `change { User::Token::Auth.count }`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change { User::Token::Auth.count }.by(1)
         end
@@ -152,14 +152,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags change matcher when receiver is a variable' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change(user, :count)
                             ^^^^^^^^^^^^^^^^^^^^ Prefer `change { user.count }`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change { user.count }
         end
@@ -167,14 +167,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags change matcher when message is a string' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change(user, 'status')
                             ^^^^^^^^^^^^^^^^^^^^^^ Prefer `change { user.status }`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change { user.status }
         end
@@ -182,14 +182,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'registers an offense for change matcher with chained method call' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { paint_users! }.to change(users.green, :count).by(1)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `change { users.green.count }`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { paint_users! }.to change { users.green.count }.by(1)
         end
@@ -197,14 +197,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags change matcher when receiver is a top-level constant' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { run }.to change(::User, :count)
                             ^^^^^^^^^^^^^^^^^^^^^^ Prefer `change { ::User.count }`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { run }.to change { ::User.count }
         end
@@ -212,14 +212,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'registers an offense for change matcher with an instance variable' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { paint_users! }.to change(@food, :taste).to(:sour)
                                      ^^^^^^^^^^^^^^^^^^^^^ Prefer `change { @food.taste }`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { paint_users! }.to change { @food.taste }.to(:sour)
         end
@@ -227,14 +227,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'registers an offense for change matcher with a global variable' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect { paint_users! }.to change($token, :value).to(nil)
                                      ^^^^^^^^^^^^^^^^^^^^^^ Prefer `change { $token.value }`.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           expect { paint_users! }.to change { $token.value }.to(nil)
         end
@@ -242,7 +242,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'ignores methods called change' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           record.change(user, :count)
         end
@@ -250,7 +250,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
     end
 
     it 'flags implicit block expectation syntax' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           expect(run).to change(User, :count).by(1)
                          ^^^^^^^^^^^^^^^^^^^^ Prefer `change { User.count }`.

--- a/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_in_hook_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
   it 'adds an offense for `expect` in `before` hook' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before do
         expect(something).to eq('foo')
         ^^^^^^ Do not use `expect` in `before` hook
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
   end
 
   it 'adds an offense for `expect` in `after` hook' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       after do
         expect(something).to eq('foo')
         ^^^^^^ Do not use `expect` in `after` hook
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
   end
 
   it 'adds an offense for `expect` in `around` hook' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       around do
         expect(something).to eq('foo')
         ^^^^^^ Do not use `expect` in `around` hook
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
   end
 
   it 'adds an offense for `expect` with block in `before` hook' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before do
         expect { something }.to eq('foo')
         ^^^^^^ Do not use `expect` in `before` hook
@@ -50,14 +50,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
   end
 
   it 'accepts an empty `before` hook' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       before do
       end
     RUBY
   end
 
   it 'accepts `allow` in `before` hook' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       before do
         allow(something).to receive(:foo)
         allow_any_instance_of(something).to receive(:foo)
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
   end
 
   it 'accepts `expect` in `it`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it do
         expect(something).to eq('foo')
         is_expected.to eq('foo')
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectInHook do
 
   context 'when Ruby 2.7', :ruby27 do
     it 'adds an offense for `expect` in `around` hook' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         around do
           expect(something).to eq('foo')
           ^^^^^^ Do not use `expect` in `around` hook

--- a/spec/rubocop/cop/rspec/expect_output_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_output_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   it 'registers an offense for overwriting $stdout within an example' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       specify do
         $stdout = StringIO.new
         ^^^^^^^ Use `expect { ... }.to output(...).to_stdout` instead of mutating $stdout.
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
 
   it 'registers an offense for overwriting $stderr ' \
      'within an example scoped hook' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before(:each) do
         $stderr = StringIO.new
         ^^^^^^^ Use `expect { ... }.to output(...).to_stderr` instead of mutating $stderr.
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not register an offense for interacting with $stdout' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       specify do
         $stdout.puts("hi")
       end
@@ -29,7 +29,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not flag assignments to other global variables' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       specify do
         $blah = StringIO.new
       end
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not flag assignments to $stdout outside of example scope' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       before(:suite) do
         $stderr = StringIO.new
       end
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectOutput do
   end
 
   it 'does not flag assignments to $stdout in example_group scope' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         $stderr = StringIO.new
       end

--- a/spec/rubocop/cop/rspec/file_path_spec.rb
+++ b/spec/rubocop/cop/rspec/file_path_spec.rb
@@ -2,198 +2,198 @@
 
 RSpec.describe RuboCop::Cop::RSpec::FilePath do
   it 'registers an offense for a bad path' do
-    expect_offense(<<-RUBY, 'wrong_path_foo_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_path_foo_spec.rb')
       describe MyClass, 'foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a bad path for all kinds of example groups' do
-    expect_offense(<<-RUBY, 'wrong_path_foo_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_path_foo_spec.rb')
       example_group MyClass, 'foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class but a correct method' do
-    expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a repeated .rb' do
-    expect_offense(<<-RUBY, 'my_class/foo_spec.rb.rb')
+    expect_offense(<<~RUBY, 'my_class/foo_spec.rb.rb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a file missing a .rb' do
-    expect_offense(<<-RUBY, 'my_class/foo_specorb')
+    expect_offense(<<~RUBY, 'my_class/foo_specorb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class and highlights metadata' do
-    expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo', blah: :blah do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class name' do
-    expect_offense(<<-RUBY, 'wrong_class_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_spec.rb')
       describe MyClass do; end
       ^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a wrong class name with a symbol argument' do
-    expect_offense(<<-RUBY, 'wrong_class_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_spec.rb')
       describe MyClass, :foo do; end
       ^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense when second argument contains spaces' do
-    expect_offense(<<-RUBY, 'wrong_class_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_spec.rb')
       describe MyClass, "via `local_failures`" do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*via_local_failures*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a file missing _spec' do
-    expect_offense(<<-RUBY, 'spec/models/user.rb')
+    expect_offense(<<~RUBY, 'spec/models/user.rb')
       describe User do; end
       ^^^^^^^^^^^^^ Spec path should end with `user*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a feature file missing _spec' do
-    expect_offense(<<-RUBY, 'spec/features/my_feature.rb')
+    expect_offense(<<~RUBY, 'spec/features/my_feature.rb')
       feature "my feature" do; end
       ^^^^^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for a file without the .rb extension' do
-    expect_offense(<<-RUBY, 'spec/models/user_specxrb')
+    expect_offense(<<~RUBY, 'spec/models/user_specxrb')
       describe User do; end
       ^^^^^^^^^^^^^ Spec path should end with `user*_spec.rb`.
     RUBY
   end
 
   it 'does not register an offense for shared examples' do
-    expect_no_offenses(<<-RUBY, 'spec/models/user.rb')
+    expect_no_offenses(<<~RUBY, 'spec/models/user.rb')
       shared_examples_for 'foo' do; end
     RUBY
   end
 
   it 'does not register an offense for example groups ' \
      'do not describe a class / method' do
-    expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/spec.rb')
       describe 'Test something' do; end
     RUBY
   end
 
   it 'does not register an offense for multiple top level describes' do
-    expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/spec.rb')
       describe MyClass, 'do_this' do; end
       describe MyClass, 'do_that' do; end
     RUBY
   end
 
   it 'does not register an offense for class specs' do
-    expect_no_offenses(<<-RUBY, 'some/class_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
   it 'does not register an offense for different parent directories' do
-    expect_no_offenses(<<-RUBY, 'parent_dir/some/class_spec.rb')
+    expect_no_offenses(<<~RUBY, 'parent_dir/some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
   it 'does not register an offense for CamelCaps class names' do
-    expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
+    expect_no_offenses(<<~RUBY, 'my_class_spec.rb')
       describe MyClass do; end
     RUBY
   end
 
   it 'does not register an offense for ACRONYMClassNames' do
-    expect_no_offenses(<<-RUBY, 'abc_one/two_spec.rb')
+    expect_no_offenses(<<~RUBY, 'abc_one/two_spec.rb')
       describe ABCOne::Two do; end
     RUBY
   end
 
   it 'does not register an offense for ALLCAPS class names' do
-    expect_no_offenses(<<-RUBY, 'allcaps_spec.rb')
+    expect_no_offenses(<<~RUBY, 'allcaps_spec.rb')
       describe ALLCAPS do; end
     RUBY
   end
 
   it 'does not register an offense for alphanumeric class names' do
-    expect_no_offenses(<<-RUBY, 'ipv4_and_ipv6_spec.rb')
+    expect_no_offenses(<<~RUBY, 'ipv4_and_ipv6_spec.rb')
       describe IPV4AndIPV6 do; end
     RUBY
   end
 
   it 'does not register an offense for instance methods' do
-    expect_no_offenses(<<-RUBY, 'some/class/inst_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'does not register an offense for class methods' do
-    expect_no_offenses(<<-RUBY, 'some/class/inst_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'does not register an offense for flat hierarchies for instance methods' do
-    expect_no_offenses(<<-RUBY, 'some/class_inst_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class_inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'does not register an offense for flat hierarchies for class methods' do
-    expect_no_offenses(<<-RUBY, 'some/class_inst_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class_inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'does not register an offense for subdirs for instance methods' do
     filename = 'some/class/instance_methods/inst_spec.rb'
-    expect_no_offenses(<<-RUBY, filename)
+    expect_no_offenses(<<~RUBY, filename)
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'does not register an offense for subdirs for class methods' do
     filename = 'some/class/class_methods/inst_spec.rb'
-    expect_no_offenses(<<-RUBY, filename)
+    expect_no_offenses(<<~RUBY, filename)
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'does not register an offense for non-alphanumeric characters' do
-    expect_no_offenses(<<-RUBY, 'some/class/pred_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/pred_spec.rb')
       describe Some::Class, '#pred?' do; end
     RUBY
   end
 
   it 'does not register an offense for bang method' do
-    expect_no_offenses(<<-RUBY, 'some/class/bang_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/bang_spec.rb')
       describe Some::Class, '#bang!' do; end
     RUBY
   end
 
   it 'does not register an offense for an arbitrary spec suffix' do
     filename = 'some/class/thing_predicate_spec.rb'
-    expect_no_offenses(<<-RUBY, filename)
+    expect_no_offenses(<<~RUBY, filename)
       describe Some::Class, '#thing?' do; end
     RUBY
   end
@@ -201,27 +201,27 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
   it 'does not register an offense for an arbitrary spec name ' \
      'for an operator method' do
     filename = 'my_little_class/spaceship_operator_spec.rb'
-    expect_no_offenses(<<-RUBY, filename)
+    expect_no_offenses(<<~RUBY, filename)
       describe MyLittleClass, '#<=>' do; end
     RUBY
   end
 
   it 'registers an offense for a path containing the class name' do
-    expect_offense(<<-RUBY, '/home/foo/spec/models/bar_spec.rb')
+    expect_offense(<<~RUBY, '/home/foo/spec/models/bar_spec.rb')
       describe Foo do; end
       ^^^^^^^^^^^^ Spec path should end with `foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for path with incorrect collapsed namespace' do
-    expect_offense(<<-RUBY, '/home/foo/spec/very/my_class_spec.rb')
+    expect_offense(<<~RUBY, '/home/foo/spec/very/my_class_spec.rb')
       describe Very::Long::Namespace::MyClass do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `very/long/namespace/my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense for path with incorrect expanded namespace' do
-    expect_offense(<<-RUBY, '/home/foo/spec/very/long/my_class_spec.rb')
+    expect_offense(<<~RUBY, '/home/foo/spec/very/long/my_class_spec.rb')
       module Very
         module Medium
           describe MyClass do; end
@@ -237,14 +237,14 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     allow(File).to receive(:expand_path).with('my_class_spec.rb').and_return(
       '/home/foo/spec/very/long/namespace/my_class_spec.rb'
     )
-    expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
+    expect_no_offenses(<<~RUBY, 'my_class_spec.rb')
       describe Very::Long::Namespace::MyClass do; end
     RUBY
   end
 
   # RSpec/FilePath runs on all files - not only **/*_spec.rb
   it 'does not register an offense for files defining an empty class' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       class Foo
       end
     RUBY
@@ -288,13 +288,13 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 
     it 'does not register an offense for custom module name transformation' do
-      expect_no_offenses(<<-RUBY, 'foofoo/some/class/bar_spec.rb')
+      expect_no_offenses(<<~RUBY, 'foofoo/some/class/bar_spec.rb')
         describe FooFoo::Some::Class, '#bar' do; end
       RUBY
     end
 
     it 'does not register an offense for routing specs' do
-      expect_no_offenses(<<-RUBY, 'foofoo/some/class/bar_spec.rb')
+      expect_no_offenses(<<~RUBY, 'foofoo/some/class/bar_spec.rb')
         describe MyController, "#foo", type: :routing do; end
       RUBY
     end
@@ -304,7 +304,7 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     let(:cop_config) { { 'IgnoreMethods' => true } }
 
     it 'does not register an offense for the described method' do
-      expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
+      expect_no_offenses(<<~RUBY, 'my_class_spec.rb')
         describe MyClass, '#look_here_a_method' do; end
       RUBY
     end
@@ -314,27 +314,27 @@ RSpec.describe RuboCop::Cop::RSpec::FilePath do
     let(:cop_config) { { 'SpecSuffixOnly' => true } }
 
     it 'does not register an offense for the described class' do
-      expect_no_offenses(<<-RUBY, 'whatever_spec.rb')
+      expect_no_offenses(<<~RUBY, 'whatever_spec.rb')
         describe MyClass do; end
       RUBY
     end
 
     it 'registers an offense when _spec.rb suffix is missing' do
-      expect_offense(<<-RUBY, 'spec/whatever.rb')
+      expect_offense(<<~RUBY, 'spec/whatever.rb')
         describe MyClass do; end
         ^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
       RUBY
     end
 
     it 'registers an offense when a feature file is missing _spec.rb suffix' do
-      expect_offense(<<-RUBY, 'spec/my_feature.rb')
+      expect_offense(<<~RUBY, 'spec/my_feature.rb')
         feature "my feature" do; end
         ^^^^^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
       RUBY
     end
 
     it 'registers an offense when the file extension is not .rb' do
-      expect_offense(<<-RUBY, 'whatever_specxrb')
+      expect_offense(<<~RUBY, 'whatever_specxrb')
         describe MyClass do; end
         ^^^^^^^^^^^^^^^^ Spec path should end with `*_spec.rb`.
       RUBY

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::Focus do
   # rubocop:disable RSpec/ExampleLength
   it 'flags all rspec example blocks with that include `focus: true`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       example 'test', meta: true, focus: true do; end
                                   ^^^^^^^^^^^ Focused spec found.
       xit 'test', meta: true, focus: true do; end
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
                                          ^^^^^^^^^^^ Focused spec found.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       example 'test', meta: true do; end
       xit 'test', meta: true do; end
       describe 'test', meta: true do; end
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'flags all rspec example blocks that include `:focus`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       example_group 'test', :focus do; end
                             ^^^^^^ Focused spec found.
       feature 'test', :focus do; end
@@ -109,7 +109,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
                              ^^^^^^ Focused spec found.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       example_group 'test' do; end
       feature 'test' do; end
       xexample 'test' do; end
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   # rubocop:enable RSpec/ExampleLength
 
   it 'does not flag unfocused specs' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       xcontext      'test' do; end
       xscenario     'test' do; end
       xspecify      'test' do; end
@@ -156,27 +156,27 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'flags a method that is focused twice' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       fit "foo", :focus do
       ^^^^^^^^^^^^^^^^^ Focused spec found.
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it "foo" do
       end
     RUBY
   end
 
   it 'ignores non-rspec code with :focus blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       some_method "foo", focus: true do
       end
     RUBY
   end
 
   it 'flags focused block types' do # rubocop:disable RSpec/ExampleLength
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       fdescribe 'test' do; end
       ^^^^^^^^^^^^^^^^ Focused spec found.
       RSpec.fdescribe 'test' do; end
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       ^^^^^^^^^^^^ Focused spec found.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe 'test' do; end
       RSpec.describe 'test' do; end
       feature 'test' do; end
@@ -211,25 +211,25 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'flags rspec example blocks that include `:focus` preceding a hash' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'test', :focus, js: true do; end
                        ^^^^^^ Focused spec found.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe 'test', js: true do; end
     RUBY
   end
 
   it 'ignores with chained method calls' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       let(:fit) { Tax.federal_income_tax }
       let(:fit_id) { fit.id }
     RUBY
   end
 
   it 'ignores when inside define method' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context 'test' do
         def foo
           fdescribe 'test'
@@ -246,7 +246,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
   end
 
   it 'ignores when inside define singleton method' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       def self.foo
         fdescribe 'test'
         ffeature 'test'

--- a/spec/rubocop/cop/rspec/hook_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/hook_argument_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
 
   shared_examples 'ignored hooks' do
     it 'ignores :context and :suite' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before(:suite) { true }
         after(:suite) { true }
         before(:context) { true }
@@ -16,13 +16,13 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     it 'ignores hooks with more than one argument' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before(:each, :something_custom) { true }
       RUBY
     end
 
     it 'ignores non-rspec hooks' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         setup(:each) { true }
       RUBY
     end
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     let(:enforced_style) { :implicit }
 
     it 'detects :each for hooks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before(:each) { true }
         ^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
         after(:each) { true }
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         ^^^^^^^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before { true }
         after { true }
         around { true }
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     it 'detects :example for hooks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before(:example) { true }
         ^^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
         after(:example) { true }
@@ -70,7 +70,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         ^^^^^^^^^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before { true }
         after { true }
         around { true }
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     it 'does not flag hooks without default scopes' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before { true }
         after { true }
         around { true }
@@ -91,29 +91,29 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
 
     context 'when Ruby 2.7', :ruby27 do
       it 'detects :each for hooks' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           around(:each) { _1 }
           ^^^^^^^^^^^^^ Omit the default `:each` argument for RSpec hooks.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           around { _1 }
         RUBY
       end
 
       it 'detects :example for hooks' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           around(:example) { _1 }
           ^^^^^^^^^^^^^^^^ Omit the default `:example` argument for RSpec hooks.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           around { _1 }
         RUBY
       end
 
       it 'does not flag hooks without default scopes' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           around { _1 }
         RUBY
       end
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     let(:enforced_style) { :each }
 
     it 'does not flag :each for hooks' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before(:each) { true }
         after(:each) { true }
         around(:each) { true }
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     it 'detects :example for hooks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before(:example) { true }
         ^^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
         after(:example) { true }
@@ -144,7 +144,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         ^^^^^^^^^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before(:each) { true }
         after(:each) { true }
         around(:each) { true }
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     it 'detects hooks without default scopes' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before { true }
         ^^^^^^ Use `:each` for RSpec hooks.
         after { true }
@@ -164,7 +164,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
                ^^^^^^ Use `:each` for RSpec hooks.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before(:each) { true }
         after(:each) { true }
         around(:each) { true }
@@ -176,29 +176,29 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
 
     context 'when Ruby 2.7', :ruby27 do
       it 'does not flag :each for hooks' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           around(:each) { _1 }
         RUBY
       end
 
       it 'detects :example for hooks' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           around(:example) { _1 }
           ^^^^^^^^^^^^^^^^ Use `:each` for RSpec hooks.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           around(:each) { _1 }
         RUBY
       end
 
       it 'detects hooks without default scopes' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           around { _1 }
           ^^^^^^ Use `:each` for RSpec hooks.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           around(:each) { _1 }
         RUBY
       end
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     let(:enforced_style) { :example }
 
     it 'does not flag :example for hooks' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before(:example) { true }
         after(:example) { true }
         around(:example) { true }
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     it 'detects :each for hooks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before(:each) { true }
         ^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
         after(:each) { true }
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
         ^^^^^^^^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before(:example) { true }
         after(:example) { true }
         around(:example) { true }
@@ -238,7 +238,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
     end
 
     it 'detects hooks without default scopes' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before { true }
         ^^^^^^ Use `:example` for RSpec hooks.
         after { true }
@@ -249,7 +249,7 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
                ^^^^^^ Use `:example` for RSpec hooks.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before(:example) { true }
         after(:example) { true }
         around(:example) { true }
@@ -261,29 +261,29 @@ RSpec.describe RuboCop::Cop::RSpec::HookArgument do
 
     context 'when Ruby 2.7', :ruby27 do
       it 'does not flag :example for hooks' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           around(:example) { _1 }
         RUBY
       end
 
       it 'detects :each for hooks' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           around(:each) { _1 }
           ^^^^^^^^^^^^^ Use `:example` for RSpec hooks.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           around(:example) { _1 }
         RUBY
       end
 
       it 'detects hooks without default scopes' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           around { _1 }
           ^^^^^^ Use `:example` for RSpec hooks.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           around(:example) { _1 }
         RUBY
       end

--- a/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/hooks_before_examples_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   it 'flags `before` after `it`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it { is_expected.to be_after_before_hook }
         before { setup }
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         before { setup }
         it { is_expected.to be_after_before_hook }
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'flags `before` after `context`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         context 'a context' do
           it { is_expected.to be_after_before_hook }
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         before { setup }
         context 'a context' do
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'flags `before` after `include_examples`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         include_examples('should be after before-hook')
 
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         before { setup }
         include_examples('should be after before-hook')
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'flags `after` after an example' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it { is_expected.to be_after_after_hook }
         after { cleanup }
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         after { cleanup }
         it { is_expected.to be_after_after_hook }
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'flags scoped hook after an example' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it { is_expected.to be_after_before_hook }
         before(:each) { cleanup }
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         before(:each) { cleanup }
         it { is_expected.to be_after_before_hook }
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'works with comments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it { is_expected.to be_after_before_hook } # h
         # setup the system
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         # setup the system
         # with multiline comment
@@ -116,7 +116,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'does not flag hooks before the examples' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         before(:each) { setup }
         after(:each) { cleanup }
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'does not flag `before` in a nested context' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         before { setup }
 
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'allows inclusion of context before hooks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         include_context 'special user'
 
@@ -158,7 +158,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
   end
 
   it 'ignores single-line example blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         include_examples 'special user' do
           before { setup }
@@ -169,7 +169,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
 
   context 'when Ruby 2.7', :ruby27 do
     it 'flags `around` after `it`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           it { is_expected.to be_after_around_hook }
           around { _1 }
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           around { _1 }
           it { is_expected.to be_after_around_hook }
@@ -186,7 +186,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
     end
 
     it 'flags `around` after `context`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           context 'a context' do
             it { is_expected.to be_after_around_hook }
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           around { _1 }
           context 'a context' do
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
     end
 
     it 'flags `around` after `include_examples`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           include_examples('should be after around-hook')
 
@@ -218,7 +218,7 @@ RSpec.describe RuboCop::Cop::RSpec::HooksBeforeExamples do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         RSpec.describe User do
           around { _1 }
           include_examples('should be after around-hook')

--- a/spec/rubocop/cop/rspec/implicit_block_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_block_expectation_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   it 'flags lambda in subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject { -> { boom } }
         it { is_expected.to change { something }.to(new_value) }
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'ignores non-lambda subject' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe do
         subject { 'normal' }
         it { is_expected.to eq(something) }
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'flags lambda in subject!' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject! { -> { boom } }
         it { is_expected.to change { something }.to(new_value) }
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'flags literal lambda' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject! { lambda { boom } }
         it { is_expected.to change { something }.to(new_value) }
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'flags proc' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject! { proc { boom } }
         it { is_expected.to change { something }.to(new_value) }
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'flags Proc.new' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject! { Proc.new { boom } }
         it { is_expected.to change { something }.to(new_value) }
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'flags named subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject(:name) { -> { boom } }
         it { is_expected.to change { something }.to(new_value) }
@@ -71,7 +71,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'flags when subject is defined in the outer example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject { -> { boom } }
         context do
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'ignores normal local subject' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe do
         subject { -> { boom } }
         context do
@@ -95,7 +95,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'ignores named subject with deeply nested lambda' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe do
         subject { {hash: -> { boom }} }
         it { is_expected.to be(something) }
@@ -104,7 +104,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'flags with `should` as implicit subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject { -> { boom } }
         it { should change { something }.to(new_value) }
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'flags with `should_not` as implicit subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
         subject { -> { boom } }
         it { should_not change { something }.to(new_value) }
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitBlockExpectation do
   end
 
   it 'ignores when there is no subject defined' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       shared_examples 'subject is defined somewhere else' do
         it { is_expected.to change { something }.to(new_value) }
       end

--- a/spec/rubocop/cop/rspec/implicit_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_expect_spec.rb
@@ -7,23 +7,23 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect do
     end
 
     it 'flags it { should }' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { should be_truthy }
              ^^^^^^ Prefer `is_expected.to` over `should`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to be_truthy }
       RUBY
     end
 
     it 'flags it { should_not }' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { should_not be_truthy }
              ^^^^^^^^^^ Prefer `is_expected.to_not` over `should_not`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to_not be_truthy }
       RUBY
     end
@@ -49,34 +49,34 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect do
     end
 
     it 'flags it { is_expected.to }' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to be_truthy }
              ^^^^^^^^^^^^^^ Prefer `should` over `is_expected.to`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { should be_truthy }
       RUBY
     end
 
     it 'flags it { is_expected.to_not }' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to_not be_truthy }
              ^^^^^^^^^^^^^^^^^^ Prefer `should_not` over `is_expected.to_not`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { should_not be_truthy }
       RUBY
     end
 
     it 'flags it { is_expected.not_to }' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.not_to be_truthy }
              ^^^^^^^^^^^^^^^^^^ Prefer `should_not` over `is_expected.not_to`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { should_not be_truthy }
       RUBY
     end

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     let(:enforced_style) { 'single_line_only' }
 
     it 'flags `is_expected` in multi-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'expect subject to be used' do
           is_expected.to be_good
           ^^^^^^^^^^^ Don't use implicit subject.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'expect subject to be used' do
           expect(subject).to be_good
         end
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     end
 
     it 'allows `is_expected` inside `its` block, in multi-line examples' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         its(:quality) do
           is_expected.to be :high
         end
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     end
 
     it 'flags `should` in multi-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'expect subject to be used' do
           should be_good
           ^^^^^^^^^^^^^^ Don't use implicit subject.
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'expect subject to be used' do
           expect(subject).to be_good
           expect(subject).not_to be_bad
@@ -50,19 +50,19 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     end
 
     it 'allows `is_expected` in single-line examples' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to be_good }
       RUBY
     end
 
     it 'allows `should` in single-line examples' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { should be_good }
       RUBY
     end
 
     it 'does not flag methods called is_expected and should' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'uses some similar sounding methods' do
           expect(baz).to receive(:is_expected)
           baz.is_expected
@@ -72,14 +72,14 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     end
 
     it 'detects usage of `is_expected` inside helper methods' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         def permits(actions)
           actions.each { |action| is_expected.to permit_action(action) }
                                   ^^^^^^^^^^^ Don't use implicit subject.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         def permits(actions)
           actions.each { |action| expect(subject).to permit_action(action) }
         end
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     let(:enforced_style) { 'single_statement_only' }
 
     it 'allows `is_expected` in multi-line example with single statement' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'expect subject to be used' do
           is_expected.to be_good
         end
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     end
 
     it 'flags `is_expected` in multi-statement examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'expect subject to be used' do
           subject.age = 18
           is_expected.to be_valid
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'expect subject to be used' do
           subject.age = 18
           expect(subject).to be_valid
@@ -120,14 +120,14 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     let(:enforced_style) { 'disallow' }
 
     it 'flags `is_expected` in multi-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'expect subject to be used' do
           is_expected.to be_good
           ^^^^^^^^^^^ Don't use implicit subject.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'expect subject to be used' do
           expect(subject).to be_good
         end
@@ -135,18 +135,18 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     end
 
     it 'flags `is_expected` in single-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to be_good }
              ^^^^^^^^^^^ Don't use implicit subject.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { expect(subject).to be_good }
       RUBY
     end
 
     it 'flags `should` in multi-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'expect subject to be used' do
           should be_good
           ^^^^^^^^^^^^^^ Don't use implicit subject.
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it 'expect subject to be used' do
           expect(subject).to be_good
           expect(subject).not_to be_bad
@@ -164,21 +164,21 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
     end
 
     it 'flags `should` in single-line examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { should be_good }
              ^^^^^^^^^^^^^^ Don't use implicit subject.
         it { should_not be_bad }
              ^^^^^^^^^^^^^^^^^ Don't use implicit subject.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { expect(subject).to be_good }
         it { expect(subject).not_to be_bad }
       RUBY
     end
 
     it 'allows `is_expected` inside `its` block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         its(:quality) { is_expected.to be :high }
       RUBY
     end
@@ -189,7 +189,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
 
     context 'with `is_expected`' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           it { is_expected.to be_good }
         RUBY
       end
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
 
     context 'with `expect { subject }`' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           it { expect { subject }.to change(goodness, :count) }
         RUBY
       end
@@ -205,7 +205,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
 
     context 'with `its`' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           its(:quality) { is_expected.to be(:high) }
         RUBY
       end
@@ -213,7 +213,7 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
 
     context 'with named subject' do
       it 'does not register an offense' do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           subject(:instance) { described_class.new }
 
           it { expect(instance).to be_good }
@@ -223,12 +223,12 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
 
     context 'with `expect(subject)` in one-line' do
       it 'registers and autocorrects an offense' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it { expect(subject).to be_good }
                ^^^^^^^^^^^^^^^ Don't use explicit subject.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           it { is_expected.to be_good }
         RUBY
       end
@@ -236,14 +236,14 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
 
     context 'with `expect(subject)` in multi-lines' do
       it 'registers and autocorrects an offense' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it do
             expect(subject).to be_good
             ^^^^^^^^^^^^^^^ Don't use explicit subject.
           end
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           it do
             is_expected.to be_good
           end

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
         it do
           foo = instance_double(Foo)
           expect(bar).to have_received(:bar)
-       end
+        end
       RUBY
     end
   end

--- a/spec/rubocop/cop/rspec/instance_spy_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_spy_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
   context 'when used with `have_received`' do
     it 'adds an offense for an instance_double with single argument' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           foo = instance_double(Foo).as_null_object
                 ^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`.
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           foo = instance_spy(Foo)
           expect(foo).to have_received(:bar)
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
     end
 
     it 'adds an offense for an instance_double with multiple arguments' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           foo = instance_double(Foo, :name).as_null_object
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `instance_spy` when you check your double with `have_received`.
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           foo = instance_spy(Foo, :name)
           expect(foo).to have_received(:bar)
@@ -37,7 +37,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
     end
 
     it 'ignores instance_double when it is not used with as_null_object' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           foo = instance_double(Foo)
           expect(bar).to have_received(:bar)
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceSpy do
 
   context 'when not used with `have_received`' do
     it 'does not add an offense' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           foo = instance_double(Foo).as_null_object
           expect(bar).to have_received(:bar)

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   it 'flags an instance variable inside a describe' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe MyClass do
         before { @foo = [] }
         it { expect(@foo).to be_empty }
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'ignores non-spec blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       not_rspec do
         before { @foo = [] }
         it { expect(@foo).to be_empty }
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'flags an instance variable inside a shared example' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       shared_examples 'shared example' do
         it { expect(@foo).to be_empty }
                     ^^^^ Avoid instance variables - use let, a method call, or a local variable (if possible).
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'flags several instance variables inside a describe' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe MyClass do
         before { @foo = [] }
         it { expect(@foo).to be_empty }
@@ -42,14 +42,14 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   it 'ignores an instance variable without describe' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       @foo = []
       @foo.empty?
     RUBY
   end
 
   it 'ignores an instance variable inside a dynamic class' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe MyClass do
         let(:object) do
           Class.new(OtherClass) do
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
 
   # Regression test for nevir/rubocop-rspec#115
   it 'ignores instance variables outside of specs' do
-    expect_no_offenses(<<-RUBY, 'lib/source_code.rb')
+    expect_no_offenses(<<~RUBY, 'lib/source_code.rb')
       feature do
         @foo = bar
 
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     end
 
     it 'flags an instance variable when it is also assigned' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           before { @foo = [] }
           it { expect(@foo).to be_empty }
@@ -144,7 +144,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     end
 
     it 'ignores an instance variable when it is not assigned' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyClass do
           it { expect(@foo).to be_empty }
         end
@@ -153,7 +153,7 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
 
     it 'flags an instance variable when it is also assigned ' \
        'in a sibling example group' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           context 'foo' do
             before { @foo = [] }

--- a/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
+++ b/spec/rubocop/cop/rspec/it_behaves_like_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike do
     let(:enforced_style) { :it_behaves_like }
 
     it 'flags an offense for it_should_behave_like' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it_should_behave_like 'a foo'
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `it_behaves_like` over `it_should_behave_like` when including examples in a nested context.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it_behaves_like 'a foo'
       RUBY
     end
@@ -28,12 +28,12 @@ RSpec.describe RuboCop::Cop::RSpec::ItBehavesLike do
     let(:enforced_style) { :it_should_behave_like }
 
     it 'flags an offense for it_behaves_like' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it_behaves_like 'a foo'
         ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `it_should_behave_like` over `it_behaves_like` when including examples in a nested context.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it_should_behave_like 'a foo'
       RUBY
     end

--- a/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/iterated_expectation_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   it 'flags `each` with an expectation' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| expect(user).to be_valid }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'flags `each` when expectation calls method with arguments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| expect(user).to be_a(User) }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores `each` without expectation' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| allow(user).to receive(:method) }
       end
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores `each` with unused variable' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |_user| do_something }
       end
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'flags `each` with multiple expectations' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each do |user|
         ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -48,7 +48,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignore `each` when the body does not contain only expectations' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each do |user|
           allow(Something).to receive(:method).and_return(user)
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores `each` with expectation on property' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| expect(user.name).to be }
       end
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores assignments in the iteration' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each { |user| array = array.concat(user) }
       end
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
   end
 
   it 'ignores `each` when there is a negative expectation' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'validates users' do
         [user1, user2, user3].each do |user|
           expect(user).not_to receive(:method)
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
 
   context 'when Ruby 2.7', :ruby27 do
     it 'flags `each` with an expectation' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'validates users' do
           [user1, user2, user3].each { expect(_1).to be_valid }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
     end
 
     it 'flags `each` when expectation calls method with arguments' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'validates users' do
           [user1, user2, user3].each { expect(_1).to be_a(User) }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
     end
 
     it 'ignores `each` without expectation' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'validates users' do
           [user1, user2, user3].each { allow(_1).to receive(:method) }
         end
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
     end
 
     it 'flags `each` with multiple expectations' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it 'validates users' do
           [user1, user2, user3].each do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using the `all` matcher instead of iterating over an array.
@@ -126,7 +126,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
     end
 
     it 'ignore `each` when the body does not contain only expectations' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'validates users' do
           [user1, user2, user3].each do
             allow(Something).to receive(:method).and_return(_1)
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
     end
 
     it 'ignores `each` with expectation on property' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'validates users' do
           [user1, user2, user3].each { expect(_1.name).to be }
         end
@@ -146,7 +146,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
     end
 
     it 'ignores assignments in the iteration' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'validates users' do
           [user1, user2, user3].each { array = array.concat(_1) }
         end
@@ -154,7 +154,7 @@ RSpec.describe RuboCop::Cop::RSpec::IteratedExpectation do
     end
 
     it 'ignores `each` when there is a negative expectation' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it 'validates users' do
           [user1, user2, user3].each do
             expect(_1).not_to receive(:method)

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   it 'registers an offense for subject below let' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:params) { foo }
 
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         let(:params) { foo }
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below let!' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let!(:params) { foo }
 
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         let!(:params) { foo }
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below let with proc argument' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:user, &args[:build_user])
 
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         let(:user, &args[:build_user])
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'does not register an offense for subject above let' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
 
@@ -72,7 +72,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'does not register an offense for subjects in contexts' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:params) { foo }
 
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'does not register an offense for subjects in tests' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         # This shouldn't really ever happen in a sane codebase but I still
         # want to avoid false positives
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below hook' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         before { allow(Foo).to receive(:bar) }
 
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         before { allow(Foo).to receive(:bar) }
@@ -116,7 +116,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below example' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it { is_expected.to be_present }
 
@@ -125,7 +125,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         it { is_expected.to be_present }
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         describe do
           it { is_expected.to be_present }
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         describe do
@@ -183,7 +183,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below shared example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         shared_examples_for 'used later' do
           it { is_expected.to be_present }
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         shared_examples_for 'used later' do
@@ -206,7 +206,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below include' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it_behaves_like 'a good citizen'
 
@@ -215,7 +215,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         it_behaves_like 'a good citizen'
@@ -225,7 +225,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below include with a block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it_behaves_like 'a good citizen' do
           let(:used_in_shared_examples) { 'something' }
@@ -236,7 +236,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         subject { described_class.new }
         it_behaves_like 'a good citizen' do
@@ -248,7 +248,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'registers an offense for subject below include with a blockpass' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         block = ->{ }
         it_behaves_like 'a good citizen', &block
@@ -258,7 +258,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         block = ->{ }
         subject { described_class.new }
@@ -269,7 +269,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'does not register an offense for subject nested inside a block' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:foo) { 'bar' }
 
@@ -281,7 +281,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
   end
 
   it 'does not register an offense for subject in arbitrary code' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       module Support
         subject do
           test

--- a/spec/rubocop/cop/rspec/leaky_constant_declaration_spec.rb
+++ b/spec/rubocop/cop/rspec/leaky_constant_declaration_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
   describe 'constant assignment' do
     it 'flags inside an example group' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe SomeClass do
           CONSTANT = "Accessible as ::CONSTANT".freeze
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Stub constant instead of declaring explicitly.
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
     end
 
     it 'flags inside shared example group' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.shared_examples 'shared example' do
           CONSTANT = "Accessible as ::CONSTANT".freeze
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Stub constant instead of declaring explicitly.
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
     end
 
     it 'flags inside an example' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe SomeClass do
           specify do
             CONSTANT = "Accessible as ::CONSTANT".freeze
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
     end
 
     it 'ignores outside of example/shared group' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         factory :some_class do
           CONSTANT = "Accessible as ::CONSTANT".freeze
         end
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
 
   describe 'class defined' do
     it 'flags inside an example group' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe SomeClass do
           class DummyClass < described_class
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Stub class constant instead of declaring explicitly.
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
     end
 
     it 'ignores anonymous classes' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe SomeClass do
           let(:dummy_playbook) do
             Class.new do
@@ -65,7 +65,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
     end
 
     it 'flags namespaced class' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe SomeClass do
           class SomeModule::AnotherModule::DummyClass
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Stub class constant instead of declaring explicitly.
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::RSpec::LeakyConstantDeclaration do
 
   describe 'module defined' do
     it 'flags inside an example group' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe SomeClass do
           module DummyModule
           ^^^^^^^^^^^^^^^^^^ Stub module constant instead of declaring explicitly.

--- a/spec/rubocop/cop/rspec/let_before_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/let_before_examples_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   it 'flags `let` after `it`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it { is_expected.to be_after_let }
         let(:foo) { bar }
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:foo) { bar }
         it { is_expected.to be_after_let }
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   end
 
   it 'flags `let` after `context`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         context 'a context' do
           it { is_expected.to be_after_let }
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:foo) { bar }
         context 'a context' do
@@ -45,7 +45,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
     # NOTE: include_examples may define the same variable as `let`,
     # and changing the order may break the spec due to order dependency
     # if `let` is moved above.
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         include_examples('should be BEFORE let as it defines `let(:foo)`, too')
 
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   end
 
   it 'flags `let` after `it_behaves_like`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it_behaves_like('should be after let')
 
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:foo) { bar }
         it_behaves_like('should be after let')
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   end
 
   it 'flags `let` with proc argument' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it_behaves_like('should be after let')
 
@@ -86,7 +86,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:user, &args[:build_user])
         it_behaves_like('should be after let')
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   end
 
   it 'flags `let` with a heredoc argument' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         it_behaves_like('should be after let')
 
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:foo) { (<<-SOURCE) }
         some long text here
@@ -119,7 +119,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   end
 
   it 'does not flag `let` before the examples' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:foo) { bar }
 
@@ -135,7 +135,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   end
 
   it 'does not flag `let` in a nested context' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:foo) { bar }
 
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   end
 
   it 'allows inclusion of context before `let`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         include_context 'special user'
 
@@ -160,7 +160,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetBeforeExamples do
   end
 
   it 'ignores single-line example blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         it_behaves_like 'special user' do
           let(:foo) { bar }

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   it 'complains when let! is used and not referenced' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         let!(:foo) { bar }
         ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'ignores let! when used in `before`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         let!(:foo) { bar }
 
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'ignores let! when used in example' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         let!(:foo) { bar }
 
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'complains when let! is used and not referenced within nested group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         context 'when something special happens' do
           let!(:foo) { bar }
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'complains when let! is used and not referenced in shared example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       shared_context 'foo' do
         let!(:bar) { baz }
         ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'complains when let! used in shared example including' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it_behaves_like 'bar' do
           let!(:baz) { foobar }
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'complains when there is only one nested node into example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         let!(:bar) { baz }
         ^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'flags unused helpers defined as strings' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         let!('bar') { baz }
         ^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'ignores used helpers defined as strings' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         let!('bar') { baz }
         it { expect(bar).to be_near }
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'flags blockpass' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       shared_context Foo do |&block|
         let!(:bar, &block)
         ^^^^^^^^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
   end
 
   it 'complains when there is a custom nesting level' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         [].each do |i|
           let!(:bar) { i }

--- a/spec/rubocop/cop/rspec/match_array_spec.rb
+++ b/spec/rubocop/cop/rspec/match_array_spec.rb
@@ -2,41 +2,41 @@
 
 RSpec.describe RuboCop::Cop::RSpec::MatchArray do
   it 'flags `match_array` with array literal arguments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { is_expected.to match_array([content1, content2]) }
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `contain_exactly` when matching an array literal.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { is_expected.to contain_exactly(content1, content2) }
     RUBY
   end
 
   it 'flags `match_array` with array literal arguments including a splat' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it { is_expected.to match_array([*content1, content2]) }
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `contain_exactly` when matching an array literal.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it { is_expected.to contain_exactly(*content1, content2) }
     RUBY
   end
 
   it 'does not flag `contain_exactly`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { is_expected.to contain_exactly(content1, content2) }
     RUBY
   end
 
   it 'does not flag `match_array` with mixed arguments' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { is_expected.to match_array([content] + array) }
     RUBY
   end
 
   it 'does not flag `match_array` with a percent array' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { is_expected.to match_array(%w(tremble in fear foolish mortals)) }
       it { is_expected.to match_array(%i(foo bar baz)) }
     RUBY
@@ -44,13 +44,13 @@ RSpec.describe RuboCop::Cop::RSpec::MatchArray do
 
   # Don't do the work of RSpec/BeEmpty
   it 'does not flag `match_array` with an empty array literal' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { is_expected.to match_array([]) }
     RUBY
   end
 
   it 'does not flag `match_array` with no argument' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it { is_expected.to match_array }
       it { is_expected.to match_array() }
     RUBY

--- a/spec/rubocop/cop/rspec/message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/message_chain_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::MessageChain do
   it 'finds `receive_message_chain`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before do
         allow(foo).to receive_message_chain(:one, :two) { :three }
                       ^^^^^^^^^^^^^^^^^^^^^ Avoid stubbing using `receive_message_chain`.
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::MessageChain do
   end
 
   it 'finds old `stub_chain` syntax' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before do
         foo.stub_chain(:one, :two).and_return(:three)
             ^^^^^^^^^^ Avoid stubbing using `stub_chain`.

--- a/spec/rubocop/cop/rspec/message_expectation_spec.rb
+++ b/spec/rubocop/cop/rspec/message_expectation_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RuboCop::Cop::RSpec::MessageExpectation do
     end
 
     it 'flags expect(...).to receive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to receive(:bar)
         ^^^^^^ Prefer `allow` for setting message expectations.
       RUBY
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::RSpec::MessageExpectation do
     end
 
     it 'flags allow(...).to receive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         allow(foo).to receive(:bar)
         ^^^^^ Prefer `expect` for setting message expectations.
       RUBY

--- a/spec/rubocop/cop/rspec/message_spies_spec.rb
+++ b/spec/rubocop/cop/rspec/message_spies_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe RuboCop::Cop::RSpec::MessageSpies do
     end
 
     it 'flags expect(send).to receive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to receive(:bar)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(lvar).to receive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         foo = baz
         expect(foo).to receive(:bar)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
@@ -22,42 +22,42 @@ RSpec.describe RuboCop::Cop::RSpec::MessageSpies do
     end
 
     it 'flags expect(ivar).to receive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(@foo).to receive(:bar)
                         ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `@foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(const).to receive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(Foo).to receive(:bar)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `Foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(...).not_to receive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).not_to receive(:bar)
                            ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(...).to_not receive' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to_not receive(:bar)
                            ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(...).to receive with' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to receive(:bar).with(:baz)
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
     end
 
     it 'flags expect(...).to receive at_most' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to receive(:bar).at_most(42).times
                        ^^^^^^^ Prefer `have_received` for setting message expectations. Setup `foo` as a spy using `allow` or `instance_spy`.
       RUBY
@@ -80,14 +80,14 @@ RSpec.describe RuboCop::Cop::RSpec::MessageSpies do
     end
 
     it 'flags expect(send).to have_received' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to have_received(:bar)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(lvar).to have_received' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         foo = baz
         expect(foo).to have_received(:bar)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
@@ -95,42 +95,42 @@ RSpec.describe RuboCop::Cop::RSpec::MessageSpies do
     end
 
     it 'flags expect(ivar).to have_received' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(@foo).to have_received(:bar)
                         ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(const).to have_received' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(Foo).to have_received(:bar)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(...).not_to have_received' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).not_to have_received(:bar)
                            ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(...).to_not have_received' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to_not have_received(:bar)
                            ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(...).to have_received with' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to have_received(:bar).with(:baz)
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY
     end
 
     it 'flags expect(...).to have_received at_most' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect(foo).to have_received(:bar).at_most(42).times
                        ^^^^^^^^^^^^^ Prefer `receive` for setting message expectations.
       RUBY

--- a/spec/rubocop/cop/rspec/missing_example_group_argument_spec.rb
+++ b/spec/rubocop/cop/rspec/missing_example_group_argument_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::MissingExampleGroupArgument do
   it 'accepts describe with an argument' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe FooClass do
       end
 
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::MissingExampleGroupArgument do
   end
 
   it 'accepts methods with a name like an example block' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       Scenario.context do
         'static'
       end
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::MissingExampleGroupArgument do
   end
 
   it 'checks first argument of describe' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe do
       ^^^^^^^^^^^ The first argument to `describe` should not be empty.
       end
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::MissingExampleGroupArgument do
   end
 
   it 'checks first argument of nested describe' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe FooClass do
         describe do
         ^^^^^^^^^^^ The first argument to `describe` should not be empty.
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::MissingExampleGroupArgument do
   end
 
   it 'checks first argument of context' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context do
       ^^^^^^^^^^ The first argument to `context` should not be empty.
       end

--- a/spec/rubocop/cop/rspec/multiple_describes_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_describes_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   it 'flags multiple top-level example groups with class and method' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe MyClass, '.do_something' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use multiple top-level example groups - try to nest them.
       describe MyClass, '.do_something_else' do; end
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   end
 
   it 'flags multiple top-level example groups only with class' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe MyClass do; end
       ^^^^^^^^^^^^^^^^ Do not use multiple top-level example groups - try to nest them.
       describe MyOtherClass do; end
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   end
 
   it 'flags multiple top-level example groups with an arbitrary argument' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'MyClass' do; end
       ^^^^^^^^^^^^^^^^^^ Do not use multiple top-level example groups - try to nest them.
       describe 'MyOtherClass' do; end
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   end
 
   it 'flags multiple top-level example groups aliases' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       example_group MyClass do; end
       ^^^^^^^^^^^^^^^^^^^^^ Do not use multiple top-level example groups - try to nest them.
       feature MyOtherClass do; end
@@ -34,14 +34,14 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleDescribes do
   end
 
   it 'ignores single top-level example group' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe MyClass do
       end
     RUBY
   end
 
   it 'ignores multiple shared example groups' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       shared_examples_for 'behaves' do
       end
       shared_examples_for 'misbehaves' do

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     let(:cop_config) { {} }
 
     it 'flags multiple expectations' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect twice' do
           ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -17,7 +17,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'approves of one expectation per example' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Foo do
           it 'does something neat' do
             expect(neat).to be(true)
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'flags multiple expect_any_instance_of' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect_any_instance_of twice' do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -43,7 +43,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'flags multiple is_expected' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect_any_instance_of twice' do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'flags multiple expects with blocks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect with block twice' do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'counts aggregate_failures as one expectation' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Foo do
           it 'aggregates failures' do
             aggregate_failures do
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'counts every aggregate_failures as an expectation' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo do
           it 'has multiple aggregate_failures calls' do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
 
   context 'with metadata' do
     it 'ignores examples with `:aggregate_failures`' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Foo do
           it 'uses expect twice', :foo, :aggregate_failures do
             expect(foo).to eq(bar)
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'ignores example groups with `:aggregate_failures`' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Foo, :foo, :aggregate_failures do
           it 'uses expect twice' do
             expect(foo).to eq(bar)
@@ -118,7 +118,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'ignores examples with `aggregate_failures: true`' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Foo do
           it 'uses expect twice', :foo, bar: 1, aggregate_failures: true do
             expect(foo).to eq(bar)
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'ignores example groups with `aggregate_failures: true`' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Foo, :foo, bar: 1, aggregate_failures: true do
           it 'uses expect twice' do
             expect(foo).to eq(bar)
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'prefers example metadata over example group metadata' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo, aggregate_failures: true do
           it 'uses expect twice', aggregate_failures: false do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -152,7 +152,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'checks examples with `aggregate_failures: false`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect twice', aggregate_failures: false do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -164,7 +164,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'checks example groups with `aggregate_failures: false`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo, aggregate_failures: false do
           it 'uses expect twice' do
           ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -176,7 +176,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'checks examples with siblings with `aggregate_failures: true`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect twice' do
           ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
@@ -192,7 +192,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'ignores examples with `aggregate_failures: true` defined deeply' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Bar, aggregate_failures: true do
           describe Foo do
             it 'uses expect twice' do
@@ -214,7 +214,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'permits two expectations' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe Foo do
           it 'uses expect twice' do
             expect(foo).to eq(bar)
@@ -225,7 +225,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
 
     it 'flags three expectations' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect three times' do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [3/2].
@@ -239,7 +239,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
   end
 
   it 'generates a todo based on the worst offense' do
-    inspect_source(<<-RUBY, 'spec/foo_spec.rb')
+    inspect_source(<<~RUBY, 'spec/foo_spec.rb')
       describe Foo do
         it 'uses expect twice' do
           expect(foo).to eq(bar)

--- a/spec/rubocop/cop/rspec/multiple_memoized_helpers_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_memoized_helpers_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleMemoizedHelpers do
   end
 
   it 'support --auto-gen-config' do
-    inspect_source(<<-RUBY, 'spec/foo_spec.rb')
+    inspect_source(<<~RUBY, 'spec/foo_spec.rb')
       describe Foo do
         let(:foo) { Foo.new }
         let(:bar) { Bar.new }

--- a/spec/rubocop/cop/rspec/multiple_subjects_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_subjects_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
   it 'registers an offense for every overwritten subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'hello there' do
         subject(:foo) { 1 }
         ^^^^^^^^^^^^^^^^^^^ Do not set more than one subject per example group
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe 'hello there' do
         let(:foo) { 1 }
         let(:bar) { 2 }
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
   end
 
   it 'does not try to autocorrect subject!' do
-    source = <<-RUBY
+    source = <<~RUBY
       describe Foo do
         subject! { a }
         ^^^^^^^^^^^^^^ Do not set more than one subject per example group
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
   end
 
   it 'does not flag shared example groups' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         it_behaves_like 'user' do
           subject { described_class.new(user, described_class) }
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
   end
 
   it 'autocorrects' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'hello there' do
         subject { 1 }
         ^^^^^^^^^^^^^ Do not set more than one subject per example group
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe 'hello there' do
         subject { 3 }
       end

--- a/spec/rubocop/cop/rspec/named_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/named_subject_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
   shared_examples_for 'checking subject outside of shared examples' do
     it 'checks `it` and `specify` for explicit subject usage' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           subject { described_class.new }
 
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     end
 
     it 'checks before and after for explicit subject usage' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           subject { described_class.new }
 
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     end
 
     it 'checks around(:each) for explicit subject usage' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           subject { described_class.new }
 
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     end
 
     it 'ignores subject when not wrapped inside a test' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         def foo
           it(subject)
         end
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     let(:cop_config) { { 'EnforcedStyle' => :named_only } }
 
     it 'ignores subject where declaration is not named' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           subject { described_class.new }
 
@@ -80,7 +80,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     end
 
     it 'ignores subject! where declaration is not named' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           subject! { described_class.new }
 
@@ -96,7 +96,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     end
 
     it 'checks subject where declaration is named' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           subject(:new_user) { described_class.new }
 
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     end
 
     it 'checks subject! where declaration is named' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           subject!(:new_user) { described_class.new }
 
@@ -132,7 +132,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     end
 
     it 'ignores subject where the closest declaration is not named' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           subject(:user) { described_class.new }
 
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     end
 
     it 'ignores subject when block has no body' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it "is a User" do
           subject.each do
             # empty body
@@ -171,7 +171,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     it_behaves_like 'checking subject outside of shared examples'
 
     it 'checks shared_examples for explicit subject usage' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         RSpec.describe User do
           subject(:new_user) { described_class.new }
 
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Cop::RSpec::NamedSubject do
     it_behaves_like 'checking subject outside of shared examples'
 
     it 'ignores explicit subject in shared_examples' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         RSpec.describe User do
           subject(:new_user) { described_class.new }
 

--- a/spec/rubocop/cop/rspec/nested_groups_spec.rb
+++ b/spec/rubocop/cop/rspec/nested_groups_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
   it 'flags nested example groups defined inside `describe`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe MyClass do
         context 'when foo' do
           context 'when bar' do
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
   end
 
   it 'flags nested example groups' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       example_group MyClass do
         context 'when foo' do
           context 'when bar' do
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
   end
 
   it 'flags nested example groups inside shared examples' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       shared_examples_for 'nested like express' do
         context 'when foo' do
           context 'when bar' do
@@ -51,7 +51,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
   end
 
   it 'support --auto-gen-config' do
-    inspect_source(<<-RUBY, 'spec/foo_spec.rb')
+    inspect_source(<<~RUBY, 'spec/foo_spec.rb')
       describe MyClass do
         context 'when foo' do
           context 'when bar' do
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
   end
 
   it 'flags example groups wrapped in classes' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       class MyThingy
         describe MyClass do
           context 'when foo' do
@@ -82,7 +82,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
   end
 
   it 'flags example groups wrapped in modules' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       module MyNamespace
         describe MyClass do
           context 'when foo' do
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
     let(:cop_config) { { 'Max' => '2' } }
 
     it 'flags two levels of nesting' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           context 'when foo' do
             context 'when bar' do
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
   end
 
   it 'counts nesting correctly when non-spec nesting' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe MyClass do
         context 'when foo' do
           context 'when bar' do
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
 
     it 'accept nested example groups defined inside `describe`' \
        'path is not counted' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         describe MyClass do
           path '/users' do
             context 'when foo' do
@@ -169,7 +169,7 @@ RSpec.describe RuboCop::Cop::RSpec::NestedGroups do
 
     it 'flags nested example groups defined inside `describe`' \
        'path is not counted but exceeded max' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         describe MyClass do
           path '/users' do
             context 'when foo' do

--- a/spec/rubocop/cop/rspec/not_to_not_spec.rb
+++ b/spec/rubocop/cop/rspec/not_to_not_spec.rb
@@ -5,25 +5,25 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot do
     let(:cop_config) { { 'EnforcedStyle' => 'not_to' } }
 
     it 'detects the `to_not` offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { expect(false).to_not be_true }
                            ^^^^^^ Prefer `not_to` over `to_not`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { expect(false).not_to be_true }
       RUBY
     end
 
     it 'detects the `to_not` offense on an expect block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect {
           2 + 2
         }.to_not raise_error
           ^^^^^^ Prefer `not_to` over `to_not`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         expect {
           2 + 2
         }.not_to raise_error
@@ -31,7 +31,7 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot do
     end
 
     it 'detects no offense when using `not_to`' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { expect(false).not_to be_true }
       RUBY
     end
@@ -41,25 +41,25 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot do
     let(:cop_config) { { 'EnforcedStyle' => 'to_not' } }
 
     it 'detects the `not_to` offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { expect(false).not_to be_true }
                            ^^^^^^ Prefer `to_not` over `not_to`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { expect(false).to_not be_true }
       RUBY
     end
 
     it 'detects the `not_to` offense on an expect block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect {
           2 + 2
         }.not_to raise_error
           ^^^^^^ Prefer `to_not` over `not_to`.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         expect {
           2 + 2
         }.to_not raise_error
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::RSpec::NotToNot do
     end
 
     it 'detects no offense when using `to_not`' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { expect(false).to_not be_true }
       RUBY
     end

--- a/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/overwriting_setup_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   it 'registers an offense for overwritten `let`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:a) { b }
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'registers an offense for overwritten `subject`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         subject(:a) { a }
 
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'registers an offense for `subject!` and `let!`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         subject!(:a) { a }
 
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'registers an offense for `let!` overwriting `let`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { b }
         let!(:a) { b }
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'does not register an offense for overwriting in different context' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
 
@@ -56,7 +56,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'registers an offense for overriding an unnamed subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         subject { a }
 
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'does not register an offense for dynamic names for `let`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe User do
         subject(:name) { a }
 
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::RSpec::OverwritingSetup do
   end
 
   it 'registers an offense for string arguments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         subject(:name) { a }
 

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -2,14 +2,14 @@
 
 RSpec.describe RuboCop::Cop::RSpec::Pending do
   it 'flags it without body' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'test'
       ^^^^^^^^^ Pending spec found.
     RUBY
   end
 
   it 'flags it without body inside describe block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'test' do
         it 'test'
         ^^^^^^^^^ Pending spec found.
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags xcontext' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       xcontext 'test' do
       ^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags xdescribe' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       xdescribe 'test' do
       ^^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags xexample' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       xexample 'test' do
       ^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags xfeature' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       xfeature 'test' do
       ^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags xit' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       xit 'test' do
       ^^^^^^^^^^ Pending spec found.
       end
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags xscenario' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       xscenario 'test' do
       ^^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags xspecify' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       xspecify 'test' do
       ^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -74,7 +74,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags skip inside of an it' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'test' do
         skip
         ^^^^ Pending spec found.
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags skip blocks' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       skip 'test' do
       ^^^^^^^^^^^ Pending spec found.
       end
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags blocks with skip symbol metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'test', :skip do
       ^^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -99,7 +99,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags describe with skip symbol metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe 'test', :skip do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -107,7 +107,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags blocks with pending symbol metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'test', :pending do
       ^^^^^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -115,7 +115,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags blocks with pending: string metadata and line break by `\`' do
-    expect_offense(<<-'RUBY')
+    expect_offense(<<~'RUBY')
       it "test", pending: 'test' \
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
                           'foo' do
@@ -124,7 +124,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags blocks with pending: string metadata and line break by `,`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "test", pending: 'test ,
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
                           foo' do
@@ -134,7 +134,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
 
   it 'flags blocks with pending: surrounded by `%()` string metadata ' \
      'and line break' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it "test", pending: %(test ,
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
                           foo) do
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags blocks with skip: true metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'test', skip: true do
       ^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -151,7 +151,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags blocks with skip: string metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'test', skip: 'skipped because of being slow' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -159,7 +159,7 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'flags pending blocks' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       pending 'test' do
       ^^^^^^^^^^^^^^ Pending spec found.
       end
@@ -167,61 +167,61 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
   end
 
   it 'ignores describe' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'test' do; end
     RUBY
   end
 
   it 'ignores example' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       example 'test' do; end
     RUBY
   end
 
   it 'ignores scenario' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       scenario 'test' do; end
     RUBY
   end
 
   it 'ignores specify' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       specify do; end
     RUBY
   end
 
   it 'ignores feature' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       feature 'test' do; end
     RUBY
   end
 
   it 'ignores context' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context 'test' do; end
     RUBY
   end
 
   it 'ignores it' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'test' do; end
     RUBY
   end
 
   it 'ignores it with skip: false metadata' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'test', skip: false do; end
     RUBY
   end
 
   it 'ignores example_group' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       example_group 'test' do; end
     RUBY
   end
 
   it 'ignores method called pending' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       subject { Project.pending }
     RUBY
   end

--- a/spec/rubocop/cop/rspec/rails/http_status_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/http_status_spec.rb
@@ -5,51 +5,51 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
     let(:cop_config) { { 'EnforcedStyle' => 'symbolic' } }
 
     it 'registers an offense when using numeric value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status 200 }
                                              ^^^ Prefer `:ok` over `200` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to have_http_status :ok }
       RUBY
     end
 
     it 'registers an offense when using double quoted string value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status "200" }
                                              ^^^^^ Prefer `:ok` over `"200"` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to have_http_status :ok }
       RUBY
     end
 
     it 'registers an offense when using single quoted string value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status '200' }
                                              ^^^^^ Prefer `:ok` over `'200'` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to have_http_status :ok }
       RUBY
     end
 
     it 'registers an offense when using percent string value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status %[200] }
                                              ^^^^^^ Prefer `:ok` over `%[200]` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to have_http_status :ok }
       RUBY
     end
 
     it 'does not register an offense when using here document' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status <<~HTTP }
           200
         HTTP
@@ -57,25 +57,25 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
     end
 
     it 'does not register an offense when using symbolic value' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status :ok }
       RUBY
     end
 
     it 'does not register an offense when using custom HTTP code' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status 550 }
       RUBY
     end
 
     context 'with parenthesis' do
       it 'registers an offense when using numeric value' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it { is_expected.to have_http_status(404) }
                                                ^^^ Prefer `:not_found` over `404` to describe HTTP status code.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           it { is_expected.to have_http_status(:not_found) }
         RUBY
       end
@@ -86,46 +86,46 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
     let(:cop_config) { { 'EnforcedStyle' => 'numeric' } }
 
     it 'registers an offense when using symbolic value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status :ok }
                                              ^^^ Prefer `200` over `:ok` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to have_http_status 200 }
       RUBY
     end
 
     it 'registers an offense when using double quoted string value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status "ok" }
                                              ^^^^ Prefer `200` over `"ok"` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to have_http_status 200 }
       RUBY
     end
 
     it 'registers an offense when using single quoted string value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status 'ok' }
                                              ^^^^ Prefer `200` over `'ok'` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to have_http_status 200 }
       RUBY
     end
 
     it 'does not register an offense when using numeric value' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status 200 }
       RUBY
     end
 
     it 'does not register an offense when using allowed symbols' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status :error }
         it { is_expected.to have_http_status :success }
         it { is_expected.to have_http_status :missing }
@@ -135,12 +135,12 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
 
     context 'with parenthesis' do
       it 'registers an offense when using symbolic value' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it { is_expected.to have_http_status(:not_found) }
                                                ^^^^^^^^^^ Prefer `404` over `:not_found` to describe HTTP status code.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           it { is_expected.to have_http_status(404) }
         RUBY
       end
@@ -151,71 +151,71 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
     let(:cop_config) { { 'EnforcedStyle' => 'be_status' } }
 
     it 'registers an offense when using numeric value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status 200 }
                             ^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status 200` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to be_ok }
       RUBY
     end
 
     it 'registers an offense when using symbolic value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status :ok }
                             ^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status :ok` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to be_ok }
       RUBY
     end
 
     it 'registers an offense when using double quoted string value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status "200" }
                             ^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status "200"` to describe HTTP status code.
         it { is_expected.to have_http_status "ok" }
                             ^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status "ok"` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to be_ok }
         it { is_expected.to be_ok }
       RUBY
     end
 
     it 'registers an offense when using single quoted string value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status '200' }
                             ^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status '200'` to describe HTTP status code.
         it { is_expected.to have_http_status 'ok' }
                             ^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status 'ok'` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to be_ok }
         it { is_expected.to be_ok }
       RUBY
     end
 
     it 'registers an offense when using percent string value' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it { is_expected.to have_http_status %[200] }
                             ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status %[200]` to describe HTTP status code.
         it { is_expected.to have_http_status %[ok] }
                             ^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_ok` over `have_http_status %[ok]` to describe HTTP status code.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it { is_expected.to be_ok }
         it { is_expected.to be_ok }
       RUBY
     end
 
     it 'does not register an offense when using here document' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status <<~HTTP }
           200
         HTTP
@@ -223,13 +223,13 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
     end
 
     it 'does not register an offense when using numeric value' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to be_ok }
       RUBY
     end
 
     it 'does not register an offense when using allowed symbols' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it { is_expected.to have_http_status :error }
         it { is_expected.to have_http_status :success }
         it { is_expected.to have_http_status :missing }
@@ -239,23 +239,23 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::HttpStatus do
 
     context 'with parenthesis' do
       it 'registers an offense when using numeric value' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it { is_expected.to have_http_status(404) }
                               ^^^^^^^^^^^^^^^^^^^^^ Prefer `be_not_found` over `have_http_status(404)` to describe HTTP status code.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           it { is_expected.to be_not_found }
         RUBY
       end
 
       it 'registers an offense when using symbolic value' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           it { is_expected.to have_http_status(:not_found) }
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `be_not_found` over `have_http_status(:not_found)` to describe HTTP status code.
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           it { is_expected.to be_not_found }
         RUBY
       end

--- a/spec/rubocop/cop/rspec/receive_counts_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_counts_spec.rb
@@ -2,129 +2,129 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ReceiveCounts do
   it 'flags usage of `exactly(1).times`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).exactly(1).times
                                   ^^^^^^^^^^^^^^^^^ Use `.once` instead of `.exactly(1).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).once
     RUBY
   end
 
   it 'flags usage of `exactly(2).times`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).exactly(2).times
                                   ^^^^^^^^^^^^^^^^^ Use `.twice` instead of `.exactly(2).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).twice
     RUBY
   end
 
   it 'allows `exactly(3).times`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       expect(foo).to receive(:bar).exactly(3).times
     RUBY
   end
 
   it 'allows `exactly(n).times`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       expect(foo).to receive(:bar).exactly(n).times
     RUBY
   end
 
   it 'flags usage of `exactly(1).times` after `with`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).with(baz).exactly(1).times
                                             ^^^^^^^^^^^^^^^^^ Use `.once` instead of `.exactly(1).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).with(baz).once
     RUBY
   end
 
   it 'flags usage of `exactly(1).times` with return value' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).exactly(1).times.and_return(true)
                                   ^^^^^^^^^^^^^^^^^ Use `.once` instead of `.exactly(1).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).once.and_return(true)
     RUBY
   end
 
   it 'flags usage of `exactly(1).times` with a block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).exactly(1).times { true }
                                   ^^^^^^^^^^^^^^^^^ Use `.once` instead of `.exactly(1).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).once { true }
     RUBY
   end
 
   it 'flags usage of `at_least(1).times`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).at_least(1).times
                                   ^^^^^^^^^^^^^^^^^^ Use `.at_least(:once)` instead of `.at_least(1).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).at_least(:once)
     RUBY
   end
 
   it 'flags usage of `at_least(2).times`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).at_least(2).times
                                   ^^^^^^^^^^^^^^^^^^ Use `.at_least(:twice)` instead of `.at_least(2).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).at_least(:twice)
     RUBY
   end
 
   it 'flags usage of `at_least(2).times` with a block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).at_least(2).times { true }
                                   ^^^^^^^^^^^^^^^^^^ Use `.at_least(:twice)` instead of `.at_least(2).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).at_least(:twice) { true }
     RUBY
   end
 
   it 'flags usage of `at_most(1).times`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).at_most(1).times
                                   ^^^^^^^^^^^^^^^^^ Use `.at_most(:once)` instead of `.at_most(1).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).at_most(:once)
     RUBY
   end
 
   it 'flags usage of `at_most(2).times`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).at_most(2).times
                                   ^^^^^^^^^^^^^^^^^ Use `.at_most(:twice)` instead of `.at_most(2).times`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).to receive(:bar).at_most(:twice)
     RUBY
   end
 
   it 'allows exactly(1).times when not called on `receive`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       expect(action).to have_published_event.exactly(1).times
     RUBY
   end

--- a/spec/rubocop/cop/rspec/receive_never_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_never_spec.rb
@@ -2,51 +2,51 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ReceiveNever do
   it 'flags usage of `never`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).never
                                    ^^^^^ Use `not_to receive` instead of `never`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).not_to receive(:bar)
     RUBY
   end
 
   it 'flags usage of `never` after `with`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).with(baz).never
                                              ^^^^^ Use `not_to receive` instead of `never`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect(foo).not_to receive(:bar).with(baz)
     RUBY
   end
 
   it 'flags usage of `never` with `is_expected`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       is_expected.to receive(:bar).with(baz).never
                                              ^^^^^ Use `not_to receive` instead of `never`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       is_expected.not_to receive(:bar).with(baz)
     RUBY
   end
 
   it 'flags usage of `never` with `expect_any_instance_of`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect_any_instance_of(Foo).to receive(:bar).with(baz).never
                                                              ^^^^^ Use `not_to receive` instead of `never`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       expect_any_instance_of(Foo).not_to receive(:bar).with(baz)
     RUBY
   end
 
   it 'allows method called `never`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       expect(foo).to receive(:bar).with(Value.never)
       expect(foo.never).to eq(bar.never)
       is_expected.to be never

--- a/spec/rubocop/cop/rspec/remove_const_spec.rb
+++ b/spec/rubocop/cop/rspec/remove_const_spec.rb
@@ -2,14 +2,14 @@
 
 RSpec.describe RuboCop::Cop::RSpec::RemoveConst do
   it 'detects the `remove_const` usage' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'does something' do
         Object.send(:remove_const, :SomeConstant)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use remove_const in specs. Consider using e.g. `stub_const`.
       end
     RUBY
 
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       before do
         SomeClass.send(:remove_const, :SomeConstant)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use remove_const in specs. Consider using e.g. `stub_const`.
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::RemoveConst do
   end
 
   it 'detects the `remove_const` usage when using `__send__`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'does something' do
         NiceClass.__send__(:remove_const, :SomeConstant)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use remove_const in specs. Consider using e.g. `stub_const`.

--- a/spec/rubocop/cop/rspec/repeated_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_description_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   it 'registers an offense for repeated descriptions' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         it "does x" do
         ^^^^^^^^^^^ Don't repeat descriptions within an example group.
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'registers offense for repeated descriptions separated by a context' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         it "does x" do
         ^^^^^^^^^^^ Don't repeat descriptions within an example group.
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'ignores descriptions repeated in a shared context' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it "does x" do
         end
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'ignores repeated descriptions in a nested context' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it "does x" do
         end
@@ -64,7 +64,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag tests which do not contain description strings' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it { foo }
         it { bar }
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag examples if metadata is different' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it 'do something' do
           # ...
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag examples with same metadata and different description' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it 'do something', :flag do
           # ...
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'registers offense for repeated description and metadata' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         it 'do something', :flag do
         ^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag descriptions with different interpolated variables' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it "does \#{x}" do
         end
@@ -129,7 +129,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'registers offense for repeated description in same iterator' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         %i[foo bar].each do |type|
           it "does a thing \#{type}" do
@@ -145,7 +145,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'registers offense for repeated description in different iterators' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         %i[foo bar].each do |type|
           it "does a thing \#{type}" do
@@ -163,7 +163,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag different descriptions in different iterators' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         %i[foo bar].each do |type|
           it "does a thing \#{type}" do
@@ -179,7 +179,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'registers offense if same method used in docstring' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         it(description) do
         ^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
@@ -195,7 +195,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag different methods used as docstring' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it(description) do
           # ...
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'registers an offense when repeated its are used' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         its(:x) { is_expected.to be_present }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat descriptions within an example group.
@@ -220,7 +220,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag examples when different its arguments are used' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         its(:x) { is_expected.to be_present }
         its(:y) { is_expected.to be_present }
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedDescription do
   end
 
   it 'does not flag examples when different its block expectations are used' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         its(:x) { is_expected.to be_present }
         its(:x) { is_expected.to be_blank }

--- a/spec/rubocop/cop/rspec/repeated_example_group_body_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_group_body_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   it 'registers an offense for repeated describe body' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
       ^^^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [5]
         it { cool_predicate_method }
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers an offense for repeated context body' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context 'when awesome case' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Repeated context block body on line(s) [5]
         it { cool_predicate_method }
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers an offense for several repeated context body' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context 'when usual case' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Repeated context block body on line(s) [5, 9]
         it { cool_predicate_method }
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'does not register offense for different block body implementation' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context 'when awesome case' do
         it { cool_predicate_method }
       end
@@ -61,7 +61,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'does not register offense if metadata is different' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it { cool_predicate_method }
       end
@@ -73,7 +73,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'does not register offense if module arg is different' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe CSV::Row do
         it { is_expected.to respond_to :headers }
       end
@@ -85,7 +85,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'does not register offense when module arg namespace is different' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe CSV::Parser do
         it { expect(described_class).to respond_to(:parse) }
       end
@@ -97,7 +97,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers an offense for when module arg and namespace are identical' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context Net::HTTP do
       ^^^^^^^^^^^^^^^^^^^^ Repeated context block body on line(s) [5]
         it { expect(described_class).to respond_to :start }
@@ -111,7 +111,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'does not register offense with several docstring' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x', :json, 'request' do
         it { cool_predicate_method }
       end
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers offense for different groups' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
       ^^^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [5]
         it { cool_predicate_method }
@@ -137,7 +137,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'does not register offense for example groups in different groups' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'A' do
         describe '.b' do
           context 'when this' do
@@ -152,7 +152,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers offense only for RSPEC namespace example groups' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       helpers.describe 'doing x' do
         it { cool_predicate_method }
       end
@@ -170,7 +170,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers offense only for RSPEC namespace example groups in any order' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe 'doing x' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [5]
         it { cool_predicate_method }
@@ -188,7 +188,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers offense only for example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe 'A' do
         stub_all_http_calls()
         allowed_statuses = %i[open submitted approved].freeze
@@ -209,7 +209,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'skips `skip` and `pending` statements' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context 'rejected' do
         skip
       end
@@ -225,7 +225,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'skips `skip` and `pending` statements with arguments' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe '#load' do
         skip 'storage feature needed'
       end
@@ -245,7 +245,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers offense correctly if `skip` and `pending` have block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe '#load' do
       ^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [5]
         skip { cool_predicate_method }
@@ -269,7 +269,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers offense correctly if example groups are separated' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'repeated' do
       ^^^^^^^^^^^^^^^^^^^^^^ Repeated describe block body on line(s) [7]
         it { is_expected.to be_truthy }
@@ -285,7 +285,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'does not register offense for same examples with different data' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context 'when admin' do
         let(:user) { admin }
         it { is_expected.to be_truthy }
@@ -299,7 +299,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'does not register offense if no descriptions, but different body' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context do
         let(:preferences) { default_preferences }
 
@@ -315,7 +315,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupBody do
   end
 
   it 'registers offense no descriptions and similar body' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context do
       ^^^^^^^^^^ Repeated context block body on line(s) [7]
         let(:preferences) { %w[a] }

--- a/spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   it 'registers an offense for repeated describe descriptions' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
       ^^^^^^^^^^^^^^^^^^^^^ Repeated describe block description on line(s) [5]
         # example group
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'registers an offense for repeated context descriptions' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context 'when awesome case' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Repeated context block description on line(s) [5]
         # example group
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'registers an offense with right pointing to lines of code' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'super feature' do
         context 'when some case' do
           # ...
@@ -55,7 +55,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'does not register offense for different block descriptions' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         # example group
       end
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'does not register offense for describe block with additional docstring' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe 'Animal', 'dog' do
         # example group
       end
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'does not register offense for describe block with several docstring' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe 'Animal', 'dog', type: :request do
         # example group
       end
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'register offense for different example group with similar descriptions' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'Animal' do
       ^^^^^^^^^^^^^^^^^^^^ Repeated describe block description on line(s) [5]
         # example group
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'registers offense only for RSPEC namespace example groups' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       helpers.describe 'doing x' do
         it { cool_predicate_method }
       end
@@ -123,7 +123,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'registers offense only for RSPEC namespace example groups in any order' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe 'doing x' do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Repeated describe block description on line(s) [5]
         it { cool_predicate_method }
@@ -141,7 +141,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'registers offense only for example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe 'A' do
         stub_all_http_calls()
         allowed_statuses = %i[open submitted approved].freeze
@@ -161,7 +161,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'considers interpolated docstrings as different descriptions' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context "when class is \#{A::B}" do
         # ...
       end
@@ -173,7 +173,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'registers offense correctly for interpolated docstrings' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context "when class is \#{A::B}" do
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Repeated context block description on line(s) [5]
         # ...
@@ -187,7 +187,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'considers different classes as different descriptions' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context A::B do
         # ...
       end
@@ -199,7 +199,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'register offense if same method used in docstring' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       context(description) do
       ^^^^^^^^^^^^^^^^^^^^^^^ Repeated context block description on line(s) [5]
         # ...
@@ -213,7 +213,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'registers offense correctly if example groups are separated' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'repeated' do
       ^^^^^^^^^^^^^^^^^^^^^^ Repeated describe block description on line(s) [7]
         it { is_expected.to be_truthy }
@@ -229,7 +229,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
   end
 
   it 'does not register offense for example group without descriptions' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       context do
         # ...
       end

--- a/spec/rubocop/cop/rspec/repeated_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   it 'registers an offense for repeated example' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         it "does x" do
         ^^^^^^^^^^^^^^ Don't repeat examples within an example group.
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not register an offense if rspec tag magic is involved' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it "does x" do
           expect(foo).to be(bar)
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not flag examples with different implementations' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it "does x" do
           expect(foo).to have_attribute(foo: 1)
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'registers an offense when repeated its are used' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe 'doing x' do
         its(:x) { is_expected.to be_present }
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't repeat examples within an example group.
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not flag examples when different its arguments are used' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         its(:x) { is_expected.to be_present }
         its(:y) { is_expected.to be_present }
@@ -66,7 +66,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not flag examples when different its block expectations are used' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         its(:x) { is_expected.to be_present }
         its(:x) { is_expected.to be_blank }
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExample do
   end
 
   it 'does not flag repeated examples in different scopes' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe 'doing x' do
         it "does x" do
           expect(foo).to be(bar)

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     let(:enforced_style) { 'and_return' }
 
     it 'finds static values returned from block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) { 42 }
                                       ^ Use `and_return` for static values.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return(42)
         end
@@ -24,14 +24,14 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds empty values returned from block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) {}
                                       ^ Use `and_return` for static values.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return(nil)
         end
@@ -39,14 +39,14 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds array with only static values returned from block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) { [42, 43] }
                                       ^ Use `and_return` for static values.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return([42, 43])
         end
@@ -54,14 +54,14 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds hash with only static values returned from block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) { {a: 42, b: 43} }
                                       ^ Use `and_return` for static values.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return({a: 42, b: 43})
         end
@@ -69,14 +69,14 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds static values in a block when there are chained methods' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Question).to receive(:meaning).with(:universe) { 42 }
                                                                ^ Use `and_return` for static values.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           allow(Question).to receive(:meaning).with(:universe).and_return(42)
         end
@@ -84,14 +84,14 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds constants returned from block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) { Life::MEANING }
                                       ^ Use `and_return` for static values.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return(Life::MEANING)
         end
@@ -99,14 +99,14 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds nested constants returned from block' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) { {Life::MEANING => 42} }
                                       ^ Use `and_return` for static values.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return({Life::MEANING => 42})
         end
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'ignores dynamic values returned from block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) { baz }
         end
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'ignores variables return from block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           $bar = 42
           baz = 123
@@ -133,7 +133,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'ignores array with dynamic values returned from block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) { [42, baz] }
         end
@@ -141,7 +141,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'ignores hash with dynamic values returned from block' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) { {a: 42, b: baz} }
         end
@@ -149,7 +149,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'ignores block returning string with interpolation' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           bar = 42
           allow(Foo).to receive(:bar) { "You called \#{bar}" }
@@ -158,7 +158,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'registers an offense for concatenated strings with no variables' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar) do
                                       ^^ Use `and_return` for static values.
@@ -168,7 +168,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return("You called" \
             "me")
@@ -177,7 +177,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'does not register an offense for a stub without return value' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           allow(Foo).to receive(:bar)
         end
@@ -185,7 +185,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'does not register an offense for stub in a method' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         def stub_foo
           allow(Foo).to receive(:bar)
         end
@@ -197,7 +197,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     let(:enforced_style) { 'block' }
 
     it 'registers an offense for static values returned from method' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return(42)
                                       ^^^^^^^^^^ Use block for static values.
@@ -206,7 +206,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'registers an offense for static values returned from chained method' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).with(1).and_return(42)
                                               ^^^^^^^^^^ Use block for static values.
@@ -215,7 +215,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'does not register an offense for dynamic values returned from method' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return(baz)
         end
@@ -223,7 +223,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'ignores string with interpolation returned from method' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           bar = 42
           allow(Foo).to receive(:bar).and_return("You called \#{bar}")
@@ -232,7 +232,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'ignores multiple values being returned from method' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           allow(Foo).to receive(:bar).and_return(42, 43, 44)
         end
@@ -240,7 +240,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds hash with only static values returned from method' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         allow(Foo).to receive(:bar).and_return({ foo: 42 })
                                     ^^^^^^^^^^ Use block for static values.
         allow(Foo).to receive(:bar).and_return(foo: 42)
@@ -252,7 +252,7 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
         )
       RUBY
 
-      expect_correction(<<-RUBY) # Not perfect, but good enough.
+      expect_correction(<<~RUBY) # Not perfect, but good enough.
         allow(Foo).to receive(:bar) { { foo: 42 } }
         allow(Foo).to receive(:bar) { { foo: 42 } }
         allow(Foo).to receive(:bar) { { a: 42,
@@ -261,24 +261,24 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
     end
 
     it 'finds nil returned from method' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         allow(Foo).to receive(:bar).and_return(nil)
                                     ^^^^^^^^^^ Use block for static values.
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         allow(Foo).to receive(:bar) { nil }
       RUBY
     end
 
     it 'finds concatenated strings with no variables' do
-      expect_offense(<<-'RUBY')
+      expect_offense(<<~'RUBY')
         allow(Foo).to receive(:bar).and_return('You called ' \
                                     ^^^^^^^^^^ Use block for static values.
           'me')
       RUBY
 
-      expect_correction(<<-'RUBY')
+      expect_correction(<<~'RUBY')
         allow(Foo).to receive(:bar) { 'You called ' \
           'me' }
       RUBY

--- a/spec/rubocop/cop/rspec/scattered_let_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_let_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   it 'flags `let` after the first different node' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         it { expect(subject.foo).to eq(a) }
@@ -11,7 +11,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:a) { a }
         let(:b) { b }
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   end
 
   it 'works with heredocs' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe User do
         let(:a) { <<-BAR }
           hello
@@ -35,7 +35,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe User do
         let(:a) { <<-BAR }
           hello
@@ -50,7 +50,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   end
 
   it 'works with comments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:a) { a } # a comment
         # example comment
@@ -63,7 +63,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       RSpec.describe User do
         let(:a) { a } # a comment
         # define the second letter
@@ -77,7 +77,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   end
 
   it 'flags `let` at different nesting levels' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe User do
         let(:a) { a }
         it { expect(subject.foo).to eq(a) }
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe User do
         let(:a) { a }
         it { expect(subject.foo).to eq(a) }
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   end
 
   it 'doesnt flag `let!` in the middle of multiple `let`s' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe User do
         subject { User }
 
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   end
 
   it 'flags scattered `let!`s' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe User do
         let!(:a) { a }
         it { expect(subject.foo).to eq(a) }
@@ -131,7 +131,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe User do
         let!(:a) { a }
         let!(:c) { c }
@@ -141,7 +141,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
   end
 
   it 'flags `let` with proc argument' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe User do
         let(:a) { a }
         it { expect(subject.foo).to eq(a) }
@@ -150,7 +150,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredLet do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       describe User do
         let(:a) { a }
         let(:user, &args[:build_user])

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores different hooks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before { bar }
         after { baz }
@@ -69,7 +69,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores different hook types' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before { bar }
         before(:all) { baz }
@@ -79,7 +79,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores hooks in different example groups' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before { bar }
 
@@ -91,7 +91,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores hooks in different shared contexts' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         shared_context 'one' do
           before { bar }
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores similar method names inside of examples' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before { bar }
 
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
   end
 
   it 'ignores hooks with different metadata' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       describe Foo do
         before(:example) { foo }
         before(:example, :special_case) { bar }

--- a/spec/rubocop/cop/rspec/shared_context_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_context_spec.rb
@@ -3,14 +3,14 @@
 RSpec.describe RuboCop::Cop::RSpec::SharedContext do
   describe 'shared_context' do
     it 'does not register an offense for empty contexts' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         shared_context 'empty' do
         end
       RUBY
     end
 
     it 'registers an offense for shared_context with only examples' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         shared_context 'foo' do
         ^^^^^^^^^^^^^^^^^^^^ Use `shared_examples` when you don't define context.
           it 'performs actions' do
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         shared_examples 'foo' do
           it 'performs actions' do
           end
@@ -27,7 +27,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'does not register an offense for `shared_context` with let' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         shared_context 'foo' do
           let(:foo) { :bar }
 
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'does not register an offense for `shared_context` with subject' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         shared_context 'foo' do
           subject(:foo) { :bar }
 
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'does not register an offense for `shared_context` with before' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         shared_context 'foo' do
           before do
             something
@@ -64,21 +64,21 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
 
   describe 'shared_examples' do
     it 'does not register an offense for empty examples' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         shared_examples 'empty' do
         end
       RUBY
     end
 
     it 'registers an offense for shared_examples with only let' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         shared_examples 'foo' do
         ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           let(:foo) { :bar }
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         shared_context 'foo' do
           let(:foo) { :bar }
         end
@@ -86,14 +86,14 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'registers an offense for shared_examples with only subject' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         shared_examples 'foo' do
         ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           subject(:foo) { :bar }
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         shared_context 'foo' do
           subject(:foo) { :bar }
         end
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'registers an offense for shared_examples with only hooks' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         shared_examples 'foo' do
         ^^^^^^^^^^^^^^^^^^^^^ Use `shared_context` when you don't define examples.
           before do
@@ -110,7 +110,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         shared_context 'foo' do
           before do
             foo
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedContext do
     end
 
     it 'does not register an offense for `shared_examples` with it' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         shared_examples 'foo' do
           subject(:foo) { 'foo' }
           let(:bar) { :baz }

--- a/spec/rubocop/cop/rspec/shared_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_examples_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
   it 'registers an offense when using symbolic title' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it_behaves_like :foo_bar_baz
                       ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
       it_should_behave_like :foo_bar_baz
@@ -25,7 +25,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
                             ^^^^^^^^^^^^ Prefer 'foo bar baz' over `:foo_bar_baz` to titleize shared examples.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       it_behaves_like 'foo bar baz'
       it_should_behave_like 'foo bar baz'
       shared_examples 'foo bar baz'
@@ -42,7 +42,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
   end
 
   it 'does not register an offense when using string title' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it_behaves_like 'foo bar baz'
       it_should_behave_like 'foo bar baz'
       shared_examples 'foo bar baz'
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
   end
 
   it 'does not register an offense when using Module/Class title' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it_behaves_like FooBarBaz
       it_should_behave_like FooBarBaz
       shared_examples FooBarBaz

--- a/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
+++ b/spec/rubocop/cop/rspec/single_argument_message_chain_spec.rb
@@ -3,14 +3,14 @@
 RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
   describe 'receive_message_chain' do
     it 'reports single-argument calls' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before do
           allow(foo).to receive_message_chain(:one) { :two }
                         ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before do
           allow(foo).to receive(:one) { :two }
         end
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'accepts multi-argument calls' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before do
           allow(foo).to receive_message_chain(:one, :two) { :three }
         end
@@ -26,14 +26,14 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'reports single-argument string calls' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before do
           allow(foo).to receive_message_chain("one") { :two }
                         ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before do
           allow(foo).to receive("one") { :two }
         end
@@ -41,7 +41,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'accepts multi-argument string calls' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before do
           allow(foo).to receive_message_chain("one.two") { :three }
         end
@@ -49,7 +49,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'accepts single-argument calls with variable' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before do
           foo = %i[:one :two]
           allow(foo).to receive_message_chain(foo) { :many }
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'accepts single-argument calls with send node' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before do
           allow(foo).to receive_message_chain(foo) { :many }
         end
@@ -67,14 +67,14 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
     context 'with single-element array argument' do
       it 'reports an offense' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           before do
             allow(foo).to receive_message_chain([:one]) { :two }
                           ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
           end
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           before do
             allow(foo).to receive(:one) { :two }
           end
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
     context 'with multiple-element array argument' do
       it "doesn't report an offense" do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           before do
             allow(foo).to receive_message_chain([:one, :two]) { :many }
           end
@@ -94,7 +94,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
     context 'with single-key hash argument' do
       it 'reports an offense' do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           before do
             allow(foo).to receive_message_chain(bar: 42)
                           ^^^^^^^^^^^^^^^^^^^^^ Use `receive` instead of calling `receive_message_chain` with a single argument.
@@ -105,7 +105,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
           end
         RUBY
 
-        expect_correction(<<-RUBY)
+        expect_correction(<<~RUBY)
           before do
             allow(foo).to receive(:bar).and_return(42)
             allow(foo).to receive("bar").and_return(42)
@@ -117,7 +117,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
     context 'with multiple keys hash argument' do
       it "doesn't report an offense" do
-        expect_no_offenses(<<-RUBY)
+        expect_no_offenses(<<~RUBY)
           before do
             allow(foo).to receive_message_chain(bar: 42, baz: 42)
           end
@@ -128,14 +128,14 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
 
   describe 'stub_chain' do
     it 'reports single-argument calls' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before do
           foo.stub_chain(:one) { :two }
               ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before do
           foo.stub(:one) { :two }
         end
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'accepts multi-argument calls' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before do
           foo.stub_chain(:one, :two) { :three }
         end
@@ -151,14 +151,14 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'reports single-argument string calls' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         before do
           foo.stub_chain("one") { :two }
               ^^^^^^^^^^ Use `stub` instead of calling `stub_chain` with a single argument.
         end
       RUBY
 
-      expect_correction(<<-RUBY)
+      expect_correction(<<~RUBY)
         before do
           foo.stub("one") { :two }
         end
@@ -166,7 +166,7 @@ RSpec.describe RuboCop::Cop::RSpec::SingleArgumentMessageChain do
     end
 
     it 'accepts multi-argument string calls' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         before do
           foo.stub_chain("one.two") { :three }
         end

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -9,157 +9,157 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
   end
 
   it 'registers an offense when wrong path for all kinds of example group' do
-    expect_offense(<<-RUBY, 'wrong_path_foo_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_path_foo_spec.rb')
       example_group MyClass, 'foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense when wrong class but a correct method' do
-    expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo' do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense when wrong class and highlights metadata' do
-    expect_offense(<<-RUBY, 'wrong_class_foo_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_foo_spec.rb')
       describe MyClass, '#foo', blah: :blah do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*foo*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense when wrong class name' do
-    expect_offense(<<-RUBY, 'wrong_class_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_spec.rb')
       describe MyClass do; end
       ^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense when wrong class name with a symbol argument' do
-    expect_offense(<<-RUBY, 'wrong_class_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_spec.rb')
       describe MyClass, :foo do; end
       ^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
     RUBY
   end
 
   it 'registers an offense when second argument contains spaces' do
-    expect_offense(<<-RUBY, 'wrong_class_spec.rb')
+    expect_offense(<<~RUBY, 'wrong_class_spec.rb')
       describe MyClass, "via `local_failures`" do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*via_local_failures*_spec.rb`.
     RUBY
   end
 
   it 'does not register an offense when only shared examples' do
-    expect_no_offenses(<<-RUBY, 'spec/models/user.rb')
+    expect_no_offenses(<<~RUBY, 'spec/models/user.rb')
       shared_examples_for 'foo' do; end
     RUBY
   end
 
   it 'does not register an offense when example groups do not describe ' \
      'a class/method' do
-    expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/spec.rb')
       describe 'Test something' do; end
     RUBY
   end
 
   it 'does not register an offense when multiple top level describes' do
-    expect_no_offenses(<<-RUBY, 'some/class/spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/spec.rb')
       describe MyClass, 'do_this' do; end
       describe MyClass, 'do_that' do; end
     RUBY
   end
 
   it 'does not register an offense when class specs' do
-    expect_no_offenses(<<-RUBY, 'some/class_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
   it 'does not register an offense when different parent directories' do
-    expect_no_offenses(<<-RUBY, 'parent_dir/some/class_spec.rb')
+    expect_no_offenses(<<~RUBY, 'parent_dir/some/class_spec.rb')
       describe Some::Class do; end
     RUBY
   end
 
   it 'does not register an offense when CamelCaps class names' do
-    expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
+    expect_no_offenses(<<~RUBY, 'my_class_spec.rb')
       describe MyClass do; end
     RUBY
   end
 
   it 'does not register an offense when ACRONYMClassNames' do
-    expect_no_offenses(<<-RUBY, 'abc_one/two_spec.rb')
+    expect_no_offenses(<<~RUBY, 'abc_one/two_spec.rb')
       describe ABCOne::Two do; end
     RUBY
   end
 
   it 'does not register an offense when ALLCAPS class names' do
-    expect_no_offenses(<<-RUBY, 'allcaps_spec.rb')
+    expect_no_offenses(<<~RUBY, 'allcaps_spec.rb')
       describe ALLCAPS do; end
     RUBY
   end
 
   it 'does not register an offense when alphanumeric class names' do
-    expect_no_offenses(<<-RUBY, 'ipv4_and_ipv6_spec.rb')
+    expect_no_offenses(<<~RUBY, 'ipv4_and_ipv6_spec.rb')
       describe IPV4AndIPV6 do; end
     RUBY
   end
 
   it 'does not register an offense when instance methods' do
-    expect_no_offenses(<<-RUBY, 'some/class/inst_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'does not register an offense when class methods' do
-    expect_no_offenses(<<-RUBY, 'some/class/inst_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'does not register an offense when flat hierarchies for ' \
      'instance methods' do
-    expect_no_offenses(<<-RUBY, 'some/class_inst_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class_inst_spec.rb')
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'does not register an offense when flat hierarchies for class methods' do
-    expect_no_offenses(<<-RUBY, 'some/class_inst_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class_inst_spec.rb')
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'does not register an offense when subdirs for instance methods' do
     filename = 'some/class/instance_methods/inst_spec.rb'
-    expect_no_offenses(<<-RUBY, filename)
+    expect_no_offenses(<<~RUBY, filename)
       describe Some::Class, '#inst' do; end
     RUBY
   end
 
   it 'does not register an offense when subdirs for class methods' do
     filename = 'some/class/class_methods/inst_spec.rb'
-    expect_no_offenses(<<-RUBY, filename)
+    expect_no_offenses(<<~RUBY, filename)
       describe Some::Class, '.inst' do; end
     RUBY
   end
 
   it 'does not register an offense when non-alphanumeric characters' do
-    expect_no_offenses(<<-RUBY, 'some/class/pred_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/pred_spec.rb')
       describe Some::Class, '#pred?' do; end
     RUBY
   end
 
   it 'does not register an offense when bang method' do
-    expect_no_offenses(<<-RUBY, 'some/class/bang_spec.rb')
+    expect_no_offenses(<<~RUBY, 'some/class/bang_spec.rb')
       describe Some::Class, '#bang!' do; end
     RUBY
   end
 
   it 'does not register an offense when an arbitrary spec suffix' do
     filename = 'some/class/thing_predicate_spec.rb'
-    expect_no_offenses(<<-RUBY, filename)
+    expect_no_offenses(<<~RUBY, filename)
       describe Some::Class, '#thing?' do; end
     RUBY
   end
@@ -167,14 +167,14 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
   it 'does not register an offense when an arbitrary spec name for ' \
      'an operator method' do
     filename = 'my_little_class/spaceship_operator_spec.rb'
-    expect_no_offenses(<<-RUBY, filename)
+    expect_no_offenses(<<~RUBY, filename)
       describe MyLittleClass, '#<=>' do; end
     RUBY
   end
 
   it 'registers an offense when path containing the class nam' do
     filename = '/home/foo/spec/models/bar_spec.rb'
-    expect_offense(<<-RUBY, filename)
+    expect_offense(<<~RUBY, filename)
       describe Foo do; end
       ^^^^^^^^^^^^ Spec path should end with `foo*_spec.rb`.
     RUBY
@@ -182,7 +182,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
 
   it 'registers an offense when path with incorrect collapsed namespace' do
     filename = '/home/foo/spec/very/my_class_spec.rb'
-    expect_offense(<<-RUBY, filename)
+    expect_offense(<<~RUBY, filename)
       describe Very::Long::Namespace::MyClass do; end
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `very/long/namespace/my_class*_spec.rb`.
     RUBY
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
 
   it 'registers an offense when path with incorrect expanded namespace' do
     filename = '/home/foo/spec/very/long/my_class_spec.rb'
-    expect_offense(<<-RUBY, filename)
+    expect_offense(<<~RUBY, filename)
       module Very
         module Medium
           describe MyClass do; end
@@ -206,14 +206,14 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     allow(File).to receive(:expand_path).with('my_class_spec.rb').and_return(
       '/home/foo/spec/very/long/namespace/my_class_spec.rb'
     )
-    expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
+    expect_no_offenses(<<~RUBY, 'my_class_spec.rb')
       describe Very::Long::Namespace::MyClass do; end
     RUBY
   end
 
   # RSpec/FilePath runs on all files - not only **/*_spec.rb
   it 'does not register an offense when files defining an empty class' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       class Foo
       end
     RUBY
@@ -237,7 +237,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     let(:cop_config) { { 'CustomTransform' => { 'FooFoo' => 'foofoo' } } }
 
     it 'does not register an offense for custom module name transformation' do
-      expect_no_offenses(<<-RUBY, 'foofoo/some/class/bar_spec.rb')
+      expect_no_offenses(<<~RUBY, 'foofoo/some/class/bar_spec.rb')
         describe FooFoo::Some::Class, '#bar' do; end
       RUBY
     end
@@ -248,7 +248,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     let(:suffix) { 'my_class*look_here_a_method*_spec.rb' }
 
     it 'registers an offense when file path not include method name' do
-      expect_offense(<<-RUBY, 'my_class_spec.rb')
+      expect_offense(<<~RUBY, 'my_class_spec.rb')
         describe MyClass, '#look_here_a_method' do; end
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*look_here_a_method*_spec.rb`.
       RUBY
@@ -259,7 +259,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     let(:cop_config) { { 'IgnoreMethods' => true } }
 
     it 'does not register an offense when file path not include method name' do
-      expect_no_offenses(<<-RUBY, 'my_class_spec.rb')
+      expect_no_offenses(<<~RUBY, 'my_class_spec.rb')
         describe MyClass, '#look_here_a_method' do; end
       RUBY
     end
@@ -269,7 +269,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     let(:cop_config) { { 'IgnoreMetadata' => { 'foo' => 'bar' } } }
 
     it 'does not register an offense when include ignored metadata' do
-      expect_no_offenses(<<-RUBY, 'wrong_class_spec.rb')
+      expect_no_offenses(<<~RUBY, 'wrong_class_spec.rb')
         describe MyClass, foo: :bar do; end
       RUBY
     end

--- a/spec/rubocop/cop/rspec/spec_file_path_suffix_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_suffix_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathSuffix do
   end
 
   it 'does not register an offense for shared examples' do
-    expect_no_global_offenses(<<-RUBY, 'spec/models/user.rb')
+    expect_no_global_offenses(<<~RUBY, 'spec/models/user.rb')
       shared_examples_for 'foo' do; end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/stubbed_mock_spec.rb
+++ b/spec/rubocop/cop/rspec/stubbed_mock_spec.rb
@@ -2,75 +2,75 @@
 
 RSpec.describe RuboCop::Cop::RSpec::StubbedMock do
   it 'flags stubbed message expectation' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).and_return('hello world')
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
     RUBY
   end
 
   it 'flags stubbed message expectation with a block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar) { 'hello world' }
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
     RUBY
   end
 
   it 'ignores stubbed message expectation with a block and block parameter' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       expect(foo).to receive(:bar) { |x| bar }
     RUBY
   end
 
   it 'flags stubbed message expectation with argument matching' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).with(42).and_return('hello world')
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
     RUBY
   end
 
   it 'flags stubbed message expectation with argument matching and a block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).with(42) { 'hello world' }
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
     RUBY
   end
 
   it 'ignores `have_received`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       expect(foo).to have_received(:bar)
     RUBY
   end
 
   it 'flags `receive_messages`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive_messages(foo: 42, bar: 777)
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
     RUBY
   end
 
   it 'flags `receive_message_chain`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive_message_chain(:foo, bar: 777)
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
     RUBY
   end
 
   it 'flags `receive_message_chain` with `.and_return`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive_message_chain(:foo, :bar).and_return(777)
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
     RUBY
   end
 
   it 'flags `receive_message_chain` with a block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive_message_chain(:foo, :bar) { 777 }
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
     RUBY
   end
 
   it 'flags with order and count constraints', pending: 'Not implemented yet' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(foo).to receive(:bar) { 'hello world' }.ordered
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
       expect(foo).to receive(:bar).ordered { 'hello world' }
@@ -87,7 +87,7 @@ RSpec.describe RuboCop::Cop::RSpec::StubbedMock do
   end
 
   it 'flags block-pass' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       canned = -> { 42 }
       expect(foo).to receive(:bar, &canned)
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
@@ -113,7 +113,7 @@ RSpec.describe RuboCop::Cop::RSpec::StubbedMock do
   end
 
   it 'ignores message allowances' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       allow(foo).to receive(:bar).and_return('hello world')
       allow(foo).to receive(:bar) { 'hello world' }
       allow(foo).to receive(:bar).with(42).and_return('hello world')
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::RSpec::StubbedMock do
   end
 
   it 'tolerates passed arguments without parentheses' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       expect(Foo)
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
         .to receive(:new)

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   it 'flags when subject is stubbed' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
 
   it 'flags when subject is stubbed and there are several named subjects ' \
      'in the same example group' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
         subject(:bar) { described_class.new }
@@ -39,7 +39,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags when subject is mocked' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -62,7 +62,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags when an unnamed subject is mocked' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject { described_class.new }
 
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags when a forced subject! is mocked and called as subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject!(:foo) { described_class.new }
 
@@ -88,7 +88,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags when a forced subject! is mocked and called by name' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject!(:foo) { described_class.new }
 
@@ -101,7 +101,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags when an unnamed forced subject! is mocked' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject! { described_class.new }
 
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags an expectation made on an unnamed subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -127,7 +127,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags one-line expectation syntax' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -140,7 +140,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags stub within context where subject name changed' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -157,7 +157,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags stub inside all matcher' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { [Object.new] }
         it 'tries to trick rubocop-rspec' do
@@ -169,7 +169,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested subject stubs when nested subject uses same name' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -190,7 +190,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested stubs when nested subject is anonymous' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -211,7 +211,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested subject stubs when example group does not define subject' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -230,7 +230,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested subject stubs' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -253,7 +253,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags nested subject stubs when adjacent context redefines' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -270,7 +270,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags deeply nested subject stubs' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -295,7 +295,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags negated runners' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -311,7 +311,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags multiple-method stubs' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -325,7 +325,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags chain stubs' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -339,7 +339,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags spy subject stubs' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         subject(:foo) { described_class.new }
 
@@ -354,7 +354,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags when an implicit subject is mocked' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       describe Foo do
         it 'uses an implicit subject' do
           expect(subject).to receive(:bar).and_return(baz)
@@ -365,7 +365,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
   end
 
   it 'flags when there are several top level example groups' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         subject(:foo) { described_class.new }
 
@@ -442,7 +442,7 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
       shared_examples shared_examples_for shared_context
     ].each do |method|
       it "flags in top level #{method}" do
-        expect_offense(<<-RUBY)
+        expect_offense(<<~RUBY)
           RSpec.#{method} '#{method}' do
             it 'uses an implicit subject' do
               expect(subject).to receive(:bar)

--- a/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
+++ b/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
   context 'with raise_error matcher' do
     it 'detects the `unspecified_exception` offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect {
           raise StandardError
         }.to raise_error
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows empty exception specification when not expecting an error' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError
         }.not_to raise_error
@@ -20,7 +20,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception classes' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError
         }.to raise_error(StandardError)
@@ -28,7 +28,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception messages' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_error('error')
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception types with messages' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_error(StandardError, 'error')
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception matching regular expressions' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_error(/err/)
@@ -52,7 +52,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception types with matching regular expressions' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_error(StandardError, /err/)
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows classes with blocks with braces' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_error { |err| err.data }
@@ -68,7 +68,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows classes with blocks with do/end' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_error do |error|
@@ -78,7 +78,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows parameterized exceptions' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         my_exception = StandardError.new('my exception')
         expect {
           raise my_exception
@@ -89,7 +89,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
 
   context 'with raise_exception matcher' do
     it 'detects the `unspecified_exception` offense' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         expect {
           raise StandardError
         }.to raise_exception
@@ -98,7 +98,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows empty exception specification when not expecting an error' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError
         }.not_to raise_exception
@@ -106,7 +106,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception classes' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError
         }.to raise_exception(StandardError)
@@ -114,7 +114,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception messages' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_exception('error')
@@ -122,7 +122,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception types with messages' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_exception(StandardError, 'error')
@@ -130,7 +130,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception matching regular expressions' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_exception(/err/)
@@ -138,7 +138,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows exception types with matching regular expressions' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_exception(StandardError, /err/)
@@ -146,7 +146,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows classes with blocks with braces' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_exception { |err| err.data }
@@ -154,7 +154,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows classes with blocks with do/end' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         expect {
           raise StandardError.new('error')
         }.to raise_exception do |error|
@@ -164,7 +164,7 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
     end
 
     it 'allows parameterized exceptions' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         my_exception = StandardError.new('my exception')
         expect {
           raise my_exception

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
   it 'finds a `double` instead of an `instance_double`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it do
         foo = double("Widget")
               ^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
     let(:cop_config) { {} }
 
     it 'find doubles whose name is a symbol' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           foo = double(:widget)
                 ^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -23,7 +23,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
     end
 
     it 'finds a `spy` instead of an `instance_spy`' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           foo = spy("Widget")
                 ^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -36,7 +36,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
     let(:cop_config) { { 'IgnoreSymbolicNames' => true } }
 
     it 'ignores doubles whose name is a symbol' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         it do
           foo = double(:widget)
         end
@@ -44,7 +44,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
     end
 
     it 'still flags doubles whose name is a string' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           foo = double("widget")
                 ^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -57,7 +57,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
     let(:cop_config) { { 'IgnoreNameless' => false } }
 
     it 'flags doubles that have no name specified' do
-      expect_offense(<<-RUBY)
+      expect_offense(<<~RUBY)
         it do
           foo = double
                 ^^^^^^ Prefer using verifying doubles over normal doubles.
@@ -67,7 +67,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
   end
 
   it 'ignores doubles that have no name specified' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it do
         foo = double
       end
@@ -75,7 +75,7 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
   end
 
   it 'ignores instance_doubles' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it do
         foo = instance_double("Foo")
       end

--- a/spec/rubocop/cop/rspec/void_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/void_expect_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
   it 'registers offenses to void `expect`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'something' do
         something = 1
         expect(something)
@@ -12,7 +12,7 @@ RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
   end
 
   it 'registers offenses to void `expect` when block has one expression' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'something' do
         expect(something)
         ^^^^^^^^^^^^^^^^^ Do not use `expect()` without `.to` or `.not_to`. Chain the methods or remove it.
@@ -21,7 +21,7 @@ RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
   end
 
   it 'registers offenses to void `expect` with block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       it 'something' do
         expect{something}
         ^^^^^^^^^^^^^^^^^ Do not use `expect()` without `.to` or `.not_to`. Chain the methods or remove it.
@@ -30,7 +30,7 @@ RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
   end
 
   it 'accepts non-void `expect`' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'something' do
         expect(something).to be 1
       end
@@ -38,7 +38,7 @@ RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
   end
 
   it 'accepts non-void `expect` with block' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       it 'something' do
         expect{something}.to raise_error(StandardError)
       end

--- a/spec/rubocop/cop/rspec/yield_spec.rb
+++ b/spec/rubocop/cop/rspec/yield_spec.rb
@@ -2,18 +2,18 @@
 
 RSpec.describe RuboCop::Cop::RSpec::Yield do
   it 'flags `block.call`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       allow(foo).to receive(:bar) { |&block| block.call }
                                   ^^^^^^^^^^^^^^^^^^^^^^^ Use `.and_yield`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       allow(foo).to receive(:bar).and_yield
     RUBY
   end
 
   it 'flags multiple `block.call`' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       allow(foo).to receive(:bar) do |&block|
                                   ^^^^^^^^^^^ Use `.and_yield`.
         block.call
@@ -21,24 +21,24 @@ RSpec.describe RuboCop::Cop::RSpec::Yield do
       end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       allow(foo).to receive(:bar).and_yield.and_yield
     RUBY
   end
 
   it 'flags `block.call` with arguments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       allow(foo).to receive(:bar) { |&block| block.call(1, 2) }
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `.and_yield`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       allow(foo).to receive(:bar).and_yield(1, 2)
     RUBY
   end
 
   it 'flags multiple `block.call` with arguments' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       allow(foo).to receive(:bar) do |&block|
                                   ^^^^^^^^^^^ Use `.and_yield`.
          block.call(1)
@@ -46,30 +46,30 @@ RSpec.describe RuboCop::Cop::RSpec::Yield do
        end
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       allow(foo).to receive(:bar).and_yield(1).and_yield(2)
     RUBY
   end
 
   it 'flags `block.call` when `receive` is chained' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       allow(foo).to receive(:bar).with(anything) { |&block| block.call }
                                                  ^^^^^^^^^^^^^^^^^^^^^^^ Use `.and_yield`.
     RUBY
 
-    expect_correction(<<-RUBY)
+    expect_correction(<<~RUBY)
       allow(foo).to receive(:bar).with(anything).and_yield
     RUBY
   end
 
   it 'ignores `receive` with no block arguments' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       allow(foo).to receive(:bar) { |block| block.call }
     RUBY
   end
 
   it 'ignores stub when `block.call` is not the only statement' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       allow(foo).to receive(:bar) do |&block|
         result = block.call
         transform(result)
@@ -79,13 +79,13 @@ RSpec.describe RuboCop::Cop::RSpec::Yield do
 
   context 'when Ruby 2.7', :ruby27 do
     it 'ignores `receive` with no block arguments' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         allow(foo).to receive(:bar) { _1.call }
       RUBY
     end
 
     it 'ignores stub when `block.call` is not the only statement' do
-      expect_no_offenses(<<-RUBY)
+      expect_no_offenses(<<~RUBY)
         allow(foo).to receive(:bar) do
           result = _1.call
           transform(result)

--- a/spec/rubocop/rspec/config_formatter_spec.rb
+++ b/spec/rubocop/rspec/config_formatter_spec.rb
@@ -40,28 +40,28 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
   it 'builds a YAML dump with spacing between cops' do
     formatter = described_class.new(config, descriptions)
 
-    expect(formatter.dump).to eql(<<-YAML.gsub(/^\s+\|/, ''))
-      |---
-      |AllCops:
-      |  Setting: forty two
-      |
-      |RSpec/Foo:
-      |  Config: 2
-      |  Enabled: true
-      |  Description: Blah
-      |  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Foo
-      |
-      |RSpec/Bar:
-      |  Enabled: true
-      |  Nullable: ~
-      |  Description: Wow
-      |  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Bar
-      |
-      |RSpec/Baz:
-      |  Enabled: true
-      |  StyleGuide: "#buzz"
-      |  Description: Woof
-      |  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Baz
+    expect(formatter.dump).to eql(<<~YAML)
+      ---
+      AllCops:
+        Setting: forty two
+
+      RSpec/Foo:
+        Config: 2
+        Enabled: true
+        Description: Blah
+        Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Foo
+
+      RSpec/Bar:
+        Enabled: true
+        Nullable: ~
+        Description: Wow
+        Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Bar
+
+      RSpec/Baz:
+        Enabled: true
+        StyleGuide: "#buzz"
+        Description: Woof
+        Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Baz
     YAML
   end
 end

--- a/spec/rubocop/rspec/description_extractor_spec.rb
+++ b/spec/rubocop/rspec/description_extractor_spec.rb
@@ -6,7 +6,7 @@ require 'rubocop/rspec/description_extractor'
 
 RSpec.describe RuboCop::RSpec::DescriptionExtractor do
   let(:yardocs) do
-    YARD.parse_string(<<-RUBY)
+    YARD.parse_string(<<~RUBY)
       # This is not a cop
       class RuboCop::Cop::Mixin::Sneaky
       end

--- a/spec/rubocop/rspec/example_group_spec.rb
+++ b/spec/rubocop/rspec/example_group_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::RSpec::ExampleGroup, :config do
   let(:cop_class) { RuboCop::Cop::RSpec::Base }
 
   let(:source) do
-    <<-RUBY
+    <<~RUBY
       RSpec.describe Foo do
         it 'does x' do
           x


### PR DESCRIPTION
Most new code uses the squiggly heredoc, but in a lot of places we were still using the "old" `<<-` heredoc.

I have seen pull requests changing the heredoc style from `<<-` to `<<~` and I don't like that :-) I prefer having style changes separate from  "real" code changes.

I have not checked if any of the specs were actually relying on the leading spaces in heredoc content, so reviewers may need to take a quick glance at that.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
