### PR TITLE
Bump to v2.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.29.0 (2024-04-04)
+
 - Fix an autocorrect error for `RSpec/ExpectActual`. ([@bquorning])
 - Add new `RSpec/UndescriptiveLiteralsDescription` cop. ([@ydah])
 - Add new `RSpec/EmptyOutput` cop. ([@bquorning])

--- a/config/default.yml
+++ b/config/default.yml
@@ -941,7 +941,7 @@ RSpec/SubjectStub:
 RSpec/UndescriptiveLiteralsDescription:
   Description: Description should be descriptive.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.29'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/UndescriptiveLiteralsDescription
 
 RSpec/UnspecifiedException:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: ~
+version: '2.29'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5656,7 +5656,7 @@ end
 | Pending
 | Yes
 | No
-| <<next>>
+| 2.29
 | -
 |===
 

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.28.0'
+      STRING = '2.29.0'
     end
   end
 end


### PR DESCRIPTION
I’m eager to see if [the new publish.yml workflow](https://github.com/rubocop/rubocop-rspec/blob/master/.github/workflows/publish.yml) works correctly ✨

Should we include #1854 in this release? Others too?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] ~Added tests.~
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
