### PR TITLE
Fix autocorrect error for RSpec/ExpectActual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix an autocorrect error for `RSpec/ExpectActual`. ([@bquorning])
+
 ## 2.28.0 (2024-03-30)
 
 - Extract RSpec Rails cops to a separate repository, [`rubocop-rspec_rails`](https://github.com/rubocop/rubocop-rspec_rails). The `rubocop-rspec_rails` repository is a dependency of `rubocop-rspec` and the cops related to rspec-rails are aliased (`RSpec/Rails/Foo` == `RSpecRails/Foo`) until v3.0 is released, so the change will be invisible to users until then. ([@ydah])

--- a/spec/rubocop/cop/rspec/expect_actual_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_actual_spec.rb
@@ -148,6 +148,28 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectActual do
     RUBY
   end
 
+  it 'autocorrects literal hash when expected is without parentheses' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(foo: 1, bar: 2).to eq bar
+                 ^^^^^^^^^^^^^^ Provide the actual value you are testing to `expect(...)`.
+          expect({ foo: 1, bar: 2 }).to eq bar
+                 ^^^^^^^^^^^^^^^^^^ Provide the actual value you are testing to `expect(...)`.
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        it 'uses expect incorrectly' do
+          expect(bar).to eq(foo: 1, bar: 2)
+          expect(bar).to eq({ foo: 1, bar: 2 })
+        end
+      end
+    RUBY
+  end
+
   it 'flags ranges containing only literal values within expect(...)' do
     expect_offense(<<~RUBY)
       describe Foo do


### PR DESCRIPTION
When the expect value is not wrapped in parentheses, the result of autocorrecting would sometimes be invalid Ruby code.

Fixes #1834
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] ~Updated documentation.~
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).