### PR TITLE
Add configuration option `OnlyStaticConstants` to `RSpec/DescribedClass`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix a false positive for `RSpec/RepeatedSubjectCall` when `subject.method_call`. ([@ydah])
+- Add configuration option `OnlyStaticConstants` to `RSpec/DescribedClass`. ([@ydah])
 
 ## 2.27.0 (2024-03-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -283,9 +283,10 @@ RSpec/DescribedClass:
   SupportedStyles:
     - described_class
     - explicit
+  OnlyStaticConstants: true
   SafeAutoCorrect: false
   VersionAdded: '1.0'
-  VersionChanged: '1.11'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass
 
 RSpec/DescribedClassModuleWrapping:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -887,7 +887,7 @@ end
 | Yes
 | Always (Unsafe)
 | 1.0
-| 1.11
+| <<next>>
 |===
 
 Checks that tests use `described_class`.
@@ -895,8 +895,10 @@ Checks that tests use `described_class`.
 If the first argument of describe is a class, the class is exposed to
 each example via described_class.
 
-This cop can be configured using the `EnforcedStyle` and `SkipBlocks`
-options.
+This cop can be configured using the `EnforcedStyle`, `SkipBlocks`
+and `OnlyStaticConstants` options.
+`OnlyStaticConstants` is only relevant when `EnforcedStyle` is
+`described_class`.
 
 There's a known caveat with rspec-rails's `controller` helper that
 runs its block in a different context, and `described_class` is not
@@ -921,6 +923,26 @@ end
 # good
 describe MyClass do
   subject { described_class.do_something }
+end
+----
+
+==== `OnlyStaticConstants: true` (default)
+
+[source,ruby]
+----
+# good
+describe MyClass do
+  subject { MyClass::CONSTANT }
+end
+----
+
+==== `OnlyStaticConstants: false`
+
+[source,ruby]
+----
+# bad
+describe MyClass do
+  subject { MyClass::CONSTANT }
 end
 ----
 
@@ -967,6 +989,10 @@ end
 | EnforcedStyle
 | `described_class`
 | `described_class`, `explicit`
+
+| OnlyStaticConstants
+| `true`
+| Boolean
 |===
 
 === References

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -148,36 +148,6 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       RUBY
     end
 
-    it 'flags class with constant' do
-      expect_offense(<<~RUBY)
-        describe MyClass do
-          subject { MyClass::FOO }
-                    ^^^^^^^ Use `described_class` instead of `MyClass`.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        describe MyClass do
-          subject { described_class::FOO }
-        end
-      RUBY
-    end
-
-    it 'flags class with subclasses' do
-      expect_offense(<<~RUBY)
-        describe MyClass do
-          subject { MyClass::Subclass }
-                    ^^^^^^^ Use `described_class` instead of `MyClass`.
-        end
-      RUBY
-
-      expect_correction(<<~RUBY)
-        describe MyClass do
-          subject { described_class::Subclass }
-        end
-      RUBY
-    end
-
     it 'ignores non-matching namespace defined on `describe` level' do
       expect_no_offenses(<<~RUBY)
         describe MyNamespace::MyClass do
@@ -309,6 +279,64 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
           end
         end
       RUBY
+    end
+
+    context 'when OnlyStaticConstants is `true`' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => :described_class, 'OnlyStaticConstants' => true }
+      end
+
+      it 'ignores class with constant' do
+        expect_no_offenses(<<~RUBY)
+          describe MyClass do
+            subject { MyClass::FOO }
+          end
+        RUBY
+      end
+
+      it 'ignores class with subclasses' do
+        expect_no_offenses(<<~RUBY)
+          describe MyClass do
+            subject { MyClass::Subclass }
+          end
+        RUBY
+      end
+    end
+
+    context 'when OnlyStaticConstants is `false`' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => :described_class, 'OnlyStaticConstants' => false }
+      end
+
+      it 'flags class with constant' do
+        expect_offense(<<~RUBY)
+          describe MyClass do
+            subject { MyClass::FOO }
+                      ^^^^^^^ Use `described_class` instead of `MyClass`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          describe MyClass do
+            subject { described_class::FOO }
+          end
+        RUBY
+      end
+
+      it 'flags class with subclasses' do
+        expect_offense(<<~RUBY)
+          describe MyClass do
+            subject { MyClass::Subclass }
+                      ^^^^^^^ Use `described_class` instead of `MyClass`.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          describe MyClass do
+            subject { described_class::Subclass }
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Fix: https://github.com/rubocop/rubocop-rspec/issues/1741#issuecomment-1973221319
Fix: https://github.com/rubocop/rubocop-rspec/issues/1741#issuecomment-1973604382

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
