### PR TITLE
Mark `RSpec/RedundantPredicateMatcher` as `Safe: false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Mark `RSpec/RedundantPredicateMatcher` as `Safe: false`. ([@koic])
+
 ## 2.26.1 (2024-01-05)
 
 - Fix an error for `RSpec/SharedExamples` when using examples without argument. ([@ydah])

--- a/config/default.yml
+++ b/config/default.yml
@@ -774,6 +774,7 @@ RSpec/RedundantAround:
 RSpec/RedundantPredicateMatcher:
   Description: Checks for redundant predicate matcher.
   Enabled: pending
+  Safe: false
   VersionAdded: '2.26'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RedundantPredicateMatcher
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4500,13 +4500,19 @@ end
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
 | Pending
-| Yes
-| Yes
+| No
+| Yes (Unsafe)
 | 2.26
 | -
 |===
 
 Checks for redundant predicate matcher.
+
+=== Safety
+
+This cop is marked as unsafe because false positives occur
+when `be_start_with` is used as a legitimate predicate matcher
+for `start_with?` method.
 
 === Examples
 

--- a/lib/rubocop/cop/rspec/redundant_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/redundant_predicate_matcher.rb
@@ -5,6 +5,11 @@ module RuboCop
     module RSpec
       # Checks for redundant predicate matcher.
       #
+      # @safety
+      #   This cop is marked as unsafe because false positives occur
+      #   when `be_start_with` is used as a legitimate predicate matcher
+      #   for `start_with?` method.
+      #
       # @example
       #   # bad
       #   expect(foo).to be_exist(bar)


### PR DESCRIPTION
`RSpec/RedundantPredicateMatcher` cop is marked as unsafe because false positives occur when `be_start_with` is used as a legitimate predicate matcher for `start_with?` method.

e.g., https://github.com/rubocop/rubocop-ast/commit/f9e6682

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
