### PR TITLE
Fix some rubocop offenses

### DIFF
--- a/spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb
@@ -90,7 +90,8 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
     RUBY
   end
 
-  it 'register offense for different example group with similar descriptions' do
+  it 'registers offense for different example group with ' \
+     'similar descriptions' do
     expect_offense(<<~RUBY)
       describe 'Animal' do
       ^^^^^^^^^^^^^^^^^^^^ Repeated describe block description on line(s) [5]
@@ -198,7 +199,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedExampleGroupDescription do
     RUBY
   end
 
-  it 'register offense if same method used in docstring' do
+  it 'registers offense if same method used in docstring' do
     expect_offense(<<~RUBY)
       context(description) do
       ^^^^^^^^^^^^^^^^^^^^^^^ Repeated context block description on line(s) [5]


### PR DESCRIPTION
```
spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb:93:6: C: [Corrected] InternalAffairs/ExampleDescription: Description does not match use of expect_offense.
  it 'register offense for different example group with similar descriptions' do
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb:93:81: C: Layout/LineLength: Line is too long. [81/80]
  it 'registers offense for different example group with similar descriptions' do
                                                                                ^
spec/rubocop/cop/rspec/repeated_example_group_description_spec.rb:201:6: C: [Corrected] InternalAffairs/ExampleDescription: Description does not match use of expect_offense.
  it 'register offense if same method used in docstring' do
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
