### PR TITLE
RSpec/UnspecifiedException: break on non-send blocks to avoid false positives on functions named `raise_exception`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix false-positive for `RSpec/UnspecifiedException` when a method is literally named `raise_exception`. ([@aarestad])
+
 ## 3.0.5 (2024-09-07)
 
 - Fix false-negative and error for `RSpec/MetadataStyle` when non-literal args are used in metadata in `EnforceStyle: hash`. ([@cbliard])
@@ -899,6 +901,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 
 <!-- Contributors (alphabetically) -->
 
+[@aarestad]: https://github.com/aarestad
 [@abrom]: https://github.com/abrom
 [@ahukkanen]: https://github.com/ahukkanen
 [@akiomik]: https://github.com/akiomik

--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -62,7 +62,10 @@ module RuboCop
         end
 
         def find_expect_to(node)
-          node.each_ancestor(:send).find do |ancestor|
+          node.each_ancestor.find do |ancestor|
+            break if ancestor.block_type?
+            next unless ancestor.send_type?
+
             expect_to?(ancestor)
           end
         end

--- a/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
+++ b/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
@@ -85,6 +85,30 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
         }.to raise_error(my_exception)
       RUBY
     end
+
+    it 'allows a subject function to be named raise_error' do
+      expect_no_offenses(<<~RUBY)
+        def raise_exception
+          raise StandardError
+        end
+
+        expect {
+          raise_error
+        }.to raise_error(StandardError)
+      RUBY
+    end
+
+    it 'allows a subject function to be named raise_exception' do
+      expect_no_offenses(<<~RUBY)
+        def raise_exception
+          raise StandardError
+        end
+
+        expect {
+          raise_exception
+        }.to raise_error(StandardError)
+      RUBY
+    end
   end
 
   context 'with raise_exception matcher' do
@@ -196,6 +220,30 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
           foo
         }.to change { bar }.and raise_exception.and change { baz }
                                 ^^^^^^^^^^^^^^^ Specify the exception being captured
+      RUBY
+    end
+
+    it 'allows a subject function to be named raise_exception' do
+      expect_no_offenses(<<~RUBY)
+        def raise_error
+          raise StandardError
+        end
+
+        expect {
+          raise_exception
+        }.to raise_exception(StandardError)
+      RUBY
+    end
+
+    it 'allows a subject function to be named raise_error' do
+      expect_no_offenses(<<~RUBY)
+        def raise_error
+          raise StandardError
+        end
+
+        expect {
+          raise_error
+        }.to raise_exception(StandardError)
       RUBY
     end
   end


### PR DESCRIPTION
Fixes a false positive in the `UnspecifiedException` cop that is triggered when a function under test is literally called `raise_exception` or `raise_error`.

Resolves #1949.