### PR TITLE
Fix false-negative and error for `RSpec/MetadataStyle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix false-negative and error for `RSpec/MetadataStyle` when non-literal args are used in metadata in `EnforceStyle: hash`. ([@cbliard])
+
 ## 3.0.4 (2024-08-05)
 
 - Fix false-negative for `UnspecifiedException` when matcher is chained. ([@r7kamura])
@@ -911,6 +913,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@bquorning]: https://github.com/bquorning
 [@brentwheeldon]: https://github.com/BrentWheeldon
 [@brianhawley]: https://github.com/BrianHawley
+[@cbliard]: https://github.com/cbliard
 [@cfabianski]: https://github.com/cfabianski
 [@clupprich]: https://github.com/clupprich
 [@composerinteralia]: https://github.com/composerinteralia

--- a/lib/rubocop/cop/rspec/metadata_style.rb
+++ b/lib/rubocop/cop/rspec/metadata_style.rb
@@ -45,13 +45,8 @@ module RuboCop
         PATTERN
 
         def on_metadata(symbols, hash)
-          # RSpec example groups accept two string arguments. In such a case,
-          # the rspec_metadata matcher will interpret the second string
-          # argument as a metadata symbol.
-          symbols.shift if symbols.first&.str_type?
-
           symbols.each do |symbol|
-            on_metadata_symbol(symbol)
+            on_metadata_symbol(symbol) if symbol.sym_type?
           end
 
           return unless hash

--- a/spec/rubocop/cop/rspec/metadata_style_spec.rb
+++ b/spec/rubocop/cop/rspec/metadata_style_spec.rb
@@ -94,6 +94,15 @@ RSpec.describe RuboCop::Cop::RSpec::MetadataStyle do
       end
     end
 
+    context 'with non-literal metadata and symbol metadata' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          describe 'Something', a, :b do
+          end
+        RUBY
+      end
+    end
+
     context 'with boolean keyword arguments metadata and symbol metadata' do
       it 'registers offense' do
         expect_offense(<<~RUBY)
@@ -243,6 +252,15 @@ RSpec.describe RuboCop::Cop::RSpec::MetadataStyle do
       end
     end
 
+    context 'with 2 non-literal metadata' do
+      it 'registers no offense' do
+        expect_no_offenses(<<~RUBY)
+          describe 'Something', a, b do
+          end
+        RUBY
+      end
+    end
+
     context 'with symbol metadata after 2 string arguments' do
       it 'registers offense' do
         expect_offense(<<~RUBY)
@@ -253,6 +271,21 @@ RSpec.describe RuboCop::Cop::RSpec::MetadataStyle do
 
         expect_correction(<<~RUBY)
           describe 'Something', 'Something else', a: true do
+          end
+        RUBY
+      end
+    end
+
+    context 'with symbol metadata after non-literal metadata' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          describe 'Something', a, :b do
+                                   ^^ Use hash style for metadata.
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          describe 'Something', a, b: true do
           end
         RUBY
       end


### PR DESCRIPTION
When RSpec/MetadataStyle cop is used with `EnforcedStyle: hash`, offenses must be registered only for metadata arguments being symbols.

This code:
```ruby
describe 'Something', a, b do
end
```

would previously report
```ruby
describe 'Something', a, b do
                      ^ Use hash style for metadata.
end
```

And this code:
```ruby
describe 'Something', a, :b do
end
```

would previously produce the following exception: "NoMethodError: undefined method `value' for an instance of RuboCop::AST::SendNode".

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
