### PR TITLE
Release v2.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 2.30.0 (2024-06-03)
+
 - Add new `RSpec/ExpectInLet` cop. ([@yasu551])
 
 ## 2.29.2 (2024-05-02)

--- a/config/default.yml
+++ b/config/default.yml
@@ -450,7 +450,7 @@ RSpec/ExpectInHook:
 RSpec/ExpectInLet:
   Description: Do not use `expect` in let.
   Enabled: pending
-  VersionAdded: "<<next>>"
+  VersionAdded: '2.30'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInLet
 
 RSpec/ExpectOutput:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: rubocop-rspec
 title: RuboCop RSpec
-version: ~
+version: '2.30'
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2050,7 +2050,7 @@ end
 | Pending
 | Yes
 | No
-| <<next>>
+| 2.30
 | -
 |===
 

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '2.29.2'
+      STRING = '2.30.0'
     end
   end
 end


### PR DESCRIPTION
The only [change visible to our users](https://github.com/rubocop/rubocop-rspec/compare/v2.29.2...release-2-30-0) is the addition of the `RSpec/ExpectInLet` cop.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
