### PR TITLE
Deprecate top_level_group? and test it in a Cop class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `RSpec/VoidExpect` to only operate inside an example block. ([@corsonknowles])
 - Change `RSpec/ContextWording` cop to always report an offense when both `Prefixes` and `AllowedPatterns` are empty. ([@ydah])
 - Fix an error for `RSpec/ChangeByZero` when `change (...) .by (0)` and `change (...)`, concatenated with `and` and `or`. ([@ydah])
+- Deprecate `top_level_group?` method from `TopLevelGroup` mixin as all of its callers were intentionally removed from `Rubocop/RSpec`. ([@corsonknowles])
 
 ## 3.1.0 (2024-10-01)
 

--- a/lib/rubocop/cop/rspec/mixin/top_level_group.rb
+++ b/lib/rubocop/cop/rspec/mixin/top_level_group.rb
@@ -7,6 +7,9 @@ module RuboCop
       module TopLevelGroup
         extend RuboCop::NodePattern::Macros
 
+        DEPRECATED_MODULE_METHOD_WARNING =
+          'top_level_group? is deprecated and will be ' \
+          'removed in the next major version of rubocop_rspec.'
         def on_new_investigation
           super
 
@@ -28,7 +31,10 @@ module RuboCop
 
         def on_top_level_group(_node); end
 
+        # @private
+        # @deprecated All callers of this method have been removed.
         def top_level_group?(node)
+          warn DEPRECATED_MODULE_METHOD_WARNING, uplevel: 1
           top_level_groups.include?(node)
         end
 

--- a/spec/rubocop/cop/rspec/mixin/top_level_group_spec.rb
+++ b/spec/rubocop/cop/rspec/mixin/top_level_group_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::RSpec::TopLevelGroup do
+  describe '#top_level_group?' do
+    let(:stub_class) do
+      Class.new do
+        include RuboCop::Cop::RSpec::TopLevelGroup
+
+        def initialize
+          @top_level_groups = []
+        end
+
+        def test_top_level_group
+          top_level_group?(nil)
+        end
+      end
+    end
+
+    it 'warns because it is deprecated' do
+      expect { stub_class.new.test_top_level_group }.to \
+        output(/warning: top_level_group\? is deprecated/).to_stderr
+    end
+  end
+end


### PR DESCRIPTION
In this PR, we add a deprecation message for `top_level_group?`, which has no callers in current `Rubocop/RSpec`. 

`top_level_group?` was confirmed unused by @bquorning here:
* https://github.com/rubocop/rubocop-rspec/pull/1957#issuecomment-2370935206
* code change: https://github.com/rubocop/rubocop-rspec/pull/977/files#diff-538fd5bdf99dca6200224146c399b06a85bc9297598c1c4e71e0c9eaead8770bL15

We test this method using some stubbing in a Cop class that includes the mixin. 

The specs can be removed along with the method in the next Major version update. 

Split from:
* https://github.com/rubocop/rubocop-rspec/pull/1970

This PR serves the goal of completing line coverage for this repo ~and unblocks~ helps unblock:
* https://github.com/rubocop/rubocop-rspec/pull/1971


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
