### PR TITLE
Add configuration option `AllowNested` to `RSpec/MultipleExpectations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix a false negative for `RSpec/DescribedClass` when class with constant. ([@ydah])
 - Fix a false positive for `RSpec/ExampleWithoutDescription` when `specify` with multi-line block and missing description. ([@ydah])
 - Fix an incorrect autocorrect for `RSpec/ChangeByZero` when compound expectations with line break before `.by(0)`. ([@ydah])
+- Add configuration option `AllowNested` to `RSpec/MultipleExpectations`. ([@ydah])
 
 ## 2.26.1 (2024-01-05)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -658,8 +658,9 @@ RSpec/MultipleExpectations:
   Description: Checks if examples contain too many `expect` calls.
   Enabled: true
   Max: 1
+  AllowNested: false
   VersionAdded: '1.7'
-  VersionChanged: '1.21'
+  VersionChanged: "<<next>>"
   StyleGuide: https://rspec.rubystyle.guide/#expectation-per-example
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3461,7 +3461,7 @@ end
 | Yes
 | No
 | 1.7
-| 1.21
+| <<next>>
 |===
 
 Checks if examples contain too many `expect` calls.
@@ -3545,6 +3545,34 @@ describe UserCreator do
 end
 ----
 
+==== `AllowNested: false` (default)
+
+[source,ruby]
+----
+# bad
+describe UserCreator do
+  it 'raises an error' do
+    expect { my_code }.to raise_error(MyErrorType) do |error|
+      expect(error.record.persisted?).to be(true)
+    end
+  end
+end
+----
+
+==== `AllowNested: true`
+
+[source,ruby]
+----
+# good
+describe UserCreator do
+  it 'raises an error' do
+    expect { my_code }.to raise_error(MyErrorType) do |error|
+      expect(error.record.persisted?).to be(true)
+    end
+  end
+end
+----
+
 === Configurable attributes
 
 |===
@@ -3553,6 +3581,10 @@ end
 | Max
 | `1`
 | Integer
+
+| AllowNested
+| `false`
+| Boolean
 |===
 
 === References

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -66,6 +66,26 @@ module RuboCop
       #     end
       #   end
       #
+      # @example `AllowNested: false` (default)
+      #   # bad
+      #   describe UserCreator do
+      #     it 'raises an error' do
+      #       expect { my_code }.to raise_error(MyErrorType) do |error|
+      #         expect(error.record.persisted?).to be(true)
+      #       end
+      #     end
+      #   end
+      #
+      # @example `AllowNested: true`
+      #   # good
+      #   describe UserCreator do
+      #     it 'raises an error' do
+      #       expect { my_code }.to raise_error(MyErrorType) do |error|
+      #         expect(error.record.persisted?).to be(true)
+      #       end
+      #     end
+      #   end
+      #
       class MultipleExpectations < Base
         include ConfigurableMax
 
@@ -124,6 +144,8 @@ module RuboCop
           # do not search inside of aggregate_failures block
           return if aggregate_failures_block?(node)
 
+          return if node.block_type? && allow_nested?
+
           node.each_child_node do |child|
             find_expectation(child, &block)
           end
@@ -142,6 +164,10 @@ module RuboCop
 
         def max_expectations
           Integer(cop_config.fetch('Max', 1))
+        end
+
+        def allow_nested?
+          cop_config.fetch('AllowNested', false)
         end
       end
     end

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -238,6 +238,39 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
     end
   end
 
+  context 'with `AllowNested: false`' do
+    let(:cop_config) { { 'AllowNested' => false } }
+
+    it 'flags nested expects' do
+      expect_offense(<<~RUBY)
+        describe Foo do
+          it 'uses expect with block' do
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+            expect { my_code }.to raise_error(MyErrorType) do |error|
+              expect(error.record.persisted?).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
+  context 'with `AllowNested: true`' do
+    let(:cop_config) { { 'AllowNested' => true } }
+
+    it 'ignores nested expects' do
+      expect_no_offenses(<<~RUBY)
+        describe Foo do
+          it 'uses expect with block twice' do
+            expect { my_code }.to raise_error(MyErrorType) do |error|
+              expect(error.record.persisted?).to be(true)
+            end
+          end
+        end
+      RUBY
+    end
+  end
+
   it 'generates a todo based on the worst offense' do
     inspect_source(<<~RUBY, 'spec/foo_spec.rb')
       describe Foo do


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/379

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
