### PR TITLE
Cover and then remove `ancestor.send_type?` branch in `UnspecifiedException`

### DIFF
--- a/lib/rubocop/cop/rspec/unspecified_exception.rb
+++ b/lib/rubocop/cop/rspec/unspecified_exception.rb
@@ -64,7 +64,6 @@ module RuboCop
         def find_expect_to(node)
           node.each_ancestor.find do |ancestor|
             break if ancestor.block_type?
-            next unless ancestor.send_type?
 
             expect_to?(ancestor)
           end

--- a/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
+++ b/spec/rubocop/cop/rspec/unspecified_exception_spec.rb
@@ -254,5 +254,12 @@ RSpec.describe RuboCop::Cop::RSpec::UnspecifiedException do
         }.to raise_exception(StandardError)
       RUBY
     end
+
+    it 'detects even when a non-send node is an ancestor' do
+      expect_offense(<<~RUBY)
+        expect { raise 'error' }.to (branch_conditional ? raise_error : handle_exception)
+                                                          ^^^^^^^^^^^ Specify the exception being captured
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Wraps some non-send type branches around `raise_error` specs

From:
<img width="242" alt="Screenshot 2024-10-30 at 5 44 37 AM" src="https://github.com/user-attachments/assets/2229ef0e-6014-456e-842b-868be36bbfc7">

To:
<img width="244" alt="Screenshot 2024-10-30 at 5 39 32 AM" src="https://github.com/user-attachments/assets/91e6e67d-8435-42e8-bef9-d83c656e203d">

Then we remove this line, because all specs pass without it due to the node pattern covering both branches.


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
