### PR TITLE
Update 'Changelog' link on rubygems.org/gems/rubocop-rspec

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ['MIT-LICENSE.md', 'README.md']
 
   spec.metadata = {
-    'changelog_uri' => 'https://github.com/rubocop/rubocop-rspec/blob/master/CHANGELOG.md',
+    'changelog_uri' => 'https://github.com/rubocop/rubocop-rspec/releases',
     'documentation_uri' => 'https://docs.rubocop.org/rubocop-rspec/',
     'rubygems_mfa_required' => 'true'
   }


### PR DESCRIPTION
The CHANGELOG.md file hasn't been updated for a couple of releases. Is it better to now point the rubygem Changelog link to the github releases page?
