### PR TITLE
Test derivative `case style` for `BeNil` cop

### DIFF
--- a/spec/rubocop/cop/rspec/be_nil_spec.rb
+++ b/spec/rubocop/cop/rspec/be_nil_spec.rb
@@ -64,4 +64,16 @@ RSpec.describe RuboCop::Cop::RSpec::BeNil do
       RUBY
     end
   end
+
+  context 'with EnforcedStyle set but stubbed to `something_arbitrary` internally' do
+    let(:enforced_style) { 'be' }
+
+    it 'does not register any offenses' do
+      allow_any_instance_of(described_class).to receive(:style).and_return('something_arbitrary')
+      expect_no_offenses(<<~RUBY)
+        expect(foo).to be_nil
+        expect(foo).to be(nil)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
I was worried all the case statements with missing branch coverage would be like this, but some other ones at least are actually reachable code.

Solves for:

<img width="266" alt="Screenshot 2024-10-30 at 2 45 27 PM" src="https://github.com/user-attachments/assets/883a9e17-3a31-4532-b253-eba29335673d">

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
