### PR TITLE
Fix a few minor things

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,8 +28,6 @@ Layout/LineLength:
   Max: 80 # default: 120
   AllowedPatterns:
     - '^\s*# .*https?:\/\/.+\[.+\]\.?$' # Allow long asciidoc links
-  Exclude:
-    - lib/rubocop/cop/rspec/rails/have_http_status.rb
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
@@ -113,6 +111,7 @@ RSpec/DescribeClass:
 RSpec/MultipleExpectations:
   Max: 2
 
+# `expect_offense` does not use Kernel#format or String#%
 Style/FormatStringToken:
   Exclude:
     - spec/rubocop/**/*.rb

--- a/spec/rubocop/cop/rspec/repeated_subject_call_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_subject_call_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe RuboCop::Cop::RSpec::RepeatedSubjectCall do
   it 'registers an offense when a singular block' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         it do
           subject
@@ -14,7 +14,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedSubjectCall do
   end
 
   it 'registers an offense when repeated blocks' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         it do
           expect { subject }.to change { Foo.count }
@@ -26,7 +26,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedSubjectCall do
   end
 
   it 'registers an offense when nested blocks' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         it do
           expect(subject.a).to eq(3)
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedSubjectCall do
   end
 
   it 'registers an offense when custom subjects' do
-    expect_offense(<<-RUBY)
+    expect_offense(<<~RUBY)
       RSpec.describe Foo do
         subject(:bar) { do_something }
 
@@ -76,7 +76,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedSubjectCall do
   end
 
   it 'does not register an offense when different subjects' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
         subject { do_something_else }
         subject(:bar) { do_something }
@@ -90,7 +90,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedSubjectCall do
   end
 
   it 'does not register an offense when multiple no description it blocks' do
-    expect_no_offenses(<<-RUBY)
+    expect_no_offenses(<<~RUBY)
       RSpec.describe Foo do
         it do
           expect { subject }.to change { Foo.count }


### PR DESCRIPTION
1. Use squiggly heredocs wherever possible
   Most new code uses the squiggly heredoc, but in a few places we were still using the "old" `<<-` heredoc.
2. Remove reference to deleted file from .rubocop.yml.
3. Add a comment to a configuration in .rubocop.yml that I didn't understand before.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
