### PR TITLE
feat: support `*_instance_of` in `RSpec/Rails/MinitestAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add support for `assert_empty`, `assert_not_empty` and `refute_empty` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
+- Support correcting `*_instance_of` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_includes` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `assert_not_equal` and `assert_not_nil` in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Fix a false positive for `RSpec/ExpectActual` when used with rspec-rails routing matchers. ([@naveg])

--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -82,17 +82,17 @@ module RuboCop
             end
 
             minitest_includes(node) do |collection, expected, failure_message|
-              on_assertion(node, IncludesAssertion.new(collection, expected,
+              on_assertion(node, IncludesAssertion.new(expected, collection,
                                                        failure_message.first))
             end
 
             minitest_nil(node) do |actual, failure_message|
-              on_assertion(node, NilAssertion.new(actual,
+              on_assertion(node, NilAssertion.new(nil, actual,
                                                   failure_message.first))
             end
 
             minitest_empty(node) do |actual, failure_message|
-              on_assertion(node, EmptyAssertion.new(actual,
+              on_assertion(node, EmptyAssertion.new(nil, actual,
                                                     failure_message.first))
             end
           end
@@ -109,99 +109,75 @@ module RuboCop
           end
 
           # :nodoc:
-          class EqualAssertion
+          class BasicAssertion
             def initialize(expected, actual, fail_message)
-              @expected = expected
-              @actual = actual
-              @fail_message = fail_message
+              @expected = expected&.source
+              @actual = actual.source
+              @fail_message = fail_message&.source
             end
 
             def replaced(node)
-              runner = node.method?(:assert_equal) ? 'to' : 'not_to'
+              runner = negated?(node) ? 'not_to' : 'to'
               if @fail_message.nil?
-                "expect(#{@actual.source}).#{runner} eq(#{@expected.source})"
+                "expect(#{@actual}).#{runner} #{assertion}"
               else
-                "expect(#{@actual.source}).#{runner}(eq(#{@expected.source})," \
-                  " #{@fail_message.source})"
+                "expect(#{@actual}).#{runner}(#{assertion}, #{@fail_message})"
               end
             end
           end
 
           # :nodoc:
-          class InstanceOfAssertion
-            def initialize(expected, actual, fail_message)
-              @expected = expected
-              @actual = actual
-              @fail_message = fail_message
+          class EqualAssertion < BasicAssertion
+            def negated?(node)
+              !node.method?(:assert_equal)
             end
 
-            def replaced(node)
-              runner = node.method?(:assert_instance_of) ? 'to' : 'not_to'
-              if @fail_message.nil?
-                "expect(#{@actual.source}).#{runner} be_an_instance_of" \
-                  "(#{@expected.source})"
-              else
-                "expect(#{@actual.source}).#{runner}(be_an_instance_of" \
-                  "(#{@expected.source}), #{@fail_message.source})"
-              end
+            def assertion
+              "eq(#{@expected})"
             end
           end
 
           # :nodoc:
-          class IncludesAssertion
-            def initialize(collection, expected, fail_message)
-              @collection = collection
-              @expected = expected
-              @fail_message = fail_message
+          class InstanceOfAssertion < BasicAssertion
+            def negated?(node)
+              !node.method?(:assert_instance_of)
             end
 
-            def replaced(node)
-              a_source = @collection.source
-              b_source = @expected.source
-
-              runner = node.method?(:assert_includes) ? 'to' : 'not_to'
-              if @fail_message.nil?
-                "expect(#{a_source}).#{runner} include(#{b_source})"
-              else
-                "expect(#{a_source}).#{runner}(include(#{b_source})," \
-                  " #{@fail_message.source})"
-              end
+            def assertion
+              "be_an_instance_of(#{@expected})"
             end
           end
 
           # :nodoc:
-          class NilAssertion
-            def initialize(actual, fail_message)
-              @actual = actual
-              @fail_message = fail_message
+          class IncludesAssertion < BasicAssertion
+            def negated?(node)
+              !node.method?(:assert_includes)
             end
 
-            def replaced(node)
-              runner = node.method?(:assert_nil) ? 'to' : 'not_to'
-              if @fail_message.nil?
-                "expect(#{@actual.source}).#{runner} eq(nil)"
-              else
-                "expect(#{@actual.source}).#{runner}(eq(nil), " \
-                  "#{@fail_message.source})"
-              end
+            def assertion
+              "include(#{@expected})"
             end
           end
 
           # :nodoc:
-          class EmptyAssertion
-            def initialize(actual, fail_message)
-              @actual = actual
-              @fail_message = fail_message
+          class NilAssertion < BasicAssertion
+            def negated?(node)
+              !node.method?(:assert_nil)
             end
 
-            def replaced(node)
-              runner = node.method?(:assert_empty) ? 'to' : 'not_to'
-              if @fail_message.nil?
-                "expect(#{@actual.source}).#{runner} be_empty"
-              else
-                "expect(#{@actual.source}).#{runner}(be_empty, " \
-                  "#{@fail_message.source})"
-              end
+            def assertion
+              'eq(nil)'
+            end
+          end
+
+          # :nodoc:
+          class EmptyAssertion < BasicAssertion
+            def negated?(node)
+              !node.method?(:assert_empty)
+            end
+
+            def assertion
+              'be_empty'
             end
           end
         end

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -84,6 +84,107 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
     end
   end
 
+  context 'with instance_of assertions' do
+    it 'registers an offense when using `assert_instance_of`' do
+      expect_offense(<<~RUBY)
+        assert_instance_of(a, b)
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_an_instance_of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_an_instance_of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_instance_of` with ' \
+       'no parentheses' do
+      expect_offense(<<~RUBY)
+        assert_instance_of a, b
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_an_instance_of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_an_instance_of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_instance_of` with' \
+       'failure message' do
+      expect_offense(<<~RUBY)
+        assert_instance_of a, b, "must be instance of"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to(be_an_instance_of(a), "must be instance of")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to(be_an_instance_of(a), "must be instance of")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_instance_of` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_instance_of(a,
+        ^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to(be_an_instance_of(a), "must be instance of")`.
+                      b,
+                      "must be instance of")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to(be_an_instance_of(a), "must be instance of")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_not_instance_of`' do
+      expect_offense(<<~RUBY)
+        assert_not_instance_of a, b
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).not_to be_an_instance_of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).not_to be_an_instance_of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `refute_instance_of`' do
+      expect_offense(<<~RUBY)
+        refute_instance_of a, b
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).not_to be_an_instance_of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).not_to be_an_instance_of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).to be_an_instance_of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).to be_an_instance_of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).not_to be_an_instance_of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).not_to be_an_instance_of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).to be_instance_of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).to be_instance_of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).not_to be_instance_of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).not_to be_instance_of(a)
+      RUBY
+    end
+  end
+
   context 'with includes assertions' do
     it 'registers an offense when using `assert_includes`' do
       expect_offense(<<~RUBY)
@@ -149,23 +250,6 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
       expect_offense(<<~RUBY)
         refute_includes a, b
         ^^^^^^^^^^^^^^^^^^^^ Use `expect(a).not_to include(b)`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        expect(a).not_to include(b)
-      RUBY
-    end
-
-    it 'does not register an offense when using `expect(a).to include(b)`' do
-      expect_no_offenses(<<~RUBY)
-        expect(a).to include(b)
-      RUBY
-    end
-
-    it 'does not register an offense when ' \
-       'using `expect(a).not_to include(b)`' do
-      expect_no_offenses(<<~RUBY)
-        expect(a).not_to include(b)
       RUBY
     end
   end


### PR DESCRIPTION
Related to #1485

I've _not_ included this in the cops documentation as I figure ultimately documenting every single form of matcher translation could end up being pretty big and this is a straightforward one - happy to add it though if folks disagree/don't mind the length.

I've also refactored the assertion classes so they extend from a basic parent that handles the generation of the actual matchers - I've kept this as a separate commit for easier review and in case folks want that landed in a different PR (or not at all).

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
