### PR TITLE
Remove unnecessary `on_numblock` method

### DIFF
--- a/lib/rubocop/cop/rspec/expect_in_let.rb
+++ b/lib/rubocop/cop/rspec/expect_in_let.rb
@@ -22,7 +22,7 @@ module RuboCop
         # @!method expectation(node)
         def_node_search :expectation, '(send nil? #Expectations.all ...)'
 
-        def on_block(node)
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless let?(node)
           return if node.body.nil?
 
@@ -30,8 +30,6 @@ module RuboCop
             add_offense(expect.loc.selector, message: message(expect))
           end
         end
-
-        alias on_numblock on_block
 
         private
 


### PR DESCRIPTION
Because numbered parameters are rarely used with let.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
