### PR TITLE
CI: Use arm64 runners

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   codespell:
     name: CodeSpell
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: CodeSpell

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   yamllint:
     name: Yamllint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Yamllint
@@ -20,7 +20,7 @@ jobs:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   mdformat:
     name: Mdformat
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - name: Mdformat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   confirm_config_and_documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     name: Confirm config and documentation
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - run: bundle exec rake confirm_config documentation_syntax_check confirm_documentation
 
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         ruby:
@@ -48,7 +48,7 @@ jobs:
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     name: "Test coverage"
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
       - run: bundle exec rake spec
 
   edge-rubocop:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         task:
@@ -80,7 +80,7 @@ jobs:
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
   oldest-rubocop:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         task:
@@ -101,7 +101,7 @@ jobs:
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
   rspec4:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     name: RSpec 4
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     name: Publish to RubyGems
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
CI: Use arm64 runners

We can now run on the arm based CI runners: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Our CI generally runs pretty fast, so it's hard to see any real difference in runtime yet. However, the two relatively slow JRuby jobs finished 10-15% faster on this PR than they did on the latest CI run on the master branch ([master](https://github.com/rubocop/rubocop-rspec/actions/runs/12763800983/job/35574680857) vs [this PR](https://github.com/rubocop/rubocop-rspec/actions/runs/12857027580/job/35844409916)).

Links:

- GitHub’s documentation of [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- The Readme for the [Ubuntu 22.04 by Arm Limited](https://github.com/actions/partner-runner-images/blob/main/images/arm-ubuntu-22-image.md) runner image.
