### PR TITLE
Implement #negated? in superclass

### DIFF
--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -44,7 +44,7 @@ module RuboCop
             end
 
             def negated?(node)
-              raise NotImplementedError
+              node.method_name.start_with?('assert_not_', 'refute_')
             end
 
             def assertion
@@ -68,10 +68,6 @@ module RuboCop
               new(expected, actual, failure_message.first)
             end
 
-            def negated?(node)
-              !node.method?(:assert_equal)
-            end
-
             def assertion
               "eq(#{@expected})"
             end
@@ -93,10 +89,6 @@ module RuboCop
               new(expected, actual, failure_message.first)
             end
 
-            def negated?(node)
-              !node.method?(:assert_instance_of)
-            end
-
             def assertion
               "be_an_instance_of(#{@expected})"
             end
@@ -116,10 +108,6 @@ module RuboCop
 
             def self.match(collection, expected, failure_message)
               new(expected, collection, failure_message.first)
-            end
-
-            def negated?(node)
-              !node.method?(:assert_includes)
             end
 
             def assertion
@@ -145,10 +133,6 @@ module RuboCop
               new(predicate, subject, failure_message.first)
             end
 
-            def negated?(node)
-              !node.method?(:assert_predicate)
-            end
-
             def assertion
               "be_#{@expected.delete_prefix(':').delete_suffix('?')}"
             end
@@ -167,10 +151,6 @@ module RuboCop
 
             def self.match(matcher, actual, failure_message)
               new(matcher, actual, failure_message.first)
-            end
-
-            def negated?(node)
-              !node.method?(:assert_match)
             end
 
             def assertion
@@ -194,10 +174,6 @@ module RuboCop
               new(nil, actual, failure_message.first)
             end
 
-            def negated?(node)
-              !node.method?(:assert_nil)
-            end
-
             def assertion
               'eq(nil)'
             end
@@ -217,10 +193,6 @@ module RuboCop
 
             def self.match(actual, failure_message)
               new(nil, actual, failure_message.first)
-            end
-
-            def negated?(node)
-              !node.method?(:assert_empty)
             end
 
             def assertion


### PR DESCRIPTION
All current matchers follow the pattern of negative assertions matching `assert_not_*` and `refute_*`. If we add a matcher where the negative assertions do not match this pattern, the method can still be overwritten in that subclass.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] ~Added tests.~
- [ ] ~Updated documentation.~
- [ ] ~Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
