### PR TITLE
Revert an change that would conceal unintentional RSpec syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ## Master (Unreleased)
 
 - Change `RSpec/ContextWording` cop to always report an offense when both `Prefixes` and `AllowedPatterns` are empty. ([@ydah])
-- Fix an error for `RSpec/ChangeByZero` when `change (...) .by (0)` and `change (...)`, concatenated with `and` and `or`. ([@ydah])
-- Revert an change that would conceal unintentional RSpec syntax. ([@pirj])
+- Add support for `and` and `or` compound matchers to `RSpec/ChangeByZero` cop. ([@ydah])
 
 ## 3.1.0 (2024-10-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Change `RSpec/ContextWording` cop to always report an offense when both `Prefixes` and `AllowedPatterns` are empty. ([@ydah])
 - Fix an error for `RSpec/ChangeByZero` when `change (...) .by (0)` and `change (...)`, concatenated with `and` and `or`. ([@ydah])
+- Revert an change that would conceal unintentional RSpec syntax. ([@pirj])
 
 ## 3.1.0 (2024-10-01)
 

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -118,11 +118,8 @@ module RuboCop
         # rubocop:enable Metrics/MethodLength
 
         def compound_expectations?(node)
-          if node.parent.send_type?
+          node.parent.send_type? &&
             %i[and or & |].include?(node.parent.method_name)
-          else
-            node.parent.and_type? || node.parent.or_type?
-          end
         end
 
         def message(change_node)


### PR DESCRIPTION
Specifically:

    expect { ... }.to change { ... }.by(...) and change { ... }.by(...)

Here the usage of `and` is incorrect, as RSpec does not (and can't reasonably) support it.
Compound should use the `and` method, not the operator, or the `&`. Same for `.or` and `|`.

Related: #1984 #1983

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
