### PR TITLE
various: fix miscellaneous typos

### DIFF
--- a/lib/rubocop/cop/rspec/redundant_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/redundant_predicate_matcher.rb
@@ -27,7 +27,7 @@ module RuboCop
 
         def on_send(node)
           return if node.parent.block_type? || node.arguments.empty?
-          return unless replacable_arguments?(node)
+          return unless replaceable_arguments?(node)
 
           method_name = node.method_name.to_s
           replaced = replaced_method_name(method_name)
@@ -45,7 +45,7 @@ module RuboCop
           format(MSG, bad: bad_method, good: good_method)
         end
 
-        def replacable_arguments?(node)
+        def replaceable_arguments?(node)
           if node.method?(:be_all)
             node.first_argument.send_type?
           else

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     RUBY
   end
 
-  it 'registers an offense when path containing the class nam' do
+  it 'registers an offense when path containing the class name' do
     filename = '/home/foo/spec/models/bar_spec.rb'
     expect_offense(<<~RUBY, filename)
       describe Foo do; end


### PR DESCRIPTION
This PR aims to fix various minor typos across the codebase. I noticed some of these when doing the same review on our Homebrew/brew repo, since we use rubocop-rspec. I've checked off what I could below given the minor nature of this change.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
