### PR TITLE
Add CI task testing with the oldest RuboCop version allowed by gemspec

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,27 @@ jobs:
       - name: Use latest RuboCop from `master`
         run: |
           echo "gem 'rubocop', github: 'rubocop/rubocop'" > Gemfile.local
+          cat Gemfile.local
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+      - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
+
+  oldest-rubocop:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task:
+          - spec
+    name: "Oldest RuboCop: ${{ matrix.task }}"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use oldest RuboCop allowed by gemspec
+        run: |
+          sed -nr "s/spec.add_dependency 'rubocop', '~> ([0-9\.]+)'/gem 'rubocop', '= \1'/p" \
+            rubocop-rspec.gemspec > Gemfile.local
+          cat Gemfile.local
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.40'
+  spec.add_dependency 'rubocop', '~> 1.40'
 end

--- a/spec/rubocop/cop/rspec/repeated_include_example_spec.rb
+++ b/spec/rubocop/cop/rspec/repeated_include_example_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe RuboCop::Cop::RSpec::RepeatedIncludeExample do
       RUBY
     end
 
-    it 'allows for beginless ranges' do
+    it 'allows for beginless ranges', :ruby27 do
       expect_no_offenses(<<~RUBY)
         describe 'foo' do
           include_examples 'irange', ..1


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rspec/pull/1879#issuecomment-2107631095

> There is one thing we might be missing - it’s to test our code against our [minimum specified rubocop version](https://github.com/rubocop/rubocop-rspec/blob/6f340256dd1502cf23f20f6c6b7410e05de0c923/rubocop-rspec.gemspec#L40).



______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
