### PR TITLE
Require VoidExpect to operate inside an example block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix `RSpec/VoidExpect` to only operate inside an example block. ([@corsonknowles])
+
 ## 3.1.0 (2024-10-01)
 
 - Add `RSpec/StringAsInstanceDoubleConstant` to check for and correct strings used as instance_doubles. ([@corsonknowles])

--- a/lib/rubocop/cop/rspec/void_expect.rb
+++ b/lib/rubocop/cop/rspec/void_expect.rb
@@ -29,12 +29,14 @@ module RuboCop
 
         def on_send(node)
           return unless expect?(node)
+          return unless inside_example?(node)
 
           check_expect(node)
         end
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           return unless expect_block?(node)
+          return unless inside_example?(node)
 
           check_expect(node)
         end
@@ -49,10 +51,13 @@ module RuboCop
 
         def void?(expect)
           parent = expect.parent
-          return true unless parent
           return true if parent.begin_type?
 
           parent.block_type? && parent.body == expect
+        end
+
+        def inside_example?(node)
+          node.each_ancestor(:block).any? { |ancestor| example?(ancestor) }
         end
       end
     end

--- a/spec/rubocop/cop/rspec/void_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/void_expect_spec.rb
@@ -44,4 +44,26 @@ RSpec.describe RuboCop::Cop::RSpec::VoidExpect do
       end
     RUBY
   end
+
+  it 'ignores unrelated method named expect in an example block' do
+    expect_no_offenses(<<~RUBY)
+      it 'something' do
+        MyObject.expect(:foo)
+      end
+    RUBY
+  end
+
+  context 'when expect has no parent node' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        expect(something)
+      RUBY
+    end
+
+    it 'does not register an offense for unrelated expect with block' do
+      expect_no_offenses(<<~RUBY)
+        expect { block_contents }
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR completes branch coverage for `VoidExpect`.

This PR copies the `inside_example?` method and re-uses it here to get more coherent behavior from the VoidExpect cop. 

Note that if we were thinking of copying `inside_example?` a 3rd time, I'd suggest factoring it out into a utility (Sandi Metz' rule of 3).

Note that I remove the `return true unless parent` guard clause, because we expect the `inside_example?` guard clause to fully cover that condition.

Split from:
* https://github.com/rubocop/rubocop-rspec/pull/1972



______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
