### PR TITLE
Fix a false negative for `RSpec/DescribedClass` when class with constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix a false positive for `RSpec/ExpectActual` when used with rspec-rails routing matchers. ([@naveg])
 - Add new `RSpec/RepeatedSubjectCall` cop. ([@drcapulet])
 - Add configuration option `ResponseMethods` to `RSpec/Rails/HaveHttpStatus`. ([@ydah])
+- Fix a false negative for `RSpec/DescribedClass` when class with constant. ([@ydah])
 
 ## 2.26.1 (2024-01-05)
 

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -113,7 +113,7 @@ module RuboCop
         def find_usage(node, &block)
           yield(node) if offensive?(node)
 
-          return if scope_change?(node) || node.const_type?
+          return if scope_change?(node)
 
           node.each_child_node do |child|
             find_usage(child, &block)

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -148,10 +148,32 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       RUBY
     end
 
-    it 'ignores subclasses' do
-      expect_no_offenses(<<~RUBY)
+    it 'flags class with constant' do
+      expect_offense(<<~RUBY)
         describe MyClass do
-          subject { MyClass::SubClass }
+          subject { MyClass::FOO }
+                    ^^^^^^^ Use `described_class` instead of `MyClass`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        describe MyClass do
+          subject { described_class::FOO }
+        end
+      RUBY
+    end
+
+    it 'flags class with subclasses' do
+      expect_offense(<<~RUBY)
+        describe MyClass do
+          subject { MyClass::Subclass }
+                    ^^^^^^^ Use `described_class` instead of `MyClass`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        describe MyClass do
+          subject { described_class::Subclass }
         end
       RUBY
     end


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1741

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
