### PR TITLE
test: showcase `RSpec/UnspecifiedException` block/chain confusion is fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix false-positive for `RSpec/UnspecifiedException` when a method is literally named `raise_exception`. ([@aarestad])
+- Fix false-positive for `RSpec/UnspecifiedException` when `not_to raise_error` is used within a block. ([@aarestad], [@G-Rath])
 
 ## 3.0.5 (2024-09-07)
 

--- a/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
+++ b/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
@@ -223,6 +223,14 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
       RUBY
     end
 
+    it 'does not confuse blocks with chains' do
+      expect_no_offenses(<<~RUBY)
+        expect do
+          expect { foo }.not_to raise_error
+        end.to change(Foo, :count).by(3)
+      RUBY
+    end
+
     it 'allows a subject function to be named raise_exception' do
       expect_no_offenses(<<~RUBY)
         def raise_error


### PR DESCRIPTION
This adds a spec to assert #1954 has been resolved by #1960

Resolves #1954

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [x] ~Added the new cop to `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: pending` in `config/default.yml`.~
- [x] ~The cop is configured as `Enabled: true` in `.rubocop.yml`.~
- [x] ~The cop documents examples of good and bad code.~
- [x] ~The tests assert both that bad code is reported and that good code is not reported.~
- [x] ~Set `VersionAdded: "<<next>>"` in `default/config.yml`.~

If you have modified an existing cop's configuration options:

- [x] ~Set `VersionChanged: "<<next>>"` in `config/default.yml`.~
