### PR TITLE
Fix a flaky test for spec/project/default_config_spec.rb

### DIFF
--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -121,6 +121,7 @@ RSpec.describe 'config/default.yml' do
         "`#{cop_name}` cop should be set `Safe: false` or " \
         '`SafeAutoCorrect: false` because `@safety` YARD tag exists.'
       )
+      YARD::Registry.clear
     end
   end
 end


### PR DESCRIPTION
```
bundle exec rspec './spec/project/default_config_spec.rb[1:8]' './spec/rubocop/rspec/description_extractor_spec.rb[1:1]' --seed=28987
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
