### PR TITLE
Publishing: Only push antora.yml if it's changed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,14 @@ jobs:
           bundle exec rake create_release_notes
           gh release create $(git tag --points-at @) \
             --title "RuboCop RSpec $(git tag --points-at @)" \
-            --notes-file relnotes.md \
+            --notes-file relnotes.md
       - name: Replace version in Antora config
         run: |
           sed -i 's/version:.*$/version: ~/' docs/antora.yml
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add docs/antora.yml
-          git commit -m "Switch docs version back"
-          git push
+          if ! git diff --exit-code docs/antora.yml; then
+            git config user.name "${GITHUB_ACTOR}"
+            git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+            git add docs/antora.yml
+            git commit -m "Switch docs version back"
+            git push
+          fi


### PR DESCRIPTION
We don't change docs/antora.yml file on patch releases.

This does _not_ fix the issue with `git push` mentioned at https://github.com/rubocop/rubocop-rspec/pull/1829#issuecomment-2038349795

_________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

