### PR TITLE
Document behavior of trailing empty lines for `ExcessiveDocstringSpacing`

### DIFF
--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -755,4 +755,21 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
       end
     RUBY
   end
+
+  it 'flags \-separated multiline interpolated strings with ' \
+     'leading whitespace and corrects trailing empty lines' do
+    expect_offense(<<~'RUBY')
+      describe "  ##{object} " \
+                ^^^^^^^^^^^^^^^^ Excessive whitespace.
+          "(is cool)" \
+            ' ' \
+            " " do
+      end
+    RUBY
+
+    expect_correction(<<~'RUBY')
+      describe "##{object} (is cool)" do
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
While beginning setup to look at branch coverage for `ExcessiveDocstringSpacing`, I found this behavior and thought we might document it. 

In this example, it autocorrects trailing empty lines without flagging them.


______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
