### PR TITLE
Change `RSpec/ContextWording` cop to always report an offense when both `Prefixes` and `AllowedPatterns` are empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Change `RSpec/ContextWording` cop to always report an offense when both `Prefixes` and `AllowedPatterns` are empty. ([@ydah])
+
 ## 3.1.0 (2024-10-01)
 
 - Add `RSpec/StringAsInstanceDoubleConstant` to check for and correct strings used as instance_doubles. ([@corsonknowles])

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -720,6 +720,9 @@ the configuration to meet project needs. Other acceptable prefixes may
 include `if`, `unless`, `for`, `before`, `after`, or `during`.
 They may consist of multiple words if desired.
 
+If both `Prefixes` and `AllowedPatterns` are empty, this cop will always
+report an offense. So you need to set at least one of them.
+
 This cop can be customized allowed context description pattern
 with `AllowedPatterns`. By default, there are no checking by pattern.
 

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -220,9 +220,10 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       { 'Prefixes' => [], 'AllowedPatterns' => [] }
     end
 
-    it 'skips any description' do
-      expect_no_offenses(<<~RUBY)
-        context 'arbitrary text' do
+    it 'always registers an offense' do
+      expect_offense(<<~RUBY)
+        context 'this is an incorrect context' do
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Current settings will always report an offense. Please add allowed words to `Prefixes` or `AllowedPatterns`.
         end
       RUBY
     end


### PR DESCRIPTION
see: https://github.com/rubocop/rubocop-rspec/pull/1972#discussion_r1808522184

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
