### PR TITLE
Complete branch coverage for ContextWording

### DIFF
--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -214,4 +214,17 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       end
     end
   end
+
+  context 'when `AllowedPatterns:` and `Prefixes:` are both empty' do
+    let(:cop_config) do
+      { 'Prefixes' => [], 'AllowedPatterns' => [] }
+    end
+
+    it 'skips any description' do
+      expect_no_offenses(<<~RUBY)
+        context 'arbitrary text' do
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Completes branch coverage for the ContextWording cop. 

See related efforts:
* https://github.com/rubocop/rubocop-rspec/pull/1970
* https://github.com/rubocop/rubocop-rspec/pull/1971
* https://github.com/rubocop/rubocop-rspec/pull/1975 (split from this PR)
* https://github.com/rubocop/rubocop-rspec/pull/1976 (split from PR#1970)

Before:

<img width="1382" alt="Screenshot 2024-10-14 at 11 24 47 AM" src="https://github.com/user-attachments/assets/0cd08c49-f278-490b-8dab-0a7a920480d6">


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
