### PR TITLE
Suppress deprecation warning for some cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add support for Unicode RIGHT SINGLE QUOTATION MARK in `RSpec/ExampleWording`. ([@jdufresne])
+- Suppress deprecation warning for `RSpec/MultipleExpectations`, `RSpec/MultipleMemoizedHelpers`, and `RSpec/NestedGroups` cops. ([@koic])
 
 ## 3.0.2 (2024-07-02)
 

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -67,12 +67,12 @@ module RuboCop
       #   end
       #
       class MultipleExpectations < Base
-        include ConfigurableMax
-
         MSG = 'Example has too many expectations [%<total>d/%<max>d].'
 
         ANYTHING = ->(_node) { true }
         TRUE_NODE = lambda(&:true_type?)
+
+        exclude_limit 'Max'
 
         # @!method aggregate_failures?(node)
         def_node_matcher :aggregate_failures?, <<~PATTERN

--- a/lib/rubocop/cop/rspec/multiple_memoized_helpers.rb
+++ b/lib/rubocop/cop/rspec/multiple_memoized_helpers.rb
@@ -82,10 +82,11 @@ module RuboCop
       #   end
       #
       class MultipleMemoizedHelpers < Base
-        include ConfigurableMax
         include Variable
 
         MSG = 'Example group has too many memoized helpers [%<count>d/%<max>d]'
+
+        exclude_limit 'Max'
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless spec_group?(node)

--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -92,7 +92,6 @@ module RuboCop
       #   end
       #
       class NestedGroups < Base
-        include ConfigurableMax
         include TopLevelGroup
 
         MSG = 'Maximum example group nesting exceeded [%<total>d/%<max>d].'
@@ -102,6 +101,8 @@ module RuboCop
         DEPRECATION_WARNING =
           "Configuration key `#{DEPRECATED_MAX_KEY}` for #{cop_name} is " \
           'deprecated in favor of `Max`. Please use that instead.'
+
+        exclude_limit 'Max'
 
         def on_top_level_group(node)
           find_nested_example_groups(node) do |example_group, nesting|


### PR DESCRIPTION
Resolves https://github.com/rubocop/rubocop/pull/13032#issuecomment-2220942111.

Starting from RuboCop 1.65, using `ConfigurableMax` module API, which is deprecated, will trigger deprecation warnings.
This PR suppresses these warnings by using `exclude_limit` instead of the deprecated API.

Related PR: https://github.com/rubocop/rubocop/pull/9471

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
