### PR TITLE
Add support for `assert_true` and `assert_false` to `RSpec/Rails/MinitestAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Add support for `assert_true` and `assert_false` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
 - Support asserts with messages in `Rspec/BeEmpty`. ([@G-Rath])
 - Add support for `assert_empty`, `assert_not_empty` and `refute_empty` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
 - Support correcting some `*_predicate` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1172,7 +1172,7 @@ RSpec/Rails/InferredSpecType:
     views: view
 
 RSpec/Rails/MinitestAssertions:
-  Description: Check if using Minitest matchers.
+  Description: Check if using Minitest-like matchers.
   Enabled: pending
   VersionAdded: '2.17'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Rails/MinitestAssertions

--- a/docs/modules/ROOT/pages/cops_rspec_rails.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec_rails.adoc
@@ -252,7 +252,10 @@ end
 | -
 |===
 
-Check if using Minitest matchers.
+Check if using Minitest-like matchers.
+
+Check the use of minitest-like matchers
+starting with `assert_` or `refute_`.
 
 === Examples
 
@@ -265,6 +268,8 @@ assert_not_includes a, b
 refute_equal(a, b)
 assert_nil a
 refute_empty(b)
+assert_true(a)
+assert_false(a)
 
 # good
 expect(b).to eq(a)
@@ -273,6 +278,8 @@ expect(a).not_to include(b)
 expect(b).not_to eq(a)
 expect(a).to eq(nil)
 expect(a).not_to be_empty
+expect(a).to be(true)
+expect(a).to be(false)
 ----
 
 === References

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -508,6 +508,100 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
     end
   end
 
+  context 'with boolean assertions' do
+    it 'registers an offense when using `assert_true`' do
+      expect_offense(<<~RUBY)
+        assert_true(a)
+        ^^^^^^^^^^^^^^ Use `expect(a).to be(true)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to be(true)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_true` with no parentheses' do
+      expect_offense(<<~RUBY)
+        assert_true a
+        ^^^^^^^^^^^^^ Use `expect(a).to be(true)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to be(true)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_true` with failure message' do
+      expect_offense(<<~RUBY)
+        assert_true a, "must be true"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to(be(true), "must be true")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to(be(true), "must be true")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_true` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_true(a,
+        ^^^^^^^^^^^^^^ Use `expect(a).to(be(true), "must be true")`.
+                    "must be true")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to(be(true), "must be true")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_false`' do
+      expect_offense(<<~RUBY)
+        assert_false(a)
+        ^^^^^^^^^^^^^^^ Use `expect(a).to be(false)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to be(false)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_false` with no parentheses' do
+      expect_offense(<<~RUBY)
+        assert_false a
+        ^^^^^^^^^^^^^^ Use `expect(a).to be(false)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to be(false)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_false` with failure message' do
+      expect_offense(<<~RUBY)
+        assert_false a, "must be false"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to(be(false), "must be false")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to(be(false), "must be false")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_false` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_false(a,
+        ^^^^^^^^^^^^^^^ Use `expect(a).to(be(false), "must be false")`.
+                     "must be false")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to(be(false), "must be false")
+      RUBY
+    end
+  end
+
   context 'with predicate assertions' do
     it 'registers an offense when using `assert_predicate` with ' \
        'an actual predicate' do


### PR DESCRIPTION
related to #1485 

This PR add support for `assert_true` and `assert_false` to `RSpec/Rails/MinitestAssertions`.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
