### PR TITLE
feat: support `*_includes` assertions in `RSpec/Rails/MinitestAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Master (Unreleased)
 
 - Add support for `assert_empty`, `assert_not_empty` and `refute_empty` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
-- Support correcting `assert_nil` and `refute_nil` in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
-- Support correcting `assert_not_equal` and `assert_not_equal` in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
+- Support correcting `*_includes` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
+- Support correcting `assert_not_equal` and `assert_not_nil` in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Fix a false positive for `RSpec/ExpectActual` when used with rspec-rails routing matchers. ([@naveg])
 - Add new `RSpec/RepeatedSubjectCall` cop. ([@drcapulet])
 

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -255,6 +255,7 @@ Check if using Minitest matchers.
 # bad
 assert_equal(a, b)
 assert_equal a, b, "must be equal"
+assert_not_includes a, b
 refute_equal(a, b)
 assert_nil a
 refute_empty(b)
@@ -262,6 +263,7 @@ refute_empty(b)
 # good
 expect(b).to eq(a)
 expect(b).to(eq(a), "must be equal")
+expect(a).not_to include(b)
 expect(b).not_to eq(a)
 expect(a).to eq(nil)
 expect(a).not_to be_empty

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -84,6 +84,92 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
     end
   end
 
+  context 'with includes assertions' do
+    it 'registers an offense when using `assert_includes`' do
+      expect_offense(<<~RUBY)
+        assert_includes(a, b)
+        ^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to include(b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to include(b)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_includes` with ' \
+       'no parentheses' do
+      expect_offense(<<~RUBY)
+        assert_includes a, b
+        ^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to include(b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to include(b)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_includes` with ' \
+       'failure message' do
+      expect_offense(<<~RUBY)
+        assert_includes a, b, "must be include"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to(include(b), "must be include")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to(include(b), "must be include")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_includes` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_includes(a,
+        ^^^^^^^^^^^^^^^^^^ Use `expect(a).to(include(b), "must be include")`.
+                      b,
+                      "must be include")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to(include(b), "must be include")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_not_includes`' do
+      expect_offense(<<~RUBY)
+        assert_not_includes a, b
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).not_to include(b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).not_to include(b)
+      RUBY
+    end
+
+    it 'registers an offense when using `refute_includes`' do
+      expect_offense(<<~RUBY)
+        refute_includes a, b
+        ^^^^^^^^^^^^^^^^^^^^ Use `expect(a).not_to include(b)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).not_to include(b)
+      RUBY
+    end
+
+    it 'does not register an offense when using `expect(a).to include(b)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(a).to include(b)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(a).not_to include(b)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(a).not_to include(b)
+      RUBY
+    end
+  end
+
   context 'with nil assertions' do
     it 'registers an offense when using `assert_nil`' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
~Branched off #1778~

This adds support for the `includes` assertions

related to #1485 
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
