### PR TITLE
Automatically create release notes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,12 @@ jobs:
           bundler-cache: true
           ruby-version: ruby
       - uses: rubygems/release-gem@v1
+      - name: Create a GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bundle exec rake create_release_notes
+          gh release create $(git tag --points-at @) --notes-file relnotes.md
       - name: Replace version in Antora config
         run: |
           sed -i 's/version:.*$/version: ~/' docs/antora.yml

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ coverage
 
 # vscode generated
 .vscode
+
+/relnotes.md

--- a/tasks/create_release_notes.rake
+++ b/tasks/create_release_notes.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+desc 'Create release notes for the most recent version.'
+task :create_release_notes do
+  CreateReleaseNotes.call
+end
+
+# Create release notes from the most recent version in the CHANGELOG.md file.
+module CreateReleaseNotes
+  module_function
+
+  def call
+    release_notes = new_version_changes.strip
+    contributor_links = user_links(release_notes)
+
+    File.open('relnotes.md', 'w') do |file|
+      file << release_notes
+      file << "\n\n"
+      file << contributor_links
+      file << "\n"
+    end
+  end
+
+  def new_version_changes
+    changelog = File.read('CHANGELOG.md')
+    _, _, new_changes, _older_changes = changelog.split(/^## .*$/, 4)
+    new_changes
+  end
+
+  def user_links(text)
+    names = text.scan(/\[@(\S+)\]/).map(&:first).uniq.sort
+    names.map { |name| "[@#{name}]: https://github.com/#{name}" }.join("\n")
+  end
+end


### PR DESCRIPTION
Adds a new rake task, `rake create_release_notes` which generates a relnotes.md file.

When CI creates and publishes a new gem version, it will now also create a release on GitHub, with the content of relnotes.md being used as release notes.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
