### PR TITLE
CI: Fix the RSpec 4 job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           sed -e '/rspec/d' -i Gemfile
           cat << EOF > Gemfile.local
-            gem 'rspec', github: 'rspec/rspec', branch: '4-0-dev'
+            gem 'rspec', github: 'rspec/rspec-metagem', branch: '4-0-dev'
             gem 'rspec-core', github: 'rspec/rspec-core', branch: '4-0-dev'
             gem 'rspec-expectations', github: 'rspec/rspec-expectations', branch: '4-0-dev'
             gem 'rspec-mocks', github: 'rspec/rspec-mocks', branch: '4-0-dev'


### PR DESCRIPTION
I think rspec/rspec was finally removed recently. We should use rspec/rspec-metagem instead.