### PR TITLE
Refactor assertions: Move node patterns into subclasses

### DIFF
--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -28,18 +28,20 @@ module RuboCop
 
           # :nodoc:
           class BasicAssertion
-            def initialize(expected, actual, fail_message)
+            attr_reader :expected, :actual, :failure_message
+
+            def initialize(expected, actual, failure_message)
               @expected = expected&.source
               @actual = actual.source
-              @fail_message = fail_message&.source
+              @failure_message = failure_message&.source
             end
 
             def replaced(node)
               runner = negated?(node) ? 'not_to' : 'to'
-              if @fail_message.nil?
-                "expect(#{@actual}).#{runner} #{assertion}"
+              if failure_message.nil?
+                "expect(#{actual}).#{runner} #{assertion}"
               else
-                "expect(#{@actual}).#{runner}(#{assertion}, #{@fail_message})"
+                "expect(#{actual}).#{runner}(#{assertion}, #{failure_message})"
               end
             end
 
@@ -69,7 +71,7 @@ module RuboCop
             end
 
             def assertion
-              "eq(#{@expected})"
+              "eq(#{expected})"
             end
           end
 
@@ -90,7 +92,7 @@ module RuboCop
             end
 
             def assertion
-              "be_an_instance_of(#{@expected})"
+              "be_an_instance_of(#{expected})"
             end
           end
 
@@ -111,7 +113,7 @@ module RuboCop
             end
 
             def assertion
-              "include(#{@expected})"
+              "include(#{expected})"
             end
           end
 
@@ -134,7 +136,7 @@ module RuboCop
             end
 
             def assertion
-              "be_#{@expected.delete_prefix(':').delete_suffix('?')}"
+              "be_#{expected.delete_prefix(':').delete_suffix('?')}"
             end
           end
 
@@ -154,7 +156,7 @@ module RuboCop
             end
 
             def assertion
-              "match(#{@expected})"
+              "match(#{expected})"
             end
           end
 


### PR DESCRIPTION
This way we can remove the metaprogramming of `def_node_matcher` and `public_send`, making the cop simpler.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).