### PR TITLE
feat: support some "predicate" assertions in `RSpec/Rails/MinitestAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support asserts with messages in `Rspec/BeEmpty`. ([@G-Rath])
 - Add support for `assert_empty`, `assert_not_empty` and `refute_empty` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
+- Support correcting some `*_predicate` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_match` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_instance_of` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_includes` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -507,4 +507,134 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
       RUBY
     end
   end
+
+  context 'with predicate assertions' do
+    it 'registers an offense when using `assert_predicate` with ' \
+       'an actual predicate' do
+      expect_offense(<<~RUBY)
+        assert_predicate(a, :valid?)
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to be_valid`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to be_valid
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_predicate` with ' \
+       'an actual predicate and no parentheses' do
+      expect_offense(<<~RUBY)
+        assert_predicate a, :valid?
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to be_valid`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to be_valid
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_predicate` with ' \
+       'an actual predicate and a failure message' do
+      expect_offense(<<~RUBY)
+        assert_predicate a, :valid?, "must be valid"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).to(be_valid, "must be valid")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to(be_valid, "must be valid")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_predicate` with ' \
+       'an actual predicate and multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_predicate(a,
+        ^^^^^^^^^^^^^^^^^^^ Use `expect(a).to(be_valid, "must be valid")`.
+                      :valid?,
+                      "must be valid")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).to(be_valid, "must be valid")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_not_predicate` with ' \
+       'an actual predicate' do
+      expect_offense(<<~RUBY)
+        assert_not_predicate a, :valid?
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).not_to be_valid`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).not_to be_valid
+      RUBY
+    end
+
+    it 'registers an offense when using `refute_predicate` with ' \
+       'an actual predicate' do
+      expect_offense(<<~RUBY)
+        refute_predicate a, :valid?
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(a).not_to be_valid`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(a).not_to be_valid
+      RUBY
+    end
+
+    it 'does not register an offense when using `expect(a).to be_predicate`' do
+      expect_no_offenses(<<~RUBY)
+        expect(a).to be_predicate
+      RUBY
+    end
+
+    it 'does not register an offense when using ' \
+       '`expect(a).not_to be_predicate`' do
+      expect_no_offenses(<<~RUBY)
+        expect(a).not_to be_predicate
+      RUBY
+    end
+
+    it 'does not register an offense when using `assert_predicate` with ' \
+       'not a predicate' do
+      expect_no_offenses(<<~RUBY)
+        assert_predicate foo, :do_something
+      RUBY
+    end
+
+    it 'does not register an offense when using `assert_not_predicate` with ' \
+       'not a predicate' do
+      expect_no_offenses(<<~RUBY)
+        assert_not_predicate foo, :do_something
+      RUBY
+    end
+
+    it 'does not register an offense when using `refute_predicate` with ' \
+       'not a predicate' do
+      expect_no_offenses(<<~RUBY)
+        refute_predicate foo, :do_something
+      RUBY
+    end
+
+    it 'does not register an offense when the predicate is not a symbol' do
+      expect_no_offenses(<<~RUBY)
+        assert_predicate a, 1
+      RUBY
+    end
+
+    it 'does not register an offense when the predicate is missing' do
+      expect_no_offenses(<<~RUBY)
+        assert_predicate a, "whoops, we forgot about the actual predicate!"
+      RUBY
+    end
+
+    it 'does not register an offense when the predicate is a variable' do
+      expect_no_offenses(<<~RUBY)
+        foo = :foo?
+
+        assert_predicate a, foo
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This implements some support for `assert_predicate` and co, focused on transforming usage with predicate methods (e.g. `valid?`) into their `be_` equivalents.

Predicates that are not symbols or that don't end with `?` are ignored - a follow up PR can expand support for other uses of `assert_predicate`.

I think technically this makes the autofix unsafe because `assert_predicate` uses `send` whereas RSpec uses `send_public` so you could assert a private method which would break when fixed, but I feel like that would generally be considered bad practice anyway and an easy mistake so arguably this could be useful?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
