### PR TITLE
feat: support "match" assertions in `RSpec/Rails/MinitestAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add support for `assert_empty`, `assert_not_empty` and `refute_empty` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
+- Support correcting `*_match` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_instance_of` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_includes` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `assert_not_equal` and `assert_not_nil` in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -254,6 +254,79 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
     end
   end
 
+  context 'with match assertions' do
+    it 'registers an offense when using `assert_match`' do
+      expect_offense(<<~RUBY)
+        assert_match(/xyz/, b)
+        ^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to match(/xyz/)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to match(/xyz/)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_match` with no parentheses' do
+      expect_offense(<<~RUBY)
+        assert_match /xyz/, b
+        ^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to match(/xyz/)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to match(/xyz/)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_match` with failure message' do
+      expect_offense(<<~RUBY)
+        assert_match /xyz/, b, "must match"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to(match(/xyz/), "must match")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to(match(/xyz/), "must match")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_match` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_match(/xyz/,
+        ^^^^^^^^^^^^^^^^^^^ Use `expect(b).to(match(/xyz/), "must match")`.
+                      b,
+                      "must match")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to(match(/xyz/), "must match")
+      RUBY
+    end
+
+    it 'registers an offense when using `refute_match`' do
+      expect_offense(<<~RUBY)
+        refute_match /xyz/, b
+        ^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).not_to match(/xyz/)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).not_to match(/xyz/)
+      RUBY
+    end
+
+    it 'does not register an offense when using `expect(b).to match(/xyz/)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).to match(/xyz/)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).not_to match(/xyz/)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).not_to match(/xyz/)
+      RUBY
+    end
+  end
+
   context 'with nil assertions' do
     it 'registers an offense when using `assert_nil`' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Related to #1485

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
