### PR TITLE
Add a case for `be_all` fixes to the `RSpec/RedundantPredicateMatcher` documentation

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4515,10 +4515,12 @@ Checks for redundant predicate matcher.
 # bad
 expect(foo).to be_exist(bar)
 expect(foo).not_to be_include(bar)
+expect(foo).to be_all(bar)
 
 # good
 expect(foo).to exist(bar)
 expect(foo).not_to include(bar)
+expect(foo).to all be(bar)
 ----
 
 === References

--- a/lib/rubocop/cop/rspec/redundant_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/redundant_predicate_matcher.rb
@@ -9,10 +9,12 @@ module RuboCop
       #   # bad
       #   expect(foo).to be_exist(bar)
       #   expect(foo).not_to be_include(bar)
+      #   expect(foo).to be_all(bar)
       #
       #   # good
       #   expect(foo).to exist(bar)
       #   expect(foo).not_to include(bar)
+      #   expect(foo).to all be(bar)
       #
       class RedundantPredicateMatcher < Base
         extend AutoCorrector


### PR DESCRIPTION
Resolve: https://github.com/rubocop/rubocop-rspec/issues/1766

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
