### PR TITLE
Complete line coverage for Metadata mixin

### DIFF
--- a/spec/rubocop/cop/rspec/mixin/metadata_spec.rb
+++ b/spec/rubocop/cop/rspec/mixin/metadata_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::Metadata do
+  describe '#on_metadata' do
+    subject(:on_metadata) do
+      stub_class.new.on_metadata(:symbol, {})
+    end
+
+    let(:stub_class) do
+      Class.new do
+        include RuboCop::Cop::RSpec::Metadata
+      end
+    end
+
+    it { expect { on_metadata }.to raise_error(NotImplementedError) }
+  end
+end


### PR DESCRIPTION
At this point, there are only 2 uncovered lines in the whole repo. This PR addresses one of them, in the Metadata mixin:
* it adds a final spec to cover an intentionally unimplemented method.

The spec  for `on_metadata` may be trivial, but it accomplishes the goal of having 100% line coverage, which means all subsequent committers will know immediately if any of their lines are uncovered. 

This will also unblock this repo from updating the existing test coverage CI check to maintain 100% coverage forever moving forward:
* https://github.com/rubocop/rubocop-rspec/pull/1971

Covering the other missing line is split to this PR:
* https://github.com/rubocop/rubocop-rspec/pull/1976  

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
