### PR TITLE
fix: support asserts with messages in `Rspec/BeEmpty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Support asserts with messages in `Rspec/BeEmpty`. ([@G-Rath])
 - Add support for `assert_empty`, `assert_not_empty` and `refute_empty` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
 - Support correcting `*_instance_of` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_includes` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])

--- a/lib/rubocop/cop/rspec/be_empty.rb
+++ b/lib/rubocop/cop/rspec/be_empty.rb
@@ -28,6 +28,7 @@ module RuboCop
               (send nil? :match_array (array))
               (send nil? :contain_exactly)
             }
+            _?
           )
         PATTERN
 

--- a/spec/rubocop/cop/rspec/be_empty_spec.rb
+++ b/spec/rubocop/cop/rspec/be_empty_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe RuboCop::Cop::RSpec::BeEmpty do
     RUBY
   end
 
+  it 'registers an offense when ' \
+     'using `expect(array).to contain_exactly, "with a message"`' do
+    expect_offense(<<~RUBY)
+      expect(array).to contain_exactly, "with a message"
+                       ^^^^^^^^^^^^^^^ Use `be_empty` matchers for checking an empty array.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(array).to be_empty, "with a message"
+    RUBY
+  end
+
   it 'registers an offense when using `expect(array).to match_array([])`' do
     expect_offense(<<~RUBY)
       expect(array).to match_array([])
@@ -23,9 +35,28 @@ RSpec.describe RuboCop::Cop::RSpec::BeEmpty do
     RUBY
   end
 
+  it 'registers an offense when ' \
+     'using `expect(array).to match_array([]), "with a message"`' do
+    expect_offense(<<~RUBY)
+      expect(array).to match_array([]), "with a message"
+                       ^^^^^^^^^^^^^^^ Use `be_empty` matchers for checking an empty array.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(array).to be_empty, "with a message"
+    RUBY
+  end
+
   it 'does not register an offense when using `expect(array).to be_empty`' do
     expect_no_offenses(<<~RUBY)
       expect(array).to be_empty
+    RUBY
+  end
+
+  it 'does not register an offense when ' \
+     'using `expect(array).to be_empty, "with a message"`' do
+    expect_no_offenses(<<~RUBY)
+      expect(array).to be_empty, "with a message"
     RUBY
   end
 end


### PR DESCRIPTION
Adds support for when `contain_exactly` and `match_array are used with a message

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
