### PR TITLE
feat: support `assert_not_equal` and `assert_not_nil` in `RSpec/Rails/MinitestAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Master (Unreleased)
 
-- Support correcting `assert_nil` and `refute_nil` to `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
+- Support correcting `assert_nil` and `refute_nil` in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
+- Support correcting `assert_not_equal` and `assert_not_equal` in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Fix a false positive for `RSpec/ExpectActual` when used with rspec-rails routing matchers. ([@naveg])
 - Add new `RSpec/RepeatedSubjectCall` cop. ([@drcapulet])
 

--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -29,19 +29,21 @@ module RuboCop
           MSG = 'Use `%<prefer>s`.'
           RESTRICT_ON_SEND = %i[
             assert_equal
+            assert_not_equal
             refute_equal
             assert_nil
+            assert_not_nil
             refute_nil
           ].freeze
 
           # @!method minitest_equal_assertion(node)
           def_node_matcher :minitest_equal_assertion, <<~PATTERN
-            (send nil? {:assert_equal :refute_equal} $_ $_ $_?)
+            (send nil? {:assert_equal :assert_not_equal :refute_equal} $_ $_ $_?)
           PATTERN
 
           # @!method minitest_nil_assertion(node)
           def_node_matcher :minitest_nil_assertion, <<~PATTERN
-            (send nil? {:assert_nil :refute_nil} $_ $_?)
+            (send nil? {:assert_nil :assert_not_nil :refute_nil} $_ $_?)
           PATTERN
 
           def on_send(node)

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
       RUBY
     end
 
+    it 'registers an offense when using `assert_not_equal`' do
+      expect_offense(<<~RUBY)
+        assert_not_equal a, b
+        ^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).not_to eq(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).not_to eq(a)
+      RUBY
+    end
+
     it 'registers an offense when using `refute_equal`' do
       expect_offense(<<~RUBY)
         refute_equal a, b
@@ -117,6 +128,17 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
 
       expect_correction(<<~RUBY)
         expect(a).to(eq(nil), "must be nil")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_not_nil`' do
+      expect_offense(<<~RUBY)
+        assert_not_nil a
+        ^^^^^^^^^^^^^^^^ Use `expect(a).not_to eq(nil)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).not_to eq(nil)
       RUBY
     end
 


### PR DESCRIPTION
I forgot about these when doing #1773 - I assume they're ok to include even though they're not technically part of native `minitest`.

I've also very slightly tweaked the wording of the changelog entry for #1773.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
