### PR TITLE
feat: support correcting `*_in_delta` assertions in `RSpec/Rails/MinitestAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support asserts with messages in `Rspec/BeEmpty`. ([@G-Rath])
 - Add support for `assert_empty`, `assert_not_empty` and `refute_empty` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
 - Support correcting some `*_predicate` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
+- Support correcting `*_in_delta` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_match` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_instance_of` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_includes` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])

--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -136,12 +136,10 @@ module RuboCop
 
             # @!method self.minitest_assertion(node)
             def_node_matcher 'self.minitest_assertion', <<~PATTERN # rubocop:disable InternalAffairs/NodeMatcherDirective
-              (send nil? {:assert_in_delta :assert_not_in_delta :refute_in_delta} $_ $_ $!{sym str}? $_?)
+              (send nil? {:assert_in_delta :assert_not_in_delta :refute_in_delta} $_ $_ $_? $_?)
             PATTERN
 
             def self.match(expected, actual, delta, failure_message)
-              return nil if delta.empty? && !failure_message.empty?
-
               new(expected, actual, delta.first, failure_message.first)
             end
 

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -271,6 +271,127 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
     end
   end
 
+  context 'with in_delta assertions' do
+    it 'registers an offense when using `assert_in_delta`' do
+      expect_offense(<<~RUBY)
+        assert_in_delta(a, b)
+        ^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_within(0.001).of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_within(0.001).of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_in_delta` with ' \
+       'no parentheses' do
+      expect_offense(<<~RUBY)
+        assert_in_delta a, b
+        ^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_within(0.001).of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_within(0.001).of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_in_delta` with ' \
+       'a custom delta' do
+      expect_offense(<<~RUBY)
+        assert_in_delta a, b, 1
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_within(1).of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_within(1).of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_in_delta` with ' \
+       'a custom delta from a variable' do
+      expect_offense(<<~RUBY)
+        delta = 1
+
+        assert_in_delta a, b, delta
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_within(delta).of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        delta = 1
+
+        expect(b).to be_within(delta).of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_in_delta` with ' \
+       'a custom delta and a failure message' do
+      expect_offense(<<~RUBY)
+        assert_in_delta a, b, 1, "must be within delta"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to(be_within(1).of(a), "must be within delta")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to(be_within(1).of(a), "must be within delta")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_in_delta` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_in_delta(a,
+        ^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_within(1).of(a)`.
+                      b,
+                      1)
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_within(1).of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_not_in_delta`' do
+      expect_offense(<<~RUBY)
+        assert_not_in_delta a, b
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).not_to be_within(0.001).of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).not_to be_within(0.001).of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `refute_in_delta`' do
+      expect_offense(<<~RUBY)
+        refute_in_delta a, b
+        ^^^^^^^^^^^^^^^^^^^^ Use `expect(b).not_to be_within(0.001).of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).not_to be_within(0.001).of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).to be_within(1).of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).to be_within(1).of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).not_to be_within(1).of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).not_to be_within(1).of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when the delta is missing' do
+      expect_no_offenses(<<~RUBY)
+        assert_in_delta a, b, "whoops, we forgot about the actual delta!"
+      RUBY
+    end
+  end
+
   context 'with match assertions' do
     it 'registers an offense when using `assert_match`' do
       expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -336,18 +336,6 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
     end
 
     it 'registers an offense when using `assert_in_delta` with ' \
-       'a missing delta' do
-      expect_offense(<<~RUBY)
-        assert_in_delta a, b, "whoops, we forgot about the actual delta!"
-        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_within("whoops, we forgot about the actual delta!").of(a)`.
-      RUBY
-
-      expect_correction(<<~RUBY)
-        expect(b).to be_within("whoops, we forgot about the actual delta!").of(a)
-      RUBY
-    end
-
-    it 'registers an offense when using `assert_in_delta` with ' \
        'multi-line arguments' do
       expect_offense(<<~RUBY)
         assert_in_delta(a,

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -336,6 +336,18 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
     end
 
     it 'registers an offense when using `assert_in_delta` with ' \
+       'a missing delta' do
+      expect_offense(<<~RUBY)
+        assert_in_delta a, b, "whoops, we forgot about the actual delta!"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_within("whoops, we forgot about the actual delta!").of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_within("whoops, we forgot about the actual delta!").of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_in_delta` with ' \
        'multi-line arguments' do
       expect_offense(<<~RUBY)
         assert_in_delta(a,
@@ -382,12 +394,6 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
        'using `expect(b).not_to be_within(1).of(a)`' do
       expect_no_offenses(<<~RUBY)
         expect(b).not_to be_within(1).of(a)
-      RUBY
-    end
-
-    it 'does not register an offense when the delta is missing' do
-      expect_no_offenses(<<~RUBY)
-        assert_in_delta a, b, "whoops, we forgot about the actual delta!"
       RUBY
     end
   end


### PR DESCRIPTION
This is branched off #1790, showing how easy it is to now add a new assertion matcher - until the prior PR is merged, the last commit of this PR should be looked at for review.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
