### PR TITLE
Fix AssignmentOnly saying false instead of true in documentation

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2748,7 +2748,7 @@ end
 ----
 # rubocop.yml
 # RSpec/InstanceVariable:
-#   AssignmentOnly: false
+#   AssignmentOnly: true
 
 # bad
 describe MyClass do

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -26,7 +26,7 @@ module RuboCop
       # @example with AssignmentOnly configuration
       #   # rubocop.yml
       #   # RSpec/InstanceVariable:
-      #   #   AssignmentOnly: false
+      #   #   AssignmentOnly: true
       #
       #   # bad
       #   describe MyClass do


### PR DESCRIPTION
This option on the documentation was accidentally flipped from what it should have been. The example following is what happens when the "AssignmentOnly" configuration is set to "true", not "false"

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Updated documentation.
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

(Rest of prerequisites not applicable to this change)
