### PR TITLE
RSpec/RepeatedSubjectCall: silence subject passed as function argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix beginless and endless range bug for RepeatedIncludeExample cop. ([@hasghari])
+- Fix a false positive for `RSpec/RepeatedSubjectCall` when subject is used as argument to function call. ([@K-S-A])
 
 ## 2.29.1 (2024-04-05)
 
@@ -978,3 +979,4 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@ypresto]: https://github.com/ypresto
 [@zdennis]: https://github.com/zdennis
 [@zverok]: https://github.com/zverok
+[@K-S-A]: https://github.com/K-S-A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -911,6 +911,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@jojos003]: https://github.com/jojos003
 [@jonatas]: https://github.com/jonatas
 [@jtannas]: https://github.com/jtannas
+[@k-s-a]: https://github.com/K-S-A
 [@kellysutton]: https://github.com/kellysutton
 [@koic]: https://github.com/koic
 [@kuahyeow]: https://github.com/kuahyeow
@@ -979,4 +980,3 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@ypresto]: https://github.com/ypresto
 [@zdennis]: https://github.com/zdennis
 [@zverok]: https://github.com/zverok
-[@K-S-A]: https://github.com/K-S-A

--- a/lib/rubocop/cop/rspec/repeated_subject_call.rb
+++ b/lib/rubocop/cop/rspec/repeated_subject_call.rb
@@ -72,6 +72,7 @@ module RuboCop
 
         def detect_offense(subject_node)
           return if subject_node.chained?
+          return if subject_node.parent.send_type?
           return unless (block_node = expect_block(subject_node))
 
           add_offense(block_node)

--- a/spec/rubocop/cop/rspec/repeated_subject_call_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_subject_call_spec.rb
@@ -114,6 +114,17 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedSubjectCall do
     RUBY
   end
 
+  it 'does not register an offense when `subject` as an argument' do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe Foo do
+        it do
+          expect { create(:bar, baz: subject) }.to change { A.count }
+          expect { create(:bar, subject) }.to not_change { A.count }
+        end
+      end
+    RUBY
+  end
+
   it 'does not register an offense when `subject` with not expectation' do
     expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do


### PR DESCRIPTION
Naive approach to resolve https://github.com/rubocop/rubocop-rspec/issues/1870
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
