### PR TITLE
test: group minitest "empty" assertions in their own context

### DIFF
--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -407,7 +407,9 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
         expect(a).not_to eq(nil)
       RUBY
     end
+  end
 
+  context 'with empty assertions' do
     it 'registers an offense when using `assert_empty`' do
       expect_offense(<<~RUBY)
         assert_empty(a)


### PR DESCRIPTION
Noticed while looking into other matchers to support

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] ~Updated documentation.~
- [x] ~Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
