### PR TITLE
Fix an error for `RSpec/SharedExamples` when using examples without argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix an error for `RSpec/SharedExamples` when using examples without argument. ([@ydah])
+
 ## 2.26.0 (2024-01-04)
 
 - Add new `RSpec/RedundantPredicateMatcher` cop. ([@ydah])

--- a/lib/rubocop/cop/rspec/shared_examples.rb
+++ b/lib/rubocop/cop/rspec/shared_examples.rb
@@ -53,7 +53,7 @@ module RuboCop
 
         def on_send(node)
           shared_examples(node) do
-            ast_node = node.first_argument
+            next unless (ast_node = node.first_argument)
             next unless offense?(ast_node)
 
             checker = new_checker(ast_node)

--- a/spec/rubocop/cop/rspec/shared_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_examples_spec.rb
@@ -150,5 +150,18 @@ RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
         end
       RUBY
     end
+
+    context 'when using run_test!' do
+      before do
+        other_cops.dig('RSpec', 'Language', 'Includes', 'Examples')
+          .push('run_test!')
+      end
+
+      it 'does not occur an error' do
+        expect_no_offenses(<<~RUBY)
+          run_test!
+        RUBY
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1765

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
