### PR TITLE
Don't always define node patterns in private scope

### DIFF
--- a/lib/rubocop/cop/rspec/around_block.rb
+++ b/lib/rubocop/cop/rspec/around_block.rb
@@ -31,6 +31,21 @@ module RuboCop
         MSG_UNUSED_ARG = 'You should call `%<arg>s.call` ' \
                          'or `%<arg>s.run`.'
 
+        # @!method hook_block(node)
+        def_node_matcher :hook_block, <<~PATTERN
+          (block (send nil? :around sym ?) (args $...) ...)
+        PATTERN
+
+        # @!method hook_numblock(node)
+        def_node_matcher :hook_numblock, <<~PATTERN
+          (numblock (send nil? :around sym ?) ...)
+        PATTERN
+
+        # @!method find_arg_usage(node)
+        def_node_search :find_arg_usage, <<~PATTERN
+          {(send $... {:call :run}) (send _ _ $...) (yield $...) (block-pass $...)}
+        PATTERN
+
         def on_block(node)
           hook_block(node) do |(example_proxy)|
             if example_proxy.nil?
@@ -48,21 +63,6 @@ module RuboCop
         end
 
         private
-
-        # @!method hook_block(node)
-        def_node_matcher :hook_block, <<~PATTERN
-          (block (send nil? :around sym ?) (args $...) ...)
-        PATTERN
-
-        # @!method hook_numblock(node)
-        def_node_matcher :hook_numblock, <<~PATTERN
-          (numblock (send nil? :around sym ?) ...)
-        PATTERN
-
-        # @!method find_arg_usage(node)
-        def_node_search :find_arg_usage, <<~PATTERN
-          {(send $... {:call :run}) (send _ _ $...) (yield $...) (block-pass $...)}
-        PATTERN
 
         def add_no_arg_offense(node)
           add_offense(node, message: MSG_NO_ARG)

--- a/lib/rubocop/cop/rspec/be.rb
+++ b/lib/rubocop/cop/rspec/be.rb
@@ -23,18 +23,16 @@ module RuboCop
 
         RESTRICT_ON_SEND = Runners.all
 
+        # @!method be_without_args(node)
+        def_node_matcher :be_without_args, <<~PATTERN
+          (send _ #Runners.all $(send nil? :be))
+        PATTERN
+
         def on_send(node)
           be_without_args(node) do |matcher|
             add_offense(matcher.loc.selector)
           end
         end
-
-        private
-
-        # @!method be_without_args(node)
-        def_node_matcher :be_without_args, <<~PATTERN
-          (send _ #Runners.all $(send nil? :be))
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/be_empty.rb
+++ b/lib/rubocop/cop/rspec/be_empty.rb
@@ -19,16 +19,6 @@ module RuboCop
         MSG = 'Use `be_empty` matchers for checking an empty array.'
         RESTRICT_ON_SEND = %i[contain_exactly match_array].freeze
 
-        def on_send(node)
-          expect_array_matcher?(node.parent) do |expect|
-            add_offense(expect) do |corrector|
-              corrector.replace(expect, 'be_empty')
-            end
-          end
-        end
-
-        private
-
         # @!method expect_array_matcher?(node)
         def_node_matcher :expect_array_matcher?, <<~PATTERN
           (send
@@ -41,6 +31,14 @@ module RuboCop
             _?
           )
         PATTERN
+
+        def on_send(node)
+          expect_array_matcher?(node.parent) do |expect|
+            add_offense(expect) do |corrector|
+              corrector.replace(expect, 'be_empty')
+            end
+          end
+        end
       end
     end
   end

--- a/lib/rubocop/cop/rspec/be_eq.rb
+++ b/lib/rubocop/cop/rspec/be_eq.rb
@@ -29,6 +29,11 @@ module RuboCop
         MSG = 'Prefer `be` over `eq`.'
         RESTRICT_ON_SEND = %i[eq].freeze
 
+        # @!method eq_type_with_identity?(node)
+        def_node_matcher :eq_type_with_identity?, <<~PATTERN
+          (send nil? :eq {true false nil})
+        PATTERN
+
         def on_send(node)
           return unless eq_type_with_identity?(node)
 
@@ -36,13 +41,6 @@ module RuboCop
             corrector.replace(node.loc.selector, 'be')
           end
         end
-
-        private
-
-        # @!method eq_type_with_identity?(node)
-        def_node_matcher :eq_type_with_identity?, <<~PATTERN
-          (send nil? :eq {true false nil})
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -43,6 +43,11 @@ module RuboCop
         MSG = 'Prefer `be` over `eql`.'
         RESTRICT_ON_SEND = %i[to].freeze
 
+        # @!method eql_type_with_identity(node)
+        def_node_matcher :eql_type_with_identity, <<~PATTERN
+          (send _ :to $(send nil? :eql {true false int float sym nil}))
+        PATTERN
+
         def on_send(node)
           eql_type_with_identity(node) do |eql|
             add_offense(eql.loc.selector) do |corrector|
@@ -50,13 +55,6 @@ module RuboCop
             end
           end
         end
-
-        private
-
-        # @!method eql_type_with_identity(node)
-        def_node_matcher :eql_type_with_identity, <<~PATTERN
-          (send _ :to $(send nil? :eql {true false int float sym nil}))
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/be_nil.rb
+++ b/lib/rubocop/cop/rspec/be_nil.rb
@@ -32,6 +32,16 @@ module RuboCop
         BE_NIL_MSG = 'Prefer `be_nil` over `be(nil)`.'
         RESTRICT_ON_SEND = %i[be be_nil].freeze
 
+        # @!method be_nil_matcher?(node)
+        def_node_matcher :be_nil_matcher?, <<~PATTERN
+          (send nil? :be_nil)
+        PATTERN
+
+        # @!method nil_value_expectation?(node)
+        def_node_matcher :nil_value_expectation?, <<~PATTERN
+          (send nil? :be nil)
+        PATTERN
+
         def on_send(node)
           case style
           when :be
@@ -42,16 +52,6 @@ module RuboCop
         end
 
         private
-
-        # @!method be_nil_matcher?(node)
-        def_node_matcher :be_nil_matcher?, <<~PATTERN
-          (send nil? :be_nil)
-        PATTERN
-
-        # @!method nil_value_expectation?(node)
-        def_node_matcher :nil_value_expectation?, <<~PATTERN
-          (send nil? :be nil)
-        PATTERN
 
         def check_be_style(node)
           return unless be_nil_matcher?(node)

--- a/lib/rubocop/cop/rspec/before_after_all.rb
+++ b/lib/rubocop/cop/rspec/before_after_all.rb
@@ -26,6 +26,11 @@ module RuboCop
 
         RESTRICT_ON_SEND = Set[:before, :after].freeze
 
+        # @!method before_or_after_all(node)
+        def_node_matcher :before_or_after_all, <<~PATTERN
+          $(send _ RESTRICT_ON_SEND (sym {:all :context}))
+        PATTERN
+
         def on_send(node)
           before_or_after_all(node) do |hook|
             add_offense(
@@ -34,13 +39,6 @@ module RuboCop
             )
           end
         end
-
-        private
-
-        # @!method before_or_after_all(node)
-        def_node_matcher :before_or_after_all, <<~PATTERN
-          $(send _ RESTRICT_ON_SEND (sym {:all :context}))
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -67,18 +67,6 @@ module RuboCop
         CHANGE_METHODS = Set[:change, :a_block_changing, :changing].freeze
         RESTRICT_ON_SEND = CHANGE_METHODS.freeze
 
-        def on_send(node)
-          expect_change_with_arguments(node.parent) do |change|
-            register_offense(node.parent, change)
-          end
-
-          expect_change_with_block(node.parent.parent) do |change|
-            register_offense(node.parent.parent, change)
-          end
-        end
-
-        private
-
         # @!method expect_change_with_arguments(node)
         def_node_matcher :expect_change_with_arguments, <<~PATTERN
           (send
@@ -100,6 +88,18 @@ module RuboCop
         def_node_search :change_nodes, <<~PATTERN
           $(send nil? CHANGE_METHODS ...)
         PATTERN
+
+        def on_send(node)
+          expect_change_with_arguments(node.parent) do |change|
+            register_offense(node.parent, change)
+          end
+
+          expect_change_with_block(node.parent.parent) do |change|
+            register_offense(node.parent.parent, change)
+          end
+        end
+
+        private
 
         # rubocop:disable Metrics/MethodLength
         def register_offense(node, change_node)

--- a/lib/rubocop/cop/rspec/context_method.rb
+++ b/lib/rubocop/cop/rspec/context_method.rb
@@ -29,6 +29,15 @@ module RuboCop
 
         MSG = 'Use `describe` for testing methods.'
 
+        # @!method context_method(node)
+        def_node_matcher :context_method, <<~PATTERN
+          (block
+            (send #rspec? :context
+              ${(str #method_name?) (dstr (str #method_name?) ...)}
+            ...)
+          ...)
+        PATTERN
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           context_method(node) do |context|
             add_offense(context) do |corrector|
@@ -38,15 +47,6 @@ module RuboCop
         end
 
         private
-
-        # @!method context_method(node)
-        def_node_matcher :context_method, <<~PATTERN
-          (block
-            (send #rspec? :context
-              ${(str #method_name?) (dstr (str #method_name?) ...)}
-            ...)
-          ...)
-        PATTERN
 
         def method_name?(description)
           description.start_with?('.', '#')

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -60,6 +60,11 @@ module RuboCop
 
         MSG = 'Context description should match %<patterns>s.'
 
+        # @!method context_wording(node)
+        def_node_matcher :context_wording, <<~PATTERN
+          (block (send #rspec? { :context :shared_context } $({str dstr xstr} ...) ...) ...)
+        PATTERN
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           context_wording(node) do |context|
             if bad_pattern?(context)
@@ -70,11 +75,6 @@ module RuboCop
         end
 
         private
-
-        # @!method context_wording(node)
-        def_node_matcher :context_wording, <<~PATTERN
-          (block (send #rspec? { :context :shared_context } $({str dstr xstr} ...) ...) ...)
-        PATTERN
 
         def allowed_patterns
           super + prefix_regexes

--- a/lib/rubocop/cop/rspec/describe_class.rb
+++ b/lib/rubocop/cop/rspec/describe_class.rb
@@ -40,16 +40,6 @@ module RuboCop
         MSG = 'The first argument to describe should be ' \
               'the class or module being tested.'
 
-        def on_top_level_group(node)
-          return if example_group_with_ignored_metadata?(node.send_node)
-
-          not_a_const_described(node.send_node) do |described|
-            add_offense(described)
-          end
-        end
-
-        private
-
         # @!method example_group_with_ignored_metadata?(node)
         def_node_matcher :example_group_with_ignored_metadata?, <<~PATTERN
           (send #rspec? :describe ... (hash <#ignored_metadata? ...>))
@@ -64,6 +54,16 @@ module RuboCop
         def_node_matcher :sym_pair, <<~PATTERN
           (pair $sym $sym)
         PATTERN
+
+        def on_top_level_group(node)
+          return if example_group_with_ignored_metadata?(node.send_node)
+
+          not_a_const_described(node.send_node) do |described|
+            add_offense(described)
+          end
+        end
+
+        private
 
         def ignored_metadata?(node)
           sym_pair(node) do |key, value|

--- a/lib/rubocop/cop/rspec/describe_method.rb
+++ b/lib/rubocop/cop/rspec/describe_method.rb
@@ -23,14 +23,6 @@ module RuboCop
         MSG = 'The second argument to describe should be the method ' \
               "being tested. '#instance' or '.class'."
 
-        def on_top_level_group(node)
-          second_string_literal_argument(node) do |argument|
-            add_offense(argument) unless method_name?(argument)
-          end
-        end
-
-        private
-
         # @!method second_string_literal_argument(node)
         def_node_matcher :second_string_literal_argument, <<~PATTERN
           (block
@@ -42,6 +34,14 @@ module RuboCop
         def_node_matcher :method_name?, <<~PATTERN
           {(str #method_name_prefix?) (dstr (str #method_name_prefix?) ...)}
         PATTERN
+
+        def on_top_level_group(node)
+          second_string_literal_argument(node) do |argument|
+            add_offense(argument) unless method_name?(argument)
+          end
+        end
+
+        private
 
         def method_name_prefix?(description)
           description.start_with?('.', '#')

--- a/lib/rubocop/cop/rspec/describe_symbol.rb
+++ b/lib/rubocop/cop/rspec/describe_symbol.rb
@@ -21,18 +21,16 @@ module RuboCop
         MSG = 'Avoid describing symbols.'
         RESTRICT_ON_SEND = %i[describe].freeze
 
+        # @!method describe_symbol?(node)
+        def_node_matcher :describe_symbol?, <<~PATTERN
+          (send #rspec? :describe $sym ...)
+        PATTERN
+
         def on_send(node)
           describe_symbol?(node) do |match|
             add_offense(match)
           end
         end
-
-        private
-
-        # @!method describe_symbol?(node)
-        def_node_matcher :describe_symbol?, <<~PATTERN
-          (send #rspec? :describe $sym ...)
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -76,23 +76,6 @@ module RuboCop
         DESCRIBED_CLASS = 'described_class'
         MSG             = 'Use `%<replacement>s` instead of `%<src>s`.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          # In case the explicit style is used, we need to remember what's
-          # being described.
-          @described_class, body = described_constant(node)
-
-          return unless body
-
-          find_usage(body) do |match|
-            msg = message(match.const_name)
-            add_offense(match, message: msg) do |corrector|
-              autocorrect(corrector, match)
-            end
-          end
-        end
-
-        private
-
         # @!method common_instance_exec_closure?(node)
         def_node_matcher :common_instance_exec_closure?, <<~PATTERN
           (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)
@@ -113,6 +96,23 @@ module RuboCop
         # @!method contains_described_class?(node)
         def_node_search :contains_described_class?,
                         '(send nil? :described_class)'
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          # In case the explicit style is used, we need to remember what's
+          # being described.
+          @described_class, body = described_constant(node)
+
+          return unless body
+
+          find_usage(body) do |match|
+            msg = message(match.const_name)
+            add_offense(match, message: msg) do |corrector|
+              autocorrect(corrector, match)
+            end
+          end
+        end
+
+        private
 
         def autocorrect(corrector, match)
           replacement = if style == :described_class

--- a/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
+++ b/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
@@ -22,18 +22,16 @@ module RuboCop
       class DescribedClassModuleWrapping < Base
         MSG = 'Avoid opening modules and defining specs within them.'
 
+        # @!method include_rspec_blocks?(node)
+        def_node_search :include_rspec_blocks?, <<~PATTERN
+          ({block numblock} (send #explicit_rspec? #ExampleGroups.all ...) ...)
+        PATTERN
+
         def on_module(node)
           return unless include_rspec_blocks?(node)
 
           add_offense(node)
         end
-
-        private
-
-        # @!method include_rspec_blocks?(node)
-        def_node_search :include_rspec_blocks?, <<~PATTERN
-          ({block numblock} (send #explicit_rspec? #ExampleGroups.all ...) ...)
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/dialect.rb
+++ b/lib/rubocop/cop/rspec/dialect.rb
@@ -61,6 +61,9 @@ module RuboCop
 
         MSG = 'Prefer `%<prefer>s` over `%<current>s`.'
 
+        # @!method rspec_method?(node)
+        def_node_matcher :rspec_method?, '(send #rspec? #ALL.all ...)'
+
         def on_send(node)
           return unless rspec_method?(node)
           return unless preferred_methods[node.method_name]
@@ -75,11 +78,6 @@ module RuboCop
             corrector.replace(current, preferred)
           end
         end
-
-        private
-
-        # @!method rspec_method?(node)
-        def_node_matcher :rspec_method?, '(send #rspec? #ALL.all ...)'
       end
     end
   end

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -42,21 +42,6 @@ module RuboCop
 
         MSG = 'Empty example group detected.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return if node.each_ancestor(:def, :defs).any?
-          return if node.each_ancestor(:block).any? { |block| example?(block) }
-
-          example_group_body(node) do |body|
-            next unless offensive?(body)
-
-            add_offense(node.send_node) do |corrector|
-              corrector.remove(removed_range(node))
-            end
-          end
-        end
-
-        private
-
         # @!method example_group_body(node)
         #   Match example group blocks and yield their body
         #
@@ -149,6 +134,21 @@ module RuboCop
             (begin <#examples_in_branches? ...>)
           }
         PATTERN
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          return if node.each_ancestor(:def, :defs).any?
+          return if node.each_ancestor(:block).any? { |block| example?(block) }
+
+          example_group_body(node) do |body|
+            next unless offensive?(body)
+
+            add_offense(node.send_node) do |corrector|
+              corrector.remove(removed_range(node))
+            end
+          end
+        end
+
+        private
 
         def offensive?(body)
           return true unless body

--- a/lib/rubocop/cop/rspec/empty_hook.rb
+++ b/lib/rubocop/cop/rspec/empty_hook.rb
@@ -29,6 +29,11 @@ module RuboCop
 
         MSG = 'Empty hook detected.'
 
+        # @!method empty_hook?(node)
+        def_node_matcher :empty_hook?, <<~PATTERN
+          (block $(send nil? #Hooks.all ...) _ nil?)
+        PATTERN
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           empty_hook?(node) do |hook|
             add_offense(hook) do |corrector|
@@ -38,13 +43,6 @@ module RuboCop
             end
           end
         end
-
-        private
-
-        # @!method empty_hook?(node)
-        def_node_matcher :empty_hook?, <<~PATTERN
-          (block $(send nil? #Hooks.all ...) _ nil?)
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/empty_output.rb
+++ b/lib/rubocop/cop/rspec/empty_output.rb
@@ -20,19 +20,6 @@ module RuboCop
         MSG = 'Use `%<runner>s` instead of matching on an empty output.'
         RESTRICT_ON_SEND = Runners.all
 
-        def on_send(send_node)
-          matching_empty_output(send_node) do |node|
-            runner = send_node.method?(:to) ? 'not_to' : 'to'
-            message = format(MSG, runner: runner)
-            add_offense(node, message: message) do |corrector|
-              corrector.replace(send_node.loc.selector, runner)
-              corrector.replace(node, 'output')
-            end
-          end
-        end
-
-        private
-
         # @!method matching_empty_output(node)
         def_node_matcher :matching_empty_output, <<~PATTERN
           (send
@@ -43,6 +30,17 @@ module RuboCop
             (send $(send nil? :output (str empty?)) ...)
           )
         PATTERN
+
+        def on_send(send_node)
+          matching_empty_output(send_node) do |node|
+            runner = send_node.method?(:to) ? 'not_to' : 'to'
+            message = format(MSG, runner: runner)
+            add_offense(node, message: message) do |corrector|
+              corrector.replace(send_node.loc.selector, runner)
+              corrector.replace(node, 'output')
+            end
+          end
+        end
       end
     end
   end

--- a/lib/rubocop/cop/rspec/eq.rb
+++ b/lib/rubocop/cop/rspec/eq.rb
@@ -19,6 +19,11 @@ module RuboCop
         MSG = 'Use `eq` instead of `be ==` to compare objects.'
         RESTRICT_ON_SEND = Runners.all
 
+        # @!method be_equals(node)
+        def_node_matcher :be_equals, <<~PATTERN
+          (send _ #Runners.all $(send (send nil? :be) :== _))
+        PATTERN
+
         def on_send(node)
           be_equals(node) do |matcher|
             range = offense_range(matcher)
@@ -29,11 +34,6 @@ module RuboCop
         end
 
         private
-
-        # @!method be_equals(node)
-        def_node_matcher :be_equals, <<~PATTERN
-          (send _ #Runners.all $(send (send nil? :be) :== _))
-        PATTERN
 
         def offense_range(matcher)
           range_between(

--- a/lib/rubocop/cop/rspec/example_without_description.rb
+++ b/lib/rubocop/cop/rspec/example_without_description.rb
@@ -63,6 +63,9 @@ module RuboCop
                                'have auto-generated description.'
         MSG_ADD_DESCRIPTION  = 'Add a description.'
 
+        # @!method example_description(node)
+        def_node_matcher :example_description, '(send nil? _ $(str $_))'
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example?(node)
 
@@ -76,9 +79,6 @@ module RuboCop
         end
 
         private
-
-        # @!method example_description(node)
-        def_node_matcher :example_description, '(send nil? _ $(str $_))'
 
         def check_example_without_description(node)
           return if node.arguments?

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -59,6 +59,14 @@ module RuboCop
         WILL_PREFIX   = /\A(?:will|won't)\b/i.freeze
         IT_PREFIX     = /\Ait /i.freeze
 
+        # @!method it_description(node)
+        def_node_matcher :it_description, <<~PATTERN
+          (block (send _ :it ${
+            (str $_)
+            (dstr (str $_ ) ...)
+          } ...) ...)
+        PATTERN
+
         # rubocop:disable Metrics/MethodLength
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           it_description(node) do |description_node, message|
@@ -77,14 +85,6 @@ module RuboCop
         # rubocop:enable Metrics/MethodLength
 
         private
-
-        # @!method it_description(node)
-        def_node_matcher :it_description, <<~PATTERN
-          (block (send _ :it ${
-            (str $_)
-            (dstr (str $_ ) ...)
-          } ...) ...)
-        PATTERN
 
         def add_wording_offense(node, message)
           docstring = docstring(node)

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -28,6 +28,14 @@ module RuboCop
 
         MSG = 'Excessive whitespace.'
 
+        # @!method example_description(node)
+        def_node_matcher :example_description, <<~PATTERN
+          (send _ {#Examples.all #ExampleGroups.all} ${
+            $str
+            $(dstr ({str dstr `sym} ...) ...)
+          } ...)
+        PATTERN
+
         def on_send(node)
           example_description(node) do |description_node, message|
             return if description_node.heredoc?
@@ -41,14 +49,6 @@ module RuboCop
         end
 
         private
-
-        # @!method example_description(node)
-        def_node_matcher :example_description, <<~PATTERN
-          (send _ {#Examples.all #ExampleGroups.all} ${
-            $str
-            $(dstr ({str dstr `sym} ...) ...)
-          } ...)
-        PATTERN
 
         # @param text [String]
         def excessive_whitespace?(text)

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -53,6 +53,18 @@ module RuboCop
         SKIPPED_MATCHERS = %i[route_to be_routable].freeze
         CORRECTABLE_MATCHERS = %i[eq eql equal be].freeze
 
+        # @!method expect_literal(node)
+        def_node_matcher :expect_literal, <<~PATTERN
+          (send
+            (send nil? :expect $#literal?)
+            #Runners.all
+            ${
+              (send (send nil? $:be) :== $_)
+              (send nil? $_ $_ ...)
+            }
+          )
+        PATTERN
+
         def on_send(node) # rubocop:disable Metrics/MethodLength
           expect_literal(node) do |actual, send_node, matcher, expected|
             next if SKIPPED_MATCHERS.include?(matcher)
@@ -72,18 +84,6 @@ module RuboCop
         end
 
         private
-
-        # @!method expect_literal(node)
-        def_node_matcher :expect_literal, <<~PATTERN
-          (send
-            (send nil? :expect $#literal?)
-            #Runners.all
-            ${
-              (send (send nil? $:be) :== $_)
-              (send nil? $_ $_ ...)
-            }
-          )
-        PATTERN
 
         # This is not implemented using a NodePattern because it seems
         # to not be able to match against an explicit (nil) sexp

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -37,6 +37,26 @@ module RuboCop
         MSG_CALL = 'Prefer `change { %<obj>s.%<attr>s }`.'
         RESTRICT_ON_SEND = %i[change].freeze
 
+        # @!method expect_change_with_arguments(node)
+        def_node_matcher :expect_change_with_arguments, <<~PATTERN
+          (send nil? :change $_ ({sym str} $_))
+        PATTERN
+
+        # @!method expect_change_with_block(node)
+        def_node_matcher :expect_change_with_block, <<~PATTERN
+          (block
+            (send nil? :change)
+            (args)
+            (send
+              ${
+                (send nil? _)  # change { user.name }
+                const          # change { User.count }
+              }
+              $_
+            )
+          )
+        PATTERN
+
         def on_send(node)
           return unless style == :block
 
@@ -60,28 +80,6 @@ module RuboCop
             end
           end
         end
-
-        private
-
-        # @!method expect_change_with_arguments(node)
-        def_node_matcher :expect_change_with_arguments, <<~PATTERN
-          (send nil? :change $_ ({sym str} $_))
-        PATTERN
-
-        # @!method expect_change_with_block(node)
-        def_node_matcher :expect_change_with_block, <<~PATTERN
-          (block
-            (send nil? :change)
-            (args)
-            (send
-              ${
-                (send nil? _)  # change { user.name }
-                const          # change { User.count }
-              }
-              $_
-            )
-          )
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/expect_in_hook.rb
+++ b/lib/rubocop/cop/rspec/expect_in_hook.rb
@@ -24,6 +24,9 @@ module RuboCop
       class ExpectInHook < Base
         MSG = 'Do not use `%<expect>s` in `%<hook>s` hook'
 
+        # @!method expectation(node)
+        def_node_search :expectation, '(send nil? #Expectations.all ...)'
+
         def on_block(node)
           return unless hook?(node)
           return if node.body.nil?
@@ -37,9 +40,6 @@ module RuboCop
         alias on_numblock on_block
 
         private
-
-        # @!method expectation(node)
-        def_node_search :expectation, '(send nil? #Expectations.all ...)'
 
         def message(expect, hook)
           format(MSG, expect: expect.method_name, hook: hook.method_name)

--- a/lib/rubocop/cop/rspec/expect_in_let.rb
+++ b/lib/rubocop/cop/rspec/expect_in_let.rb
@@ -19,6 +19,9 @@ module RuboCop
       class ExpectInLet < Base
         MSG = 'Do not use `%<expect>s` in let'
 
+        # @!method expectation(node)
+        def_node_search :expectation, '(send nil? #Expectations.all ...)'
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless let?(node)
           return if node.body.nil?
@@ -29,9 +32,6 @@ module RuboCop
         end
 
         private
-
-        # @!method expectation(node)
-        def_node_search :expectation, '(send nil? #Expectations.all ...)'
 
         def message(expect)
           format(MSG, expect: expect.method_name)

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -55,22 +55,6 @@ module RuboCop
 
         MSG = 'Focused spec found.'
 
-        def on_send(node)
-          return if node.chained? || node.each_ancestor(:def, :defs).any?
-
-          focus_metadata(node) do |focus|
-            add_offense(focus) do |corrector|
-              if focus.pair_type? || focus.str_type? || focus.sym_type?
-                corrector.remove(with_surrounding(focus))
-              elsif focus.send_type?
-                correct_send(corrector, focus)
-              end
-            end
-          end
-        end
-
-        private
-
         # @!method focusable_selector?(node)
         def_node_matcher :focusable_selector?, <<~PATTERN
           {
@@ -93,6 +77,22 @@ module RuboCop
         def_node_matcher :focused_block?, <<~PATTERN
           (send #rspec? {#ExampleGroups.focused #Examples.focused} ...)
         PATTERN
+
+        def on_send(node)
+          return if node.chained? || node.each_ancestor(:def, :defs).any?
+
+          focus_metadata(node) do |focus|
+            add_offense(focus) do |corrector|
+              if focus.pair_type? || focus.str_type? || focus.sym_type?
+                corrector.remove(with_surrounding(focus))
+              elsif focus.send_type?
+                correct_send(corrector, focus)
+              end
+            end
+          end
+        end
+
+        private
 
         def focus_metadata(node, &block)
           yield(node) if focused_block?(node)

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -65,6 +65,16 @@ module RuboCop
         IMPLICIT_MSG = 'Omit the default `%<scope>p` argument for RSpec hooks.'
         EXPLICIT_MSG = 'Use `%<scope>p` for RSpec hooks.'
 
+        # @!method scoped_hook(node)
+        def_node_matcher :scoped_hook, <<~PATTERN
+          ({block numblock} $(send _ #Hooks.all (sym ${:each :example})) ...)
+        PATTERN
+
+        # @!method unscoped_hook(node)
+        def_node_matcher :unscoped_hook, <<~PATTERN
+          ({block numblock} $(send _ #Hooks.all) ...)
+        PATTERN
+
         def on_block(node)
           hook(node) do |method_send, scope_name|
             return correct_style_detected if scope_name.equal?(style)
@@ -81,16 +91,6 @@ module RuboCop
         alias on_numblock on_block
 
         private
-
-        # @!method scoped_hook(node)
-        def_node_matcher :scoped_hook, <<~PATTERN
-          ({block numblock} $(send _ #Hooks.all (sym ${:each :example})) ...)
-        PATTERN
-
-        # @!method unscoped_hook(node)
-        def_node_matcher :unscoped_hook, <<~PATTERN
-          ({block numblock} $(send _ #Hooks.all) ...)
-        PATTERN
 
         def autocorrect(corrector, _node, method_send)
           scope = implicit_style? ? '' : "(#{style.inspect})"

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -27,16 +27,6 @@ module RuboCop
 
         MSG = 'Move `%<hook>s` above the examples in the group.'
 
-        def on_block(node)
-          return unless example_group_with_body?(node)
-
-          check_hooks(node.body) if multiline_block?(node.body)
-        end
-
-        alias on_numblock on_block
-
-        private
-
         # @!method example_or_group?(node)
         def_node_matcher :example_or_group?, <<~PATTERN
           {
@@ -47,6 +37,16 @@ module RuboCop
             (send nil? #Includes.examples ...)
           }
         PATTERN
+
+        def on_block(node)
+          return unless example_group_with_body?(node)
+
+          check_hooks(node.body) if multiline_block?(node.body)
+        end
+
+        alias on_numblock on_block
+
+        private
 
         def multiline_block?(block)
           block.begin_type?

--- a/lib/rubocop/cop/rspec/identical_equality_assertion.rb
+++ b/lib/rubocop/cop/rspec/identical_equality_assertion.rb
@@ -19,20 +19,18 @@ module RuboCop
               'may indicate a flawed test.'
         RESTRICT_ON_SEND = %i[to].freeze
 
-        def on_send(node)
-          equality_check?(node) do |left, right|
-            add_offense(node) if left == right
-          end
-        end
-
-        private
-
         # @!method equality_check?(node)
         def_node_matcher :equality_check?, <<~PATTERN
           (send (send nil? :expect $_) :to
             {(send nil? {:eql :eq :be} $_)
              (send (send nil? :be) :== $_)})
         PATTERN
+
+        def on_send(node)
+          equality_check?(node) do |left, right|
+            add_offense(node) if left == right
+          end
+        end
       end
     end
   end

--- a/lib/rubocop/cop/rspec/implicit_block_expectation.rb
+++ b/lib/rubocop/cop/rspec/implicit_block_expectation.rb
@@ -21,15 +21,6 @@ module RuboCop
         MSG = 'Avoid implicit block expectations.'
         RESTRICT_ON_SEND = %i[is_expected should should_not].freeze
 
-        def on_send(node)
-          implicit_expect(node) do |implicit_expect|
-            subject = nearest_subject(implicit_expect)
-            add_offense(implicit_expect) if lambda_subject?(subject&.body)
-          end
-        end
-
-        private
-
         # @!method lambda?(node)
         def_node_matcher :lambda?, <<~PATTERN
           {
@@ -45,6 +36,15 @@ module RuboCop
         def_node_matcher :implicit_expect, <<~PATTERN
           $(send nil? {:is_expected :should :should_not} ...)
         PATTERN
+
+        def on_send(node)
+          implicit_expect(node) do |implicit_expect|
+            subject = nearest_subject(implicit_expect)
+            add_offense(implicit_expect) if lambda_subject?(subject&.body)
+          end
+        end
+
+        private
 
         def nearest_subject(node)
           node

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -30,6 +30,14 @@ module RuboCop
 
         RESTRICT_ON_SEND = Runners.all + %i[should should_not]
 
+        # @!method implicit_expect(node)
+        def_node_matcher :implicit_expect, <<~PATTERN
+          {
+            (send nil? ${:should :should_not} ...)
+            (send (send nil? $:is_expected) #Runners.all ...)
+          }
+        PATTERN
+
         alternatives = {
           'is_expected.to'     => 'should',
           'is_expected.not_to' => 'should_not',
@@ -57,14 +65,6 @@ module RuboCop
         end
 
         private
-
-        # @!method implicit_expect(node)
-        def_node_matcher :implicit_expect, <<~PATTERN
-          {
-            (send nil? ${:should :should_not} ...)
-            (send (send nil? $:is_expected) #Runners.all ...)
-          }
-        PATTERN
 
         def offending_expect(node)
           case implicit_expect(node)

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -77,16 +77,6 @@ module RuboCop
           should_not
         ].freeze
 
-        def on_send(node)
-          return unless invalid?(node)
-
-          add_offense(node) do |corrector|
-            autocorrect(corrector, node)
-          end
-        end
-
-        private
-
         # @!method explicit_unnamed_subject?(node)
         def_node_matcher :explicit_unnamed_subject?, <<~PATTERN
           (send nil? :expect (send nil? :subject))
@@ -96,6 +86,16 @@ module RuboCop
         def_node_matcher :implicit_subject?, <<~PATTERN
           (send nil? {:should :should_not :is_expected} ...)
         PATTERN
+
+        def on_send(node)
+          return unless invalid?(node)
+
+          add_offense(node) do |corrector|
+            autocorrect(corrector, node)
+          end
+        end
+
+        private
 
         def autocorrect(corrector, node)
           case node.method_name

--- a/lib/rubocop/cop/rspec/indexed_let.rb
+++ b/lib/rubocop/cop/rspec/indexed_let.rb
@@ -51,6 +51,14 @@ module RuboCop
         MSG = 'This `let` statement uses index in its name. Please give it ' \
               'a meaningful name.'
 
+        # @!method let_name(node)
+        def_node_matcher :let_name, <<~PATTERN
+          {
+            (block (send nil? #Helpers.all ({str sym} $_) ...) ...)
+            (send nil? #Helpers.all ({str sym} $_) block_pass)
+          }
+        PATTERN
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless spec_group?(node)
 
@@ -63,14 +71,6 @@ module RuboCop
         end
 
         private
-
-        # @!method let_name(node)
-        def_node_matcher :let_name, <<~PATTERN
-          {
-            (block (send nil? #Helpers.all ({str sym} $_) ...) ...)
-            (send nil? #Helpers.all ({str sym} $_) block_pass)
-          }
-        PATTERN
 
         SUFFIX_INDEX_REGEX = /_?\d+$/.freeze
         INDEX_REGEX = /\d+/.freeze

--- a/lib/rubocop/cop/rspec/instance_spy.rb
+++ b/lib/rubocop/cop/rspec/instance_spy.rb
@@ -24,22 +24,6 @@ module RuboCop
         MSG = 'Use `instance_spy` when you check your double ' \
               'with `have_received`.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless example?(node)
-
-          null_double(node) do |var, receiver|
-            have_received_usage(node) do |expected|
-              next if expected != var
-
-              add_offense(receiver) do |corrector|
-                autocorrect(corrector, receiver)
-              end
-            end
-          end
-        end
-
-        private
-
         # @!method null_double(node)
         def_node_search :null_double, <<~PATTERN
           (lvasgn $_
@@ -57,6 +41,22 @@ module RuboCop
             ...)
           ...)
         PATTERN
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          return unless example?(node)
+
+          null_double(node) do |var, receiver|
+            have_received_usage(node) do |expected|
+              next if expected != var
+
+              add_offense(receiver) do |corrector|
+                autocorrect(corrector, receiver)
+              end
+            end
+          end
+        end
+
+        private
 
         def autocorrect(corrector, node)
           replacement = 'instance_spy'

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -51,17 +51,6 @@ module RuboCop
         MSG = 'Avoid instance variables - use let, ' \
               'a method call, or a local variable (if possible).'
 
-        def on_top_level_group(node)
-          ivar_usage(node) do |ivar, name|
-            next if valid_usage?(ivar)
-            next if assignment_only? && !ivar_assigned?(node, name)
-
-            add_offense(ivar)
-          end
-        end
-
-        private
-
         # @!method dynamic_class?(node)
         def_node_matcher :dynamic_class?, <<~PATTERN
           (block (send (const nil? :Class) :new ...) ...)
@@ -80,6 +69,17 @@ module RuboCop
 
         # @!method ivar_assigned?(node)
         def_node_search :ivar_assigned?, '(ivasgn % ...)'
+
+        def on_top_level_group(node)
+          ivar_usage(node) do |ivar, name|
+            next if valid_usage?(ivar)
+            next if assignment_only? && !ivar_assigned?(node, name)
+
+            add_offense(ivar)
+          end
+        end
+
+        private
 
         def valid_usage?(node)
           node.each_ancestor(:block).any? do |block|

--- a/lib/rubocop/cop/rspec/is_expected_specify.rb
+++ b/lib/rubocop/cop/rspec/is_expected_specify.rb
@@ -25,6 +25,11 @@ module RuboCop
         IS_EXPECTED_METHODS = ::Set[:is_expected, :are_expected].freeze
         MSG = 'Use `it` instead of `specify`.'
 
+        # @!method offense?(node)
+        def_node_matcher :offense?, <<~PATTERN
+          (block (send _ :specify) _ (send (send _ IS_EXPECTED_METHODS) ...))
+        PATTERN
+
         def on_send(node)
           block_node = node.parent
           return unless block_node&.single_line? && offense?(block_node)
@@ -34,13 +39,6 @@ module RuboCop
             corrector.replace(selector, 'it')
           end
         end
-
-        private
-
-        # @!method offense?(node)
-        def_node_matcher :offense?, <<~PATTERN
-          (block (send _ :specify) _ (send (send _ IS_EXPECTED_METHODS) ...))
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/it_behaves_like.rb
+++ b/lib/rubocop/cop/rspec/it_behaves_like.rb
@@ -27,6 +27,9 @@ module RuboCop
               'examples in a nested context.'
         RESTRICT_ON_SEND = %i[it_behaves_like it_should_behave_like].freeze
 
+        # @!method example_inclusion_offense(node)
+        def_node_matcher :example_inclusion_offense, '(send _ % ...)'
+
         def on_send(node)
           example_inclusion_offense(node, alternative_style) do
             add_offense(node) do |corrector|
@@ -36,9 +39,6 @@ module RuboCop
         end
 
         private
-
-        # @!method example_inclusion_offense(node)
-        def_node_matcher :example_inclusion_offense, '(send _ % ...)'
 
         def message(_node)
           format(MSG, replacement: style, original: alternative_style)

--- a/lib/rubocop/cop/rspec/iterated_expectation.rb
+++ b/lib/rubocop/cop/rspec/iterated_expectation.rb
@@ -20,24 +20,6 @@ module RuboCop
         MSG = 'Prefer using the `all` matcher instead ' \
               'of iterating over an array.'
 
-        def on_block(node)
-          each?(node) do |arg, body|
-            if single_expectation?(body, arg) || only_expectations?(body, arg)
-              add_offense(node.send_node)
-            end
-          end
-        end
-
-        def on_numblock(node)
-          each_numblock?(node) do |body|
-            if single_expectation?(body, :_1) || only_expectations?(body, :_1)
-              add_offense(node.send_node)
-            end
-          end
-        end
-
-        private
-
         # @!method each?(node)
         def_node_matcher :each?, <<~PATTERN
           (block
@@ -58,6 +40,24 @@ module RuboCop
         def_node_matcher :expectation?, <<~PATTERN
           (send (send nil? :expect (lvar %)) :to ...)
         PATTERN
+
+        def on_block(node)
+          each?(node) do |arg, body|
+            if single_expectation?(body, arg) || only_expectations?(body, arg)
+              add_offense(node.send_node)
+            end
+          end
+        end
+
+        def on_numblock(node)
+          each_numblock?(node) do |body|
+            if single_expectation?(body, :_1) || only_expectations?(body, :_1)
+              add_offense(node.send_node)
+            end
+          end
+        end
+
+        private
 
         def single_expectation?(body, arg)
           expectation?(body, arg)

--- a/lib/rubocop/cop/rspec/let_before_examples.rb
+++ b/lib/rubocop/cop/rspec/let_before_examples.rb
@@ -35,18 +35,6 @@ module RuboCop
 
         MSG = 'Move `let` before the examples in the group.'
 
-        def self.autocorrect_incompatible_with
-          [RSpec::ScatteredLet]
-        end
-
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless example_group_with_body?(node)
-
-          check_let_declarations(node.body) if multiline_block?(node.body)
-        end
-
-        private
-
         # @!method example_or_group?(node)
         def_node_matcher :example_or_group?, <<~PATTERN
           {
@@ -62,6 +50,18 @@ module RuboCop
             (send nil? :include_examples ...)
           }
         PATTERN
+
+        def self.autocorrect_incompatible_with
+          [RSpec::ScatteredLet]
+        end
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          return unless example_group_with_body?(node)
+
+          check_let_declarations(node.body) if multiline_block?(node.body)
+        end
+
+        private
 
         def example_group_with_include_examples?(body)
           body.children.any? { |sibling| include_examples?(sibling) }

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -28,16 +28,6 @@ module RuboCop
       class LetSetup < Base
         MSG = 'Do not use `let!` to setup objects not referenced in tests.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless example_or_shared_group_or_including?(node)
-
-          unused_let_bang(node) do |let|
-            add_offense(let)
-          end
-        end
-
-        private
-
         # @!method example_or_shared_group_or_including?(node)
         def_node_matcher :example_or_shared_group_or_including?, <<~PATTERN
           (block {
@@ -56,6 +46,16 @@ module RuboCop
 
         # @!method method_called?(node)
         def_node_search :method_called?, '(send nil? %)'
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          return unless example_or_shared_group_or_including?(node)
+
+          unused_let_bang(node) do |let|
+            add_offense(let)
+          end
+        end
+
+        private
 
         def unused_let_bang(node)
           child_let_bang(node) do |method_send, method_name|

--- a/lib/rubocop/cop/rspec/match_array.rb
+++ b/lib/rubocop/cop/rspec/match_array.rb
@@ -28,6 +28,11 @@ module RuboCop
         MSG = 'Prefer `contain_exactly` when matching an array literal.'
         RESTRICT_ON_SEND = %i[match_array].freeze
 
+        # @!method match_array_with_empty_array?(node)
+        def_node_matcher :match_array_with_empty_array?, <<~PATTERN
+          (send nil? :match_array (array))
+        PATTERN
+
         def on_send(node)
           return unless node.first_argument&.array_type?
           return if match_array_with_empty_array?(node)
@@ -36,11 +41,6 @@ module RuboCop
         end
 
         private
-
-        # @!method match_array_with_empty_array?(node)
-        def_node_matcher :match_array_with_empty_array?, <<~PATTERN
-          (send nil? :match_array (array))
-        PATTERN
 
         def check_populated_array(node)
           return if node.first_argument.percent_literal?

--- a/lib/rubocop/cop/rspec/message_expectation.rb
+++ b/lib/rubocop/cop/rspec/message_expectation.rb
@@ -31,6 +31,14 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[to].freeze
 
+        # @!method message_expectation(node)
+        def_node_matcher :message_expectation, <<~PATTERN
+          (send $(send nil? {:expect :allow} ...) :to #receive_message?)
+        PATTERN
+
+        # @!method receive_message?(node)
+        def_node_search :receive_message?, '(send nil? :receive ...)'
+
         def on_send(node)
           message_expectation(node) do |match|
             return correct_style_detected if preferred_style?(match)
@@ -43,14 +51,6 @@ module RuboCop
         end
 
         private
-
-        # @!method message_expectation(node)
-        def_node_matcher :message_expectation, <<~PATTERN
-          (send $(send nil? {:expect :allow} ...) :to #receive_message?)
-        PATTERN
-
-        # @!method receive_message?(node)
-        def_node_search :receive_message?, '(send nil? :receive ...)'
 
         def preferred_style?(expectation)
           expectation.method_name.equal?(style)

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -41,6 +41,16 @@ module RuboCop
 
         RESTRICT_ON_SEND = Runners.all
 
+        # @!method message_expectation(node)
+        def_node_matcher :message_expectation, %(
+          (send (send nil? :expect $_) #Runners.all ...)
+        )
+
+        # @!method receive_message(node)
+        def_node_search :receive_message, %(
+          $(send nil? {:receive :have_received} ...)
+        )
+
         def on_send(node)
           receive_message_matcher(node) do |receiver, message_matcher|
             return correct_style_detected if preferred_style?(message_matcher)
@@ -53,16 +63,6 @@ module RuboCop
         end
 
         private
-
-        # @!method message_expectation(node)
-        def_node_matcher :message_expectation, %(
-          (send (send nil? :expect $_) #Runners.all ...)
-        )
-
-        # @!method receive_message(node)
-        def_node_search :receive_message, %(
-          $(send nil? {:receive :have_received} ...)
-        )
 
         def receive_message_matcher(node)
           return unless (receiver = message_expectation(node))

--- a/lib/rubocop/cop/rspec/metadata_style.rb
+++ b/lib/rubocop/cop/rspec/metadata_style.rb
@@ -29,6 +29,21 @@ module RuboCop
         include Metadata
         include RangeHelp
 
+        # @!method extract_metadata_hash(node)
+        def_node_matcher :extract_metadata_hash, <<~PATTERN
+          (send _ _ _ ... $hash)
+        PATTERN
+
+        # @!method match_boolean_metadata_pair?(node)
+        def_node_matcher :match_boolean_metadata_pair?, <<~PATTERN
+          (pair sym true)
+        PATTERN
+
+        # @!method match_ambiguous_trailing_metadata?(node)
+        def_node_matcher :match_ambiguous_trailing_metadata?, <<~PATTERN
+          (send _ _ _ ... !{hash sym})
+        PATTERN
+
         def on_metadata(symbols, hash)
           # RSpec example groups accept two string arguments. In such a case,
           # the rspec_metadata matcher will interpret the second string
@@ -47,21 +62,6 @@ module RuboCop
         end
 
         private
-
-        # @!method extract_metadata_hash(node)
-        def_node_matcher :extract_metadata_hash, <<~PATTERN
-          (send _ _ _ ... $hash)
-        PATTERN
-
-        # @!method match_boolean_metadata_pair?(node)
-        def_node_matcher :match_boolean_metadata_pair?, <<~PATTERN
-          (pair sym true)
-        PATTERN
-
-        # @!method match_ambiguous_trailing_metadata?(node)
-        def_node_matcher :match_ambiguous_trailing_metadata?, <<~PATTERN
-          (send _ _ _ ... !{hash sym})
-        PATTERN
 
         def autocorrect_pair(corrector, node)
           remove_pair(corrector, node)

--- a/lib/rubocop/cop/rspec/mixin/comments_help.rb
+++ b/lib/rubocop/cop/rspec/mixin/comments_help.rb
@@ -7,8 +7,6 @@ module RuboCop
       module CommentsHelp
         include FinalEndLocation
 
-        private
-
         def source_range_with_comment(node)
           begin_pos = begin_pos_with_comment(node).begin_pos
           end_pos = end_line_position(node).end_pos

--- a/lib/rubocop/cop/rspec/mixin/empty_line_separation.rb
+++ b/lib/rubocop/cop/rspec/mixin/empty_line_separation.rb
@@ -12,8 +12,6 @@ module RuboCop
         include FinalEndLocation
         include RangeHelp
 
-        private
-
         def missing_separating_line_offense(node)
           return if last_child?(node)
 

--- a/lib/rubocop/cop/rspec/mixin/file_help.rb
+++ b/lib/rubocop/cop/rspec/mixin/file_help.rb
@@ -5,8 +5,6 @@ module RuboCop
     module RSpec
       # Help methods for file.
       module FileHelp
-        private
-
         def expanded_file_path
           File.expand_path(processed_source.file_path)
         end

--- a/lib/rubocop/cop/rspec/mixin/final_end_location.rb
+++ b/lib/rubocop/cop/rspec/mixin/final_end_location.rb
@@ -5,8 +5,6 @@ module RuboCop
     module RSpec
       # Helps find the true end location of nodes which might contain heredocs.
       module FinalEndLocation
-        private
-
         def final_end_location(start_node)
           heredoc_endings =
             start_node.each_node(:str, :dstr, :xstr)

--- a/lib/rubocop/cop/rspec/mixin/metadata.rb
+++ b/lib/rubocop/cop/rspec/mixin/metadata.rb
@@ -9,6 +9,24 @@ module RuboCop
 
         include RuboCop::RSpec::Language
 
+        # @!method rspec_metadata(node)
+        def_node_matcher :rspec_metadata, <<~PATTERN
+          (block
+            (send
+              #rspec? {#Examples.all #ExampleGroups.all #SharedGroups.all #Hooks.all} _ $...)
+            ...)
+        PATTERN
+
+        # @!method rspec_configure(node)
+        def_node_matcher :rspec_configure, <<~PATTERN
+          (block (send #rspec? :configure) (args (arg $_)) ...)
+        PATTERN
+
+        # @!method metadata_in_block(node)
+        def_node_search :metadata_in_block, <<~PATTERN
+          (send (lvar %) #Hooks.all _ $...)
+        PATTERN
+
         def on_block(node)
           rspec_configure(node) do |block_var|
             metadata_in_block(node, block_var) do |metadata_arguments|
@@ -27,24 +45,6 @@ module RuboCop
         end
 
         private
-
-        # @!method rspec_metadata(node)
-        def_node_matcher :rspec_metadata, <<~PATTERN
-          (block
-            (send
-              #rspec? {#Examples.all #ExampleGroups.all #SharedGroups.all #Hooks.all} _ $...)
-            ...)
-        PATTERN
-
-        # @!method rspec_configure(node)
-        def_node_matcher :rspec_configure, <<~PATTERN
-          (block (send #rspec? :configure) (args (arg $_)) ...)
-        PATTERN
-
-        # @!method metadata_in_block(node)
-        def_node_search :metadata_in_block, <<~PATTERN
-          (send (lvar %) #Hooks.all _ $...)
-        PATTERN
 
         def on_metadata_arguments(metadata_arguments)
           *symbols, last = metadata_arguments

--- a/lib/rubocop/cop/rspec/mixin/skip_or_pending.rb
+++ b/lib/rubocop/cop/rspec/mixin/skip_or_pending.rb
@@ -7,8 +7,6 @@ module RuboCop
       module SkipOrPending
         extend RuboCop::NodePattern::Macros
 
-        private
-
         # @!method skipped_in_metadata?(node)
         def_node_matcher :skipped_in_metadata?, <<~PATTERN
           {

--- a/lib/rubocop/cop/rspec/mixin/variable.rb
+++ b/lib/rubocop/cop/rspec/mixin/variable.rb
@@ -10,11 +10,6 @@ module RuboCop
         Subjects = RuboCop::RSpec::Language::Subjects
         Helpers = RuboCop::RSpec::Language::Helpers
 
-        private_constant :Subjects
-        private_constant :Helpers
-
-        private
-
         # @!method variable_definition?(node)
         def_node_matcher :variable_definition?, <<~PATTERN
           (send nil? {#Subjects.all #Helpers.all}

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -74,22 +74,6 @@ module RuboCop
         ANYTHING = ->(_node) { true }
         TRUE_NODE = lambda(&:true_type?)
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return unless example?(node)
-
-          return if example_with_aggregate_failures?(node)
-
-          expectations_count = to_enum(:find_expectation, node).count
-
-          return if expectations_count <= max_expectations
-
-          self.max = expectations_count
-
-          flag_example(node, expectation_count: expectations_count)
-        end
-
-        private
-
         # @!method aggregate_failures?(node)
         def_node_matcher :aggregate_failures?, <<~PATTERN
           (block {
@@ -105,6 +89,22 @@ module RuboCop
         def_node_matcher :aggregate_failures_block?, <<~PATTERN
           (block (send nil? :aggregate_failures ...) ...)
         PATTERN
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          return unless example?(node)
+
+          return if example_with_aggregate_failures?(node)
+
+          expectations_count = to_enum(:find_expectation, node).count
+
+          return if expectations_count <= max_expectations
+
+          self.max = expectations_count
+
+          flag_example(node, expectation_count: expectations_count)
+        end
+
+        private
 
         def example_with_aggregate_failures?(example_node)
           node_with_aggregate_failures = find_aggregate_failures(example_node)

--- a/lib/rubocop/cop/rspec/named_subject.rb
+++ b/lib/rubocop/cop/rspec/named_subject.rb
@@ -81,18 +81,6 @@ module RuboCop
 
         MSG = 'Name your test subject if you need to reference it explicitly.'
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          if !example_or_hook_block?(node) || ignored_shared_example?(node)
-            return
-          end
-
-          subject_usage(node) do |subject_node|
-            check_explicit_subject(subject_node)
-          end
-        end
-
-        private
-
         # @!method example_or_hook_block?(node)
         def_node_matcher :example_or_hook_block?, <<~PATTERN
           (block (send nil? {#Examples.all #Hooks.all} ...) ...)
@@ -105,6 +93,18 @@ module RuboCop
 
         # @!method subject_usage(node)
         def_node_search :subject_usage, '$(send nil? :subject)'
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          if !example_or_hook_block?(node) || ignored_shared_example?(node)
+            return
+          end
+
+          subject_usage(node) do |subject_node|
+            check_explicit_subject(subject_node)
+          end
+        end
+
+        private
 
         def ignored_shared_example?(node)
           return false unless cop_config['IgnoreSharedExamples']

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -61,20 +61,6 @@ module RuboCop
 
         MSG = 'No expectation found in this example.'
 
-        # @param [RuboCop::AST::BlockNode] node
-        def on_block(node)
-          return unless regular_or_focused_example?(node)
-          return if includes_expectation?(node)
-          return if includes_skip_example?(node)
-          return if skipped_in_metadata?(node.send_node)
-
-          add_offense(node)
-        end
-
-        alias on_numblock on_block
-
-        private
-
         # @!method regular_or_focused_example?(node)
         # @param [RuboCop::AST::Node] node
         # @return [Boolean]
@@ -98,6 +84,18 @@ module RuboCop
         def_node_search :includes_skip_example?, <<~PATTERN
           (send nil? {:pending :skip} ...)
         PATTERN
+
+        # @param [RuboCop::AST::BlockNode] node
+        def on_block(node)
+          return unless regular_or_focused_example?(node)
+          return if includes_expectation?(node)
+          return if includes_skip_example?(node)
+          return if skipped_in_metadata?(node.send_node)
+
+          add_offense(node)
+        end
+
+        alias on_numblock on_block
       end
     end
   end

--- a/lib/rubocop/cop/rspec/not_to_not.rb
+++ b/lib/rubocop/cop/rspec/not_to_not.rb
@@ -34,6 +34,9 @@ module RuboCop
         MSG = 'Prefer `%<replacement>s` over `%<original>s`.'
         RESTRICT_ON_SEND = %i[not_to to_not].freeze
 
+        # @!method not_to_not_offense(node)
+        def_node_matcher :not_to_not_offense, '(send _ % ...)'
+
         def on_send(node)
           not_to_not_offense(node, alternative_style) do
             add_offense(node.loc.selector) do |corrector|
@@ -43,9 +46,6 @@ module RuboCop
         end
 
         private
-
-        # @!method not_to_not_offense(node)
-        def_node_matcher :not_to_not_offense, '(send _ % ...)'
 
         def message(_node)
           format(MSG, replacement: style, original: alternative_style)

--- a/lib/rubocop/cop/rspec/overwriting_setup.rb
+++ b/lib/rubocop/cop/rspec/overwriting_setup.rb
@@ -25,6 +25,14 @@ module RuboCop
       class OverwritingSetup < Base
         MSG = '`%<name>s` is already defined.'
 
+        # @!method setup?(node)
+        def_node_matcher :setup?, <<~PATTERN
+          (block (send nil? {#Helpers.all #Subjects.all} ...) ...)
+        PATTERN
+
+        # @!method first_argument_name(node)
+        def_node_matcher :first_argument_name, '(send _ _ ({str sym} $_))'
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless example_group_with_body?(node)
 
@@ -37,14 +45,6 @@ module RuboCop
         end
 
         private
-
-        # @!method setup?(node)
-        def_node_matcher :setup?, <<~PATTERN
-          (block (send nil? {#Helpers.all #Subjects.all} ...) ...)
-        PATTERN
-
-        # @!method first_argument_name(node)
-        def_node_matcher :first_argument_name, '(send _ _ ({str sym} $_))'
 
         def find_duplicates(node)
           setup_expressions = Set.new

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -37,14 +37,6 @@ module RuboCop
 
         MSG = 'Pending spec found.'
 
-        def on_send(node)
-          return unless pending_block?(node) || skipped?(node)
-
-          add_offense(node)
-        end
-
-        private
-
         # @!method skippable?(node)
         def_node_matcher :skippable?, <<~PATTERN
           {
@@ -65,6 +57,14 @@ module RuboCop
             (send nil? {#Examples.skipped #Examples.pending} ...)
           }
         PATTERN
+
+        def on_send(node)
+          return unless pending_block?(node) || skipped?(node)
+
+          add_offense(node)
+        end
+
+        private
 
         def skipped?(node)
           (skippable?(node) && skipped_in_metadata?(node)) ||

--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -59,20 +59,6 @@ module RuboCop
       class PendingWithoutReason < Base
         MSG = 'Give the reason for pending or skip.'
 
-        def on_send(node)
-          on_pending_by_metadata(node)
-          return unless (parent = parent_node(node))
-
-          if spec_group?(parent) || block_node_example_group?(node)
-            on_skipped_by_example_method(node)
-            on_skipped_by_example_group_method(node)
-          elsif example?(parent)
-            on_skipped_by_in_example_method(node)
-          end
-        end
-
-        private
-
         # @!method skipped_in_example?(node)
         def_node_matcher :skipped_in_example?, <<~PATTERN
           {
@@ -112,6 +98,20 @@ module RuboCop
         def_node_matcher :pending_step_without_reason?, <<~PATTERN
           (send nil? {:skip :pending})
         PATTERN
+
+        def on_send(node)
+          on_pending_by_metadata(node)
+          return unless (parent = parent_node(node))
+
+          if spec_group?(parent) || block_node_example_group?(node)
+            on_skipped_by_example_method(node)
+            on_skipped_by_example_group_method(node)
+          elsif example?(parent)
+            on_skipped_by_in_example_method(node)
+          end
+        end
+
+        private
 
         def parent_node(node)
           node_or_block = node.block_node || node

--- a/lib/rubocop/cop/rspec/receive_counts.rb
+++ b/lib/rubocop/cop/rspec/receive_counts.rb
@@ -29,6 +29,14 @@ module RuboCop
 
         RESTRICT_ON_SEND = %i[times].freeze
 
+        # @!method receive_counts(node)
+        def_node_matcher :receive_counts, <<~PATTERN
+          (send $(send _ {:exactly :at_least :at_most} (int {1 2})) :times)
+        PATTERN
+
+        # @!method stub?(node)
+        def_node_search :stub?, '(send nil? :receive ...)'
+
         def on_send(node)
           receive_counts(node) do |offending_node|
             return unless stub?(offending_node.receiver)
@@ -43,14 +51,6 @@ module RuboCop
         end
 
         private
-
-        # @!method receive_counts(node)
-        def_node_matcher :receive_counts, <<~PATTERN
-          (send $(send _ {:exactly :at_least :at_most} (int {1 2})) :times)
-        PATTERN
-
-        # @!method stub?(node)
-        def_node_search :stub?, '(send nil? :receive ...)'
 
         def autocorrect(corrector, node, range)
           replacement = matcher_for(

--- a/lib/rubocop/cop/rspec/receive_messages.rb
+++ b/lib/rubocop/cop/rspec/receive_messages.rb
@@ -35,16 +35,6 @@ module RuboCop
         MSG = 'Use `receive_messages` instead of multiple stubs on lines ' \
               '%<loc>s.'
 
-        def on_begin(node)
-          repeated_receive_message(node).each do |item, repeated_lines, args|
-            next if repeated_lines.empty?
-
-            register_offense(item, repeated_lines, args)
-          end
-        end
-
-        private
-
         # @!method allow_receive_message?(node)
         def_node_matcher :allow_receive_message?, <<~PATTERN
           (send (send nil? :allow ...) :to (send (send nil? :receive (sym _)) :and_return !#heredoc_or_splat?))
@@ -69,6 +59,16 @@ module RuboCop
         def_node_matcher :receive_and_return_argument, <<~PATTERN
           (send (send nil? :allow ...) :to (send (send nil? :receive (sym $_)) :and_return $_))
         PATTERN
+
+        def on_begin(node)
+          repeated_receive_message(node).each do |item, repeated_lines, args|
+            next if repeated_lines.empty?
+
+            register_offense(item, repeated_lines, args)
+          end
+        end
+
+        private
 
         def repeated_receive_message(node)
           node

--- a/lib/rubocop/cop/rspec/receive_never.rb
+++ b/lib/rubocop/cop/rspec/receive_never.rb
@@ -14,9 +14,11 @@ module RuboCop
       #
       class ReceiveNever < Base
         extend AutoCorrector
-
         MSG = 'Use `not_to receive` instead of `never`.'
         RESTRICT_ON_SEND = %i[never].freeze
+
+        # @!method method_on_stub?(node)
+        def_node_search :method_on_stub?, '(send nil? :receive ...)'
 
         def on_send(node)
           return unless node.method?(:never) && method_on_stub?(node)
@@ -27,9 +29,6 @@ module RuboCop
         end
 
         private
-
-        # @!method method_on_stub?(node)
-        def_node_search :method_on_stub?, '(send nil? :receive ...)'
 
         def autocorrect(corrector, node)
           corrector.replace(node.parent.loc.selector, 'not_to')

--- a/lib/rubocop/cop/rspec/remove_const.rb
+++ b/lib/rubocop/cop/rspec/remove_const.rb
@@ -22,19 +22,17 @@ module RuboCop
               'Consider using e.g. `stub_const`.'
         RESTRICT_ON_SEND = %i[send __send__].freeze
 
+        # @!method remove_const(node)
+        def_node_matcher :remove_const, <<~PATTERN
+          (send _ {:send | :__send__} (sym :remove_const) _)
+        PATTERN
+
         # Check for offenses
         def on_send(node)
           remove_const(node) do
             add_offense(node)
           end
         end
-
-        private
-
-        # @!method remove_const(node)
-        def_node_matcher :remove_const, <<~PATTERN
-          (send _ {:send | :__send__} (sym :remove_const) _)
-        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/rspec/repeated_example_group_body.rb
+++ b/lib/rubocop/cop/rspec/repeated_example_group_body.rb
@@ -47,16 +47,6 @@ module RuboCop
 
         MSG = 'Repeated %<group>s block body on line(s) %<loc>s'
 
-        def on_begin(node)
-          return unless several_example_groups?(node)
-
-          repeated_group_bodies(node).each do |group, repeats|
-            add_offense(group, message: message(group, repeats))
-          end
-        end
-
-        private
-
         # @!method several_example_groups?(node)
         def_node_matcher :several_example_groups?, <<~PATTERN
           (begin <#example_group_with_body? #example_group_with_body? ...>)
@@ -70,6 +60,16 @@ module RuboCop
 
         # @!method const_arg(node)
         def_node_matcher :const_arg, '(block (send _ _ $const ...) ...)'
+
+        def on_begin(node)
+          return unless several_example_groups?(node)
+
+          repeated_group_bodies(node).each do |group, repeats|
+            add_offense(group, message: message(group, repeats))
+          end
+        end
+
+        private
 
         def repeated_group_bodies(node)
           node

--- a/lib/rubocop/cop/rspec/repeated_example_group_description.rb
+++ b/lib/rubocop/cop/rspec/repeated_example_group_description.rb
@@ -47,16 +47,6 @@ module RuboCop
 
         MSG = 'Repeated %<group>s block description on line(s) %<loc>s'
 
-        def on_begin(node)
-          return unless several_example_groups?(node)
-
-          repeated_group_descriptions(node).each do |group, repeats|
-            add_offense(group, message: message(group, repeats))
-          end
-        end
-
-        private
-
         # @!method several_example_groups?(node)
         def_node_matcher :several_example_groups?, <<~PATTERN
           (begin <#example_group? #example_group? ...>)
@@ -69,6 +59,16 @@ module RuboCop
 
         # @!method empty_description?(node)
         def_node_matcher :empty_description?, '(block (send _ _) ...)'
+
+        def on_begin(node)
+          return unless several_example_groups?(node)
+
+          repeated_group_descriptions(node).each do |group, repeats|
+            add_offense(group, message: message(group, repeats))
+          end
+        end
+
+        private
 
         def repeated_group_descriptions(node)
           node

--- a/lib/rubocop/cop/rspec/repeated_include_example.rb
+++ b/lib/rubocop/cop/rspec/repeated_include_example.rb
@@ -49,16 +49,6 @@ module RuboCop
         MSG = 'Repeated include of shared_examples %<name>s ' \
               'on line(s) %<repeat>s'
 
-        def on_begin(node)
-          return unless several_include_examples?(node)
-
-          repeated_include_examples(node).each do |item, repeats|
-            add_offense(item, message: message(item, repeats))
-          end
-        end
-
-        private
-
         # @!method several_include_examples?(node)
         def_node_matcher :several_include_examples?, <<~PATTERN
           (begin <#include_examples? #include_examples? ...>)
@@ -71,6 +61,16 @@ module RuboCop
         # @!method shared_examples_name(node)
         def_node_matcher :shared_examples_name,
                          '(send nil? #Includes.examples $_name ...)'
+
+        def on_begin(node)
+          return unless several_include_examples?(node)
+
+          repeated_include_examples(node).each do |item, repeats|
+            add_offense(item, message: message(item, repeats))
+          end
+        end
+
+        private
 
         def repeated_include_examples(node)
           node

--- a/lib/rubocop/cop/rspec/repeated_subject_call.rb
+++ b/lib/rubocop/cop/rspec/repeated_subject_call.rb
@@ -34,14 +34,6 @@ module RuboCop
 
         MSG = 'Calls to subject are memoized, this block is misleading'
 
-        def on_top_level_group(node)
-          @subjects_by_node = detect_subjects_in_scope(node)
-
-          detect_offenses_in_block(node)
-        end
-
-        private
-
         # @!method subject?(node)
         #   Find a named or unnamed subject definition
         #
@@ -69,6 +61,14 @@ module RuboCop
         def_node_search :subject_calls, <<~PATTERN
           (send nil? %)
         PATTERN
+
+        def on_top_level_group(node)
+          @subjects_by_node = detect_subjects_in_scope(node)
+
+          detect_offenses_in_block(node)
+        end
+
+        private
 
         def detect_offense(subject_node)
           return if subject_node.chained?

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -41,6 +41,17 @@ module RuboCop
         MSG_BLOCK = 'Use block for static values.'
         RESTRICT_ON_SEND = %i[and_return].freeze
 
+        # @!method contains_stub?(node)
+        def_node_search :contains_stub?, '(send nil? :receive (...))'
+
+        # @!method stub_with_block?(node)
+        def_node_matcher :stub_with_block?, '(block #contains_stub? ...)'
+
+        # @!method and_return_value(node)
+        def_node_search :and_return_value, <<~PATTERN
+          $(send _ :and_return $(...))
+        PATTERN
+
         def on_send(node)
           return unless style == :block
           return unless contains_stub?(node)
@@ -56,17 +67,6 @@ module RuboCop
         end
 
         private
-
-        # @!method contains_stub?(node)
-        def_node_search :contains_stub?, '(send nil? :receive (...))'
-
-        # @!method stub_with_block?(node)
-        def_node_matcher :stub_with_block?, '(block #contains_stub? ...)'
-
-        # @!method and_return_value(node)
-        def_node_search :and_return_value, <<~PATTERN
-          $(send _ :and_return $(...))
-        PATTERN
 
         def check_and_return_call(node)
           and_return_value(node) do |and_return, args|

--- a/lib/rubocop/cop/rspec/shared_context.rb
+++ b/lib/rubocop/cop/rspec/shared_context.rb
@@ -56,22 +56,6 @@ module RuboCop
         MSG_EXAMPLES = "Use `shared_examples` when you don't define context."
         MSG_CONTEXT  = "Use `shared_context` when you don't define examples."
 
-        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          context_with_only_examples(node) do
-            add_offense(node.send_node, message: MSG_EXAMPLES) do |corrector|
-              corrector.replace(node.send_node.loc.selector, 'shared_examples')
-            end
-          end
-
-          examples_with_only_context(node) do
-            add_offense(node.send_node, message: MSG_CONTEXT) do |corrector|
-              corrector.replace(node.send_node.loc.selector, 'shared_context')
-            end
-          end
-        end
-
-        private
-
         # @!method examples?(node)
         def_node_search :examples?, <<~PATTERN
           (send nil? {#Includes.examples #Examples.all} ...)
@@ -93,6 +77,22 @@ module RuboCop
         def_node_matcher :shared_example, <<~PATTERN
           (block (send #rspec? #SharedGroups.examples ...) ...)
         PATTERN
+
+        def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
+          context_with_only_examples(node) do
+            add_offense(node.send_node, message: MSG_EXAMPLES) do |corrector|
+              corrector.replace(node.send_node.loc.selector, 'shared_examples')
+            end
+          end
+
+          examples_with_only_context(node) do
+            add_offense(node.send_node, message: MSG_CONTEXT) do |corrector|
+              corrector.replace(node.send_node.loc.selector, 'shared_context')
+            end
+          end
+        end
+
+        private
 
         def context_with_only_examples(node)
           shared_context(node) { yield if examples?(node) && !context?(node) }

--- a/lib/rubocop/cop/rspec/shared_examples.rb
+++ b/lib/rubocop/cop/rspec/shared_examples.rb
@@ -43,6 +43,14 @@ module RuboCop
         extend AutoCorrector
         include ConfigurableEnforcedStyle
 
+        # @!method shared_examples(node)
+        def_node_matcher :shared_examples, <<~PATTERN
+          {
+            (send #rspec? #SharedGroups.all $_ ...)
+            (send nil? #Includes.all $_ ...)
+          }
+        PATTERN
+
         def on_send(node)
           shared_examples(node) do |ast_node|
             next unless offense?(ast_node)
@@ -55,14 +63,6 @@ module RuboCop
         end
 
         private
-
-        # @!method shared_examples(node)
-        def_node_matcher :shared_examples, <<~PATTERN
-          {
-            (send #rspec? #SharedGroups.all $_ ...)
-            (send nil? #Includes.all $_ ...)
-          }
-        PATTERN
 
         def offense?(ast_node)
           if style == :symbol

--- a/lib/rubocop/cop/rspec/single_argument_message_chain.rb
+++ b/lib/rubocop/cop/rspec/single_argument_message_chain.rb
@@ -23,6 +23,14 @@ module RuboCop
               '`%<called>s` with a single argument.'
         RESTRICT_ON_SEND = %i[receive_message_chain stub_chain].freeze
 
+        # @!method message_chain(node)
+        def_node_matcher :message_chain, <<~PATTERN
+          (send _ {:receive_message_chain :stub_chain} $_)
+        PATTERN
+
+        # @!method single_key_hash?(node)
+        def_node_matcher :single_key_hash?, '(hash pair)'
+
         def on_send(node)
           message_chain(node) do |arg|
             return if valid_usage?(arg)
@@ -37,14 +45,6 @@ module RuboCop
         end
 
         private
-
-        # @!method message_chain(node)
-        def_node_matcher :message_chain, <<~PATTERN
-          (send _ {:receive_message_chain :stub_chain} $_)
-        PATTERN
-
-        # @!method single_key_hash?(node)
-        def_node_matcher :single_key_hash?, '(hash pair)'
 
         def autocorrect(corrector, node, method, arg)
           corrector.replace(node.loc.selector, replacement(method))

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -39,6 +39,14 @@ module RuboCop
 
         MSG = 'Spec path should end with `%<suffix>s`.'
 
+        # @!method example_group_arguments(node)
+        def_node_matcher :example_group_arguments, <<~PATTERN
+          (block $(send #rspec? #ExampleGroups.all $_ $...) ...)
+        PATTERN
+
+        # @!method metadata_key_value(node)
+        def_node_search :metadata_key_value, '(pair (sym $_key) (sym $_value))'
+
         def on_top_level_example_group(node)
           return unless top_level_groups.one?
 
@@ -50,14 +58,6 @@ module RuboCop
         end
 
         private
-
-        # @!method example_group_arguments(node)
-        def_node_matcher :example_group_arguments, <<~PATTERN
-          (block $(send #rspec? #ExampleGroups.all $_ $...) ...)
-        PATTERN
-
-        # @!method metadata_key_value(node)
-        def_node_search :metadata_key_value, '(pair (sym $_key) (sym $_value))'
 
         def ensure_correct_file_path(send_node, class_name, arguments)
           pattern = correct_path_pattern(class_name, arguments)

--- a/lib/rubocop/cop/rspec/stubbed_mock.rb
+++ b/lib/rubocop/cop/rspec/stubbed_mock.rb
@@ -16,15 +16,6 @@ module RuboCop
       class StubbedMock < Base
         MSG = 'Prefer `%<replacement>s` over `%<method_name>s` when ' \
               'configuring a response.'
-        RESTRICT_ON_SEND = %i[to].freeze
-
-        def on_send(node)
-          expectation(node) do |expectation, method_name, matcher|
-            on_expectation(expectation, method_name, matcher)
-          end
-        end
-
-        private
 
         # @!method message_expectation?(node)
         #   Match message expectation matcher
@@ -141,6 +132,16 @@ module RuboCop
             (send (send nil? :receive ...) :with ... block_pass)            # receive(:foo).with('foo', &canned)
           }
         PATTERN
+
+        RESTRICT_ON_SEND = %i[to].freeze
+
+        def on_send(node)
+          expectation(node) do |expectation, method_name, matcher|
+            on_expectation(expectation, method_name, matcher)
+          end
+        end
+
+        private
 
         def on_expectation(expectation, method_name, matcher)
           flag_expectation = lambda do

--- a/lib/rubocop/cop/rspec/subject_declaration.rb
+++ b/lib/rubocop/cop/rspec/subject_declaration.rb
@@ -23,6 +23,11 @@ module RuboCop
         MSG_LET = 'Use subject explicitly rather than using let'
         MSG_REDUNDANT = 'Ambiguous declaration of subject'
 
+        # @!method offensive_subject_declaration?(node)
+        def_node_matcher :offensive_subject_declaration?, <<~PATTERN
+          (send nil? ${#Subjects.all #Helpers.all} ({sym str} #Subjects.all) ...)
+        PATTERN
+
         def on_send(node)
           offense = offensive_subject_declaration?(node)
           return unless offense
@@ -31,11 +36,6 @@ module RuboCop
         end
 
         private
-
-        # @!method offensive_subject_declaration?(node)
-        def_node_matcher :offensive_subject_declaration?, <<~PATTERN
-          (send nil? ${#Subjects.all #Helpers.all} ({sym str} #Subjects.all) ...)
-        PATTERN
 
         def message_for(offense)
           Helpers.all(offense) ? MSG_LET : MSG_REDUNDANT

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -52,17 +52,6 @@ module RuboCop
 
         MSG = 'Do not stub methods of the object under test.'
 
-        def on_top_level_group(node)
-          @explicit_subjects = find_all_explicit(node) { |n| subject?(n) }
-          @subject_overrides = find_all_explicit(node) { |n| let?(n) }
-
-          find_subject_expectations(node) do |stub|
-            add_offense(stub)
-          end
-        end
-
-        private
-
         # @!method subject?(node)
         #   Find a named or unnamed subject definition
         #
@@ -122,6 +111,17 @@ module RuboCop
             :receive :receive_messages :receive_message_chain :have_received
             } ...)
         PATTERN
+
+        def on_top_level_group(node)
+          @explicit_subjects = find_all_explicit(node) { |n| subject?(n) }
+          @subject_overrides = find_all_explicit(node) { |n| let?(n) }
+
+          find_subject_expectations(node) do |stub|
+            add_offense(stub)
+          end
+        end
+
+        private
 
         def find_all_explicit(node)
           node.each_descendant(:block).with_object({}) do |child, h|

--- a/lib/rubocop/cop/rspec/undescriptive_literals_description.rb
+++ b/lib/rubocop/cop/rspec/undescriptive_literals_description.rb
@@ -47,6 +47,11 @@ module RuboCop
       class UndescriptiveLiteralsDescription < Base
         MSG = 'Description should be descriptive.'
 
+        # @!method example_groups_or_example?(node)
+        def_node_matcher :example_groups_or_example?, <<~PATTERN
+          (block (send #rspec? {#ExampleGroups.all #Examples.all} $_) ...)
+        PATTERN
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           example_groups_or_example?(node) do |arg|
             add_offense(arg) if offense?(arg)
@@ -54,11 +59,6 @@ module RuboCop
         end
 
         private
-
-        # @!method example_groups_or_example?(node)
-        def_node_matcher :example_groups_or_example?, <<~PATTERN
-          (block (send #rspec? {#ExampleGroups.all #Examples.all} $_) ...)
-        PATTERN
 
         def offense?(node)
           %i[xstr int regexp].include?(node.type)

--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -34,14 +34,6 @@ module RuboCop
         MSG = 'Specify the exception being captured'
         RESTRICT_ON_SEND = %i[to].freeze
 
-        def on_send(node)
-          return unless empty_exception_matcher?(node)
-
-          add_offense(node.children.last)
-        end
-
-        private
-
         # @!method empty_raise_error_or_exception(node)
         def_node_matcher :empty_raise_error_or_exception, <<~PATTERN
           (send
@@ -51,6 +43,14 @@ module RuboCop
             (send nil? {:raise_error :raise_exception})
           )
         PATTERN
+
+        def on_send(node)
+          return unless empty_exception_matcher?(node)
+
+          add_offense(node.children.last)
+        end
+
+        private
 
         def empty_exception_matcher?(node)
           empty_raise_error_or_exception(node) && !block_with_args?(node.parent)

--- a/lib/rubocop/cop/rspec/verified_double_reference.rb
+++ b/lib/rubocop/cop/rspec/verified_double_reference.rb
@@ -62,6 +62,15 @@ module RuboCop
           const: :constant
         }.freeze
 
+        # @!method verified_double(node)
+        def_node_matcher :verified_double, <<~PATTERN
+          (send
+            nil?
+            RESTRICT_ON_SEND
+            $_class_reference
+            ...)
+        PATTERN
+
         def on_send(node)
           verified_double(node) do |class_reference|
             break correct_style_detected unless opposing_style?(class_reference)
@@ -79,15 +88,6 @@ module RuboCop
         end
 
         private
-
-        # @!method verified_double(node)
-        def_node_matcher :verified_double, <<~PATTERN
-          (send
-            nil?
-            RESTRICT_ON_SEND
-            $_class_reference
-            ...)
-        PATTERN
 
         def opposing_style?(class_reference)
           class_reference_style = REFERENCE_TYPE_STYLES[class_reference.type]

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -27,6 +27,11 @@ module RuboCop
         MSG = 'Prefer using verifying doubles over normal doubles.'
         RESTRICT_ON_SEND = %i[double spy].freeze
 
+        # @!method unverified_double(node)
+        def_node_matcher :unverified_double, <<~PATTERN
+          {(send nil? {:double :spy} $...)}
+        PATTERN
+
         def on_send(node)
           unverified_double(node) do |name, *_args|
             return if name.nil? && cop_config['IgnoreNameless']
@@ -37,11 +42,6 @@ module RuboCop
         end
 
         private
-
-        # @!method unverified_double(node)
-        def_node_matcher :unverified_double, <<~PATTERN
-          {(send nil? {:double :spy} $...)}
-        PATTERN
 
         def symbol?(name)
           name&.sym_type?

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -17,6 +17,16 @@ module RuboCop
               'Chain the methods or remove it.'
         RESTRICT_ON_SEND = %i[expect].freeze
 
+        # @!method expect?(node)
+        def_node_matcher :expect?, <<~PATTERN
+          (send nil? :expect ...)
+        PATTERN
+
+        # @!method expect_block?(node)
+        def_node_matcher :expect_block?, <<~PATTERN
+          (block #expect? (args) _body)
+        PATTERN
+
         def on_send(node)
           return unless expect?(node)
 
@@ -30,16 +40,6 @@ module RuboCop
         end
 
         private
-
-        # @!method expect?(node)
-        def_node_matcher :expect?, <<~PATTERN
-          (send nil? :expect ...)
-        PATTERN
-
-        # @!method expect_block?(node)
-        def_node_matcher :expect_block?, <<~PATTERN
-          (block #expect? (args) _body)
-        PATTERN
 
         def check_expect(node)
           return unless void?(node)

--- a/lib/rubocop/cop/rspec/yield.rb
+++ b/lib/rubocop/cop/rspec/yield.rb
@@ -18,6 +18,15 @@ module RuboCop
 
         MSG = 'Use `.and_yield`.'
 
+        # @!method method_on_stub?(node)
+        def_node_search :method_on_stub?, '(send nil? :receive ...)'
+
+        # @!method block_arg(node)
+        def_node_matcher :block_arg, '(args (blockarg $_))'
+
+        # @!method block_call?(node)
+        def_node_matcher :block_call?, '(send (lvar %) :call ...)'
+
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless method_on_stub?(node.send_node)
 
@@ -33,15 +42,6 @@ module RuboCop
         end
 
         private
-
-        # @!method method_on_stub?(node)
-        def_node_search :method_on_stub?, '(send nil? :receive ...)'
-
-        # @!method block_arg(node)
-        def_node_matcher :block_arg, '(args (blockarg $_))'
-
-        # @!method block_call?(node)
-        def_node_matcher :block_call?, '(send (lvar %) :call ...)'
 
         def autocorrect(corrector, node, range)
           corrector.replace(

--- a/lib/rubocop/rspec/example.rb
+++ b/lib/rubocop/rspec/example.rb
@@ -4,6 +4,15 @@ module RuboCop
   module RSpec
     # Wrapper for RSpec examples
     class Example < Concept
+      # @!method extract_doc_string(node)
+      def_node_matcher :extract_doc_string,     '(send _ _ $_ ...)'
+
+      # @!method extract_metadata(node)
+      def_node_matcher :extract_metadata,       '(send _ _ _ $...)'
+
+      # @!method extract_implementation(node)
+      def_node_matcher :extract_implementation, '(block send args $_)'
+
       def doc_string
         extract_doc_string(definition)
       end
@@ -23,17 +32,6 @@ module RuboCop
           node.send_node
         end
       end
-
-      private
-
-      # @!method extract_doc_string(node)
-      def_node_matcher :extract_doc_string,     '(send _ _ $_ ...)'
-
-      # @!method extract_metadata(node)
-      def_node_matcher :extract_metadata,       '(send _ _ _ $...)'
-
-      # @!method extract_implementation(node)
-      def_node_matcher :extract_implementation, '(block send args $_)'
     end
   end
 end

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -4,6 +4,19 @@ module RuboCop
   module RSpec
     # Wrapper for RSpec example groups
     class ExampleGroup < Concept
+      # @!method scope_change?(node)
+      #
+      #   Detect if the node is an example group or shared example
+      #
+      #   Selectors which indicate that we should stop searching
+      #
+      def_node_matcher :scope_change?, <<~PATTERN
+        (block {
+          (send #rspec? {#SharedGroups.all #ExampleGroups.all} ...)
+          (send nil? #Includes.all ...)
+        } ...)
+      PATTERN
+
       def lets
         find_all_in_scope(node, :let?)
       end
@@ -25,19 +38,6 @@ module RuboCop
       end
 
       private
-
-      # @!method scope_change?(node)
-      #
-      #   Detect if the node is an example group or shared example
-      #
-      #   Selectors which indicate that we should stop searching
-      #
-      def_node_matcher :scope_change?, <<~PATTERN
-        (block {
-          (send #rspec? {#SharedGroups.all #ExampleGroups.all} ...)
-          (send nil? #Includes.all ...)
-        } ...)
-      PATTERN
 
       # Recursively search for predicate within the current scope
       #

--- a/lib/rubocop/rspec/hook.rb
+++ b/lib/rubocop/rspec/hook.rb
@@ -4,6 +4,13 @@ module RuboCop
   module RSpec
     # Wrapper for RSpec hook
     class Hook < Concept
+      # @!method extract_metadata(node)
+      def_node_matcher :extract_metadata, <<~PATTERN
+        (block
+          (send _ _ #valid_scope? ? $...) ...
+        )
+      PATTERN
+
       def name
         node.method_name
       end
@@ -36,13 +43,6 @@ module RuboCop
       end
 
       private
-
-      # @!method extract_metadata(node)
-      def_node_matcher :extract_metadata, <<~PATTERN
-        (block
-          (send _ _ #valid_scope? ? $...) ...
-        )
-      PATTERN
 
       def valid_scope?(node)
         node&.sym_type? && Language::HookScopes.all(node.value)


### PR DESCRIPTION
Mostly a revert of #1906, based on arguments in this thread: https://github.com/rubocop/rubocop-rspec/pull/1906#discussion_r1629301489

The only thing not reverted is [the change to .rubocop.yml](https://github.com/rubocop/rubocop-rspec/blob/cfb3a48896278749540d2059ff234eb83d05dfbc/.rubocop.yml#L50-L53).