### PR TITLE
CI: Add GH_TOKEN to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
             --title "RuboCop RSpec $(git tag --points-at @)" \
             --notes-file relnotes.md
       - name: Replace version in Antora config
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           sed -i 's/version:.*$/version: ~/' docs/antora.yml
           if ! git diff --exit-code docs/antora.yml; then


### PR DESCRIPTION
When trying to release a minor version, [GitHub Actions said](https://github.com/rubocop/rubocop-rspec/actions/runs/9347594123/job/25724913002#step:6:42):

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```
we didn't notice it before, because this code doesn't run on patch releases.