### PR TITLE
feat: support "kind_of" assertions in `RSpec/Rails/MinitestAssertions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Support asserts with messages in `Rspec/BeEmpty`. ([@G-Rath])
 - Add support for `assert_empty`, `assert_not_empty` and `refute_empty` to `RSpec/Rails/MinitestAssertions`. ([@ydah])
 - Support correcting some `*_predicate` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
+- Support correcting `*_kind_of` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_in_delta` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_match` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])
 - Support correcting `*_instance_of` assertions in `RSpec/Rails/MinitestAssertions`. ([@G-Rath])

--- a/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
+++ b/lib/rubocop/cop/rspec/rails/minitest_assertions.rb
@@ -90,6 +90,28 @@ module RuboCop
           end
 
           # :nodoc:
+          class KindOfAssertion < BasicAssertion
+            MATCHERS = %i[
+              assert_kind_of
+              assert_not_kind_of
+              refute_kind_of
+            ].freeze
+
+            # @!method self.minitest_assertion(node)
+            def_node_matcher 'self.minitest_assertion', <<~PATTERN # rubocop:disable InternalAffairs/NodeMatcherDirective
+              (send nil? {:assert_kind_of :assert_not_kind_of :refute_kind_of} $_ $_ $_?)
+            PATTERN
+
+            def self.match(expected, actual, failure_message)
+              new(expected, actual, failure_message.first)
+            end
+
+            def assertion
+              "be_a_kind_of(#{expected})"
+            end
+          end
+
+          # :nodoc:
           class InstanceOfAssertion < BasicAssertion
             MATCHERS = %i[
               assert_instance_of

--- a/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
+++ b/spec/rubocop/cop/rspec/rails/minitest_assertions_spec.rb
@@ -84,6 +84,107 @@ RSpec.describe RuboCop::Cop::RSpec::Rails::MinitestAssertions do
     end
   end
 
+  context 'with kind_of assertions' do
+    it 'registers an offense when using `assert_kind_of`' do
+      expect_offense(<<~RUBY)
+        assert_kind_of(a, b)
+        ^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_a_kind_of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_a_kind_of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_kind_of` with ' \
+       'no parentheses' do
+      expect_offense(<<~RUBY)
+        assert_kind_of a, b
+        ^^^^^^^^^^^^^^^^^^^ Use `expect(b).to be_a_kind_of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to be_a_kind_of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_kind_of` with ' \
+       'failure message' do
+      expect_offense(<<~RUBY)
+        assert_kind_of a, b, "must be kind of"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).to(be_a_kind_of(a), "must be kind of")`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to(be_a_kind_of(a), "must be kind of")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_kind_of` with ' \
+       'multi-line arguments' do
+      expect_offense(<<~RUBY)
+        assert_kind_of(a,
+        ^^^^^^^^^^^^^^^^^ Use `expect(b).to(be_a_kind_of(a), "must be kind of")`.
+                      b,
+                      "must be kind of")
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).to(be_a_kind_of(a), "must be kind of")
+      RUBY
+    end
+
+    it 'registers an offense when using `assert_not_kind_of`' do
+      expect_offense(<<~RUBY)
+        assert_not_kind_of a, b
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `expect(b).not_to be_a_kind_of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).not_to be_a_kind_of(a)
+      RUBY
+    end
+
+    it 'registers an offense when using `refute_kind_of`' do
+      expect_offense(<<~RUBY)
+        refute_kind_of a, b
+        ^^^^^^^^^^^^^^^^^^^ Use `expect(b).not_to be_a_kind_of(a)`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(b).not_to be_a_kind_of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).to be_a_kind_of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).to be_a_kind_of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).not_to be_a_kind_of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).not_to be_a_kind_of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).to be_kind_of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).to be_kind_of(a)
+      RUBY
+    end
+
+    it 'does not register an offense when ' \
+       'using `expect(b).not_to be_kind_of(a)`' do
+      expect_no_offenses(<<~RUBY)
+        expect(b).not_to be_kind_of(a)
+      RUBY
+    end
+  end
+
   context 'with instance_of assertions' do
     it 'registers an offense when using `assert_instance_of`' do
       expect_offense(<<~RUBY)


### PR DESCRIPTION
Relates to #1485
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
