### PR TITLE
Fix false-negative for `UnspecifiedException` when matcher is chained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix false-negative for `UnspecifiedException` when matcher is chained. ([@r7kamura])
+
 ## 3.0.3 (2024-07-12)
 
 - Add support for Unicode RIGHT SINGLE QUOTATION MARK in `RSpec/ExampleWording`. ([@jdufresne])

--- a/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
+++ b/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
@@ -171,5 +171,32 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
         }.to raise_exception(my_exception)
       RUBY
     end
+
+    it 'detects chained offenses' do
+      expect_offense(<<~RUBY)
+        expect {
+          foo
+        }.to raise_exception.and change { bar }
+             ^^^^^^^^^^^^^^^ Specify the exception being captured
+      RUBY
+    end
+
+    it 'detects more chained offenses' do
+      expect_offense(<<~RUBY)
+        expect {
+          foo
+        }.to raise_exception.and change { bar }.and change { baz }
+             ^^^^^^^^^^^^^^^ Specify the exception being captured
+      RUBY
+    end
+
+    it 'detects more complex chained offenses' do
+      expect_offense(<<~RUBY)
+        expect {
+          foo
+        }.to change { bar }.and raise_exception.and change { baz }
+                                ^^^^^^^^^^^^^^^ Specify the exception being captured
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
I noticed that this cop could not detect the following cases, so fixed it.

```ruby
expect {
  foo
}.to raise_exception.and change { bar }
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).