### PR TITLE
`AutoCorrect: contextual` needs rubocop v1.61

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Bump RuboCop requirement to +1.61. ([@ydah])
+
 ## 3.0.0 (2024-06-11)
 
 - Remove extracted cops in `Capybara`, `FactoryBot` and `Rails` departments. ([@ydah])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+## 3.0.1 (2024-06-11)
+
 - Bump RuboCop requirement to +1.61. ([@ydah])
 
 ## 3.0.0 (2024-06-11)

--- a/lib/rubocop/rspec/version.rb
+++ b/lib/rubocop/rspec/version.rb
@@ -4,7 +4,7 @@ module RuboCop
   module RSpec
     # Version information for the RSpec RuboCop plugin.
     module Version
-      STRING = '3.0.0'
+      STRING = '3.0.1'
     end
   end
 end

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true'
   }
 
-  spec.add_dependency 'rubocop', '~> 1.40'
+  spec.add_dependency 'rubocop', '~> 1.61'
 end


### PR DESCRIPTION
https://github.com/rubocop/rubocop/releases/tag/v1.61.0

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
