### PR TITLE
Remove unnecessary early return in `RSpec/ContextWording`cop

### DIFF
--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -67,7 +67,7 @@ module RuboCop
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           context_wording(node) do |context|
-            if bad_pattern?(context)
+            unless matches_allowed_pattern?(description(context))
               message = format(MSG, patterns: expect_patterns)
               add_offense(context, message: message)
             end
@@ -82,12 +82,6 @@ module RuboCop
 
         def prefix_regexes
           @prefix_regexes ||= prefixes.map { |pre| /^#{Regexp.escape(pre)}\b/ }
-        end
-
-        def bad_pattern?(node)
-          return false if allowed_patterns.empty?
-
-          !matches_allowed_pattern?(description(node))
         end
 
         def description(context)


### PR DESCRIPTION
Checks if `allowed_patterns` is empty, but looking at the implementation of `matches_allowed_pattern?`, it refers to it as `allowed_patterns.any?`, so `return false if allowed_patterns .empty?` is a completely unnecessary early return.

https://github.com/rubocop/rubocop/blob/e7ccb0200d013d1c4b75b3face0dea0538620769/lib/rubocop/cop/mixin/allowed_pattern.rb#L29-L31

```
def matches_allowed_pattern?(line)
  allowed_patterns.any? { |pattern| Regexp.new(pattern).match?(line) }
end
```

also resolve:  https://github.com/rubocop/rubocop-rspec/pull/1972

![image](https://github.com/user-attachments/assets/75ed96b7-23ed-4105-825b-991054420db0)
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
