### PR TITLE
Fix an error for `RSpec/ScatteredSetup` when one of the hooks is an empty block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Support `AutoCorrect: contextual` option for LSP. ([@ydah])
 - Enable all pending cops. ([@bquorning])
 - Add new `RSpec/MissingExpectationTargetMethod` cop. ([@krororo])
+- Fix an error for `RSpec/ScatteredSetup` when one of the hooks is an empty block. ([@earlopain])
 
 ## 2.29.2 (2024-05-02)
 
@@ -894,6 +895,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@drowze]: https://github.com/Drowze
 [@dswij]: https://github.com/dswij
 [@dvandersluis]: https://github.com/dvandersluis
+[@earlopain]: https://github.com/earlopain
 [@edgibbs]: https://github.com/edgibbs
 [@eikes]: https://github.com/eikes
 [@eitoball]: https://github.com/eitoball

--- a/lib/rubocop/cop/rspec/scattered_setup.rb
+++ b/lib/rubocop/cop/rspec/scattered_setup.rb
@@ -76,7 +76,7 @@ module RuboCop
           return if first_occurrence == occurrence || !first_occurrence.body
 
           corrector.insert_after(first_occurrence.body,
-                                 "\n#{occurrence.body.source}")
+                                 "\n#{occurrence.body&.source}")
           corrector.remove(range_by_whole_lines(occurrence.source_range,
                                                 include_final_newline: true))
         end

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -150,4 +150,22 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
       end
     RUBY
   end
+
+  it 'flags hooks when one of the hooks is an empty block' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        before { do_something }
+        ^^^^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 3).
+        before { }
+        ^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo do
+        before { do_something
+       }
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
The produced autocorrect is not the best but there are other cops that will push this into something more pleasing.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- x ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).