### PR TITLE
Add some commits into .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,7 @@
 # .git-blame-ignore-revs
 # Add mdformat to the workflow in GitHub Actions
 4874a5a4a2a58e76d343aaa02279cd93b16f5a30
+# Move node patterns into private scope
+089491fb1fa173145f8e6eb1b511d4a7a1bf28ff
+# Don't always define node patterns in private scope
+ce09cb2b25b9f3778bf032d0caaa862da6635b54


### PR DESCRIPTION
How about https://github.com/rubocop/rubocop-rspec/pull/1906/commits/089491fb1fa173145f8e6eb1b511d4a7a1bf28ff and ce09cb2b25b9f3778bf032d0caaa862da6635b54 ?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
