### PR TITLE
Fix an error for `RSpec/ChangeByZero` when `change (...) .by (0)` and `change (...)`, concatenated with `and` and `or`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Change `RSpec/ContextWording` cop to always report an offense when both `Prefixes` and `AllowedPatterns` are empty. ([@ydah])
+- Fix an error for `RSpec/ChangeByZero` when `change (...) .by (0)` and `change (...)`, concatenated with `and` and `or`. ([@ydah])
 
 ## 3.1.0 (2024-10-01)
 

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -118,7 +118,11 @@ module RuboCop
         # rubocop:enable Metrics/MethodLength
 
         def compound_expectations?(node)
-          %i[and or & |].include?(node.parent.method_name)
+          if node.parent.send_type?
+            %i[and or & |].include?(node.parent.method_name)
+          else
+            node.parent.and_type? || node.parent.or_type?
+          end
         end
 
         def message(change_node)

--- a/spec/rubocop/cop/rspec/change_by_zero_spec.rb
+++ b/spec/rubocop/cop/rspec/change_by_zero_spec.rb
@@ -68,6 +68,10 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
           expect { foo }.to change { Foo.bar }.by(0).and change { Foo.baz }.by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
                                                          ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change(Foo, :bar).by(0).and change(Foo, :baz)
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar }.and change { Foo.baz }.by(0)
+                                                   ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
         end
       RUBY
 
@@ -84,6 +88,10 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
           expect { foo }.to change { Foo.bar }.by(0) & change { Foo.baz }.by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change(Foo, :bar).by(0) & change(Foo, :baz)
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar } & change { Foo.baz }.by(0)
+                                                 ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
         end
       RUBY
 
@@ -100,6 +108,10 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
           expect { foo }.to change { Foo.bar }.by(0).or change { Foo.baz }.by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change(Foo, :bar).by(0).or change(Foo, :baz)
+                            ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar }.or change { Foo.baz }.by(0)
+                                                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
         end
       RUBY
 
@@ -116,6 +128,10 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
           expect { foo }.to change { Foo.bar }.by(0) | change { Foo.baz }.by(0)
                             ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change(Foo, :bar) | change(Foo, :baz).by(0)
+                                                ^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
+          expect { foo }.to change { Foo.bar }.by(0) | change { Foo.baz }
+                            ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer negated matchers with compound expectations over `change.by(0)`.
         end
       RUBY
 
@@ -244,6 +260,14 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
                 ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
             .and change { Foo.baz }.by(0)
                  ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+          expect { foo }
+            .to change(Foo, :bar)
+            .and change(Foo, :baz).by(0)
+                 ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
+          expect { foo }
+            .to change { Foo.bar }
+            .and change { Foo.baz }.by(0)
+                 ^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `not_change` with compound expectations over `change.by(0)`.
         end
       RUBY
 
@@ -254,6 +278,12 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
             .and not_change(Foo, :baz)
           expect { foo }
             .to not_change { Foo.bar }
+            .and not_change { Foo.baz }
+          expect { foo }
+            .to change(Foo, :bar)
+            .and not_change(Foo, :baz)
+          expect { foo }
+            .to change { Foo.bar }
             .and not_change { Foo.baz }
         end
       RUBY


### PR DESCRIPTION
fix: https://github.com/rubocop/rubocop-rspec/issues/1983

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
