### PR TITLE
Fix `RSpec/SortMetadata` cop to sort only trailing metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix `RSpec/SortMetadata` cop to limit sorting to trailing metadata arguments. ([@cbliard])
+
 ## 3.3.0 (2024-12-12)
 
 - Deprecate `top_level_group?` method from `TopLevelGroup` mixin as all of its callers were intentionally removed from `Rubocop/RSpec`. ([@corsonknowles])

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5735,6 +5735,8 @@ end
 
 Sort RSpec metadata alphabetically.
 
+Only the trailing metadata is sorted.
+
 [#examples-rspecsortmetadata]
 === Examples
 
@@ -5749,6 +5751,10 @@ it 'works', :b, :a, foo: 'bar', baz: true
 describe 'Something', :a, :b
 context 'Something', baz: true, foo: 'bar'
 it 'works', :a, :b, baz: true, foo: 'bar'
+
+# good, trailing metadata is sorted
+describe 'Something', 'description', :a, :b, :z
+context 'Something', :z, variable, :a, :b
 ----
 
 [#references-rspecsortmetadata]

--- a/lib/rubocop/cop/rspec/mixin/metadata.rb
+++ b/lib/rubocop/cop/rspec/mixin/metadata.rb
@@ -47,15 +47,12 @@ module RuboCop
         private
 
         def on_metadata_arguments(metadata_arguments)
-          *symbols, last = metadata_arguments
-          hash = nil
-          case last&.type
-          when :hash
-            hash = last
-          when :sym
-            symbols << last
+          if metadata_arguments.last&.hash_type?
+            *metadata_arguments, hash = metadata_arguments
+            on_metadata(metadata_arguments, hash)
+          else
+            on_metadata(metadata_arguments, nil)
           end
-          on_metadata(symbols, hash)
         end
       end
     end

--- a/lib/rubocop/rspec/description_extractor.rb
+++ b/lib/rubocop/rspec/description_extractor.rb
@@ -62,8 +62,8 @@ module RuboCop
         end
 
         def cop_subclass?
-          yardoc.superclass.path == RSPEC_COP_CLASS_NAME ||
-            yardoc.superclass.path == RUBOCOP_COP_CLASS_NAME
+          [RSPEC_COP_CLASS_NAME,
+           RUBOCOP_COP_CLASS_NAME].include?(yardoc.superclass.path)
         end
 
         def abstract?


### PR DESCRIPTION
Fixes #1946.

Symbols in metadata are processed by RSpec only when they are positioned last, meaning the other parameter types must be positioned before the symbols. RSpec `context`/`describe` accepts second non-symbol argument as an additional description.

Previously this cop was sorting all arguments, regardless of their type, which could lead to having the second string argument (the additional description) moved to another place (see #1946 for details). This PR fixes it.

Questions for reviewers:
- ~~is it ok to sort strings before variables? I have the feeling that this cop's responsibility should be to just take care of sorting symbols at the end of the arguments list.~~ As discussed during the review, only the last metadata arguments are considered (symbols and final hash argument).
- ~~the message "Sort metadata alphabetically." does not fully reflect what the cop is doing anymore, and can be confusing for code like `describe 'Something', :a, b, :c` because the metadata *is* sorted. I could not come up with a good message. Suggestions?~~ As only the trailing metadata is sorted now, the message seems ok.
- I noticed an autocorrect issue with `describe 'Something', :b, :a, { foo: :bar }`: it gets autocorrected to `describe 'Something', :b, :a, foo: :bar }`. Should it be fixed in the same PR?
- I updated the `RuboCop::Cop::RSpec::Metadata#on_metadata_arguments` method because it was skipping the last argument if it was not a hash. I also renamed `symbols` to `metadata_arguments` (or `args` in `RSpec/SortMetadata` cop). Should `symbols` be renamed to `metadata_arguments` or `args` in other cops relying on `on_metadata` too?
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
