### PR TITLE
Bump version to v2.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Master (Unreleased)
 
+## 2.26.0 (2024-01-04)
+
 - Add new `RSpec/RedundantPredicateMatcher` cop. ([@ydah])
-- Add support for correcting "it will" (future tense) for `RSpec/ExampleWording`. ([@jdufresne])
 - Add new `RSpec/RemoveConst` cop. ([@swelther])
-- Ensure `PendingWithoutReason` can detect violations inside shared groups. ([@robinaugh])
+- Add support for correcting "it will" (future tense) for `RSpec/ExampleWording`. ([@jdufresne])
 - Add support for `symbol` style for `RSpec/SharedExamples`. ([@jessieay])
+- Ensure `PendingWithoutReason` can detect violations inside shared groups. ([@robinaugh])
 
 ## 2.25.0 (2023-10-27)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -774,13 +774,13 @@ RSpec/RedundantAround:
 RSpec/RedundantPredicateMatcher:
   Description: Checks for redundant predicate matcher.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.26'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RedundantPredicateMatcher
 
 RSpec/RemoveConst:
   Description: Checks that `remove_const` is not used in specs.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.26'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RemoveConst
 
 RSpec/RepeatedDescription:
@@ -851,7 +851,7 @@ RSpec/SharedExamples:
     - string
     - symbol
   VersionAdded: '1.25'
-  VersionChanged: "<<next>>"
+  VersionChanged: '2.26'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples
 
 RSpec/SingleArgumentMessageChain:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: ~
+version: '2.26'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4502,7 +4502,7 @@ end
 | Pending
 | Yes
 | Yes
-| <<next>>
+| 2.26
 | -
 |===
 
@@ -4533,7 +4533,7 @@ expect(foo).not_to include(bar)
 | Pending
 | Yes
 | No
-| <<next>>
+| 2.26
 | -
 |===
 
@@ -5050,7 +5050,7 @@ end
 | Yes
 | Yes
 | 1.25
-| <<next>>
+| 2.26
 |===
 
 Checks for consistent style for shared example names.

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.25.0'
+      STRING = '2.26.0'
     end
   end
 end


### PR DESCRIPTION
I think it’s time for the first release of the year. Changes:

- Add new `RSpec/RedundantPredicateMatcher` cop. ([@ydah])
- Add new `RSpec/RemoveConst` cop. ([@swelther])
- Add support for correcting "it will" (future tense) for `RSpec/ExampleWording`. ([@jdufresne])
- Add support for `symbol` style for `RSpec/SharedExamples`. ([@jessieay])
- Ensure `PendingWithoutReason` can detect violations inside shared groups. ([@robinaugh])

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

[@ydah]: https://github.com/ydah
[@swelther]: https://github.com/swelther
[@jdufresne]: https://github.com/jdufresne
[@jessieay]: https://github.com/jessieay
[@robinaugh]: https://github.com/robinaugh
