### PR TITLE
Fix typo in example_without_description_spec.rb

### DIFF
--- a/spec/rubocop/cop/rspec/example_without_description_spec.rb
+++ b/spec/rubocop/cop/rspec/example_without_description_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWithoutDescription do
       RUBY
     end
 
-    it 'ignores `specify` missing decripton in multi-line examples' do
+    it 'ignores `specify` missing description in multi-line examples' do
       expect_no_offenses(<<~RUBY)
         specify do
           expect(subject).to be_good


### PR DESCRIPTION
Only fix typo.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
