### PR TITLE
Fix a false positive for RSpec/ExpectActual with rspec-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Support correcting `assert_nil` and `refute_nil` to `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
+- Fix a false positive for `RSpec/ExpectActual` when used with rspec-rails routing matchers. ([@naveg])
 
 ## 2.26.1 (2024-01-05)
 
@@ -894,6 +895,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@mockdeep]: https://github.com/mockdeep
 [@mothonmars]: https://github.com/MothOnMars
 [@mvz]: https://github.com/mvz
+[@naveg]: https://github.com/naveg
 [@nc-holodakg]: https://github.com/nc-holodakg
 [@nevir]: https://github.com/nevir
 [@ngouy]: https://github.com/ngouy

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -50,7 +50,8 @@ module RuboCop
           regexp
         ].freeze
 
-        SUPPORTED_MATCHERS = %i[eq eql equal be].freeze
+        SKIPPED_MATCHERS = %i[route_to be_routable].freeze
+        CORRECTABLE_MATCHERS = %i[eq eql equal be].freeze
 
         # @!method expect_literal(node)
         def_node_matcher :expect_literal, <<~PATTERN
@@ -66,8 +67,10 @@ module RuboCop
 
         def on_send(node)
           expect_literal(node) do |actual, matcher, expected|
+            next if SKIPPED_MATCHERS.include?(matcher)
+
             add_offense(actual.source_range) do |corrector|
-              next unless SUPPORTED_MATCHERS.include?(matcher)
+              next unless CORRECTABLE_MATCHERS.include?(matcher)
               next if literal?(expected)
 
               swap(corrector, actual, expected)

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -317,6 +317,17 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
     expect_no_corrections
   end
 
+  it 'does not flag when the matcher is a rails routing matcher' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        it 'routes correctly' do
+          expect({:get => "foo"}).to be_routable
+          expect({:get => "foo"}).to route_to("bar#baz")
+        end
+      end
+    RUBY
+  end
+
   context 'when inspecting rspec-rails routing specs' do
     let(:cop_config) { {} }
 


### PR DESCRIPTION
rspec-rails comes with routing matchers that use literals in the `expect()`.

Fixes #759

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
