### PR TITLE
Use 'registers no offense' instead of 'register no offense'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,6 +85,9 @@ Naming/InclusiveLanguage:
     violation:
       Suggestions:
         - offense
+    'register no offense':
+      Suggestions:
+        - registers no offense
 
 RSpec:
   Language:


### PR DESCRIPTION
This PR use 'registers no offense' instead of 'register no offense'
Follow up: rubocop/rubocop#12779

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
