### PR TITLE
Fix an edge offense for `Style/SymbolProc`

### DIFF
--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -72,7 +72,7 @@ module RuboCop
         MSG = 'Example has too many expectations [%<total>d/%<max>d].'
 
         ANYTHING = ->(_node) { true }
-        TRUE = ->(node) { node.true_type? }
+        TRUE = lambda(&:true_type?)
 
         # @!method aggregate_failures?(node)
         def_node_matcher :aggregate_failures?, <<~PATTERN


### PR DESCRIPTION
see: https://github.com/rubocop/rubocop-rspec/actions/runs/9147530544/job/25149073488?pr=1876

```
Inspecting 272 files
.................................................................................C..............................................................................................................................................................................................

Offenses:

lib/rubocop/cop/rspec/multiple_expectations.rb:[7](https://github.com/rubocop/rubocop-rspec/actions/runs/9147530544/job/25149073488?pr=1876#step:5:8)5:25: C: [Correctable] Style/SymbolProc: Pass &:true_type? as an argument to lambda instead of a block.
        TRUE = ->(node) { node.true_type? }
                        ^^^^^^^^^^^^^^^^^^^

272 files inspected, 1 offense detected, 1 offense autocorrectable
Error: Process completed with exit code 1.
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
