### PR TITLE
Add an else condition to correct `StubbedMock` behavior

### DIFF
--- a/lib/rubocop/cop/rspec/stubbed_mock.rb
+++ b/lib/rubocop/cop/rspec/stubbed_mock.rb
@@ -14,8 +14,9 @@ module RuboCop
       #   expect(foo).to receive(:bar).with(42)
       #
       class StubbedMock < Base
-        MSG = 'Prefer `%<replacement>s` over `%<method_name>s` when ' \
+        MSG = 'Prefer %<replacement>s over `%<method_name>s` when ' \
               'configuring a response.'
+        RESTRICT_ON_SEND = %i[to].freeze
 
         # @!method message_expectation?(node)
         #   Match message expectation matcher
@@ -133,8 +134,6 @@ module RuboCop
           }
         PATTERN
 
-        RESTRICT_ON_SEND = %i[to].freeze
-
         def on_send(node)
           expectation(node) do |expectation, method_name, matcher|
             on_expectation(expectation, method_name, matcher)
@@ -155,19 +154,23 @@ module RuboCop
         end
 
         def msg(method_name)
-          format(MSG,
-                 method_name: method_name,
-                 replacement: replacement(method_name))
+          format(
+            MSG,
+            method_name: method_name,
+            replacement: replacement(method_name)
+          )
         end
 
         def replacement(method_name)
           case method_name
           when :expect
-            :allow
+            '`allow`'
           when :is_expected
-            'allow(subject)'
+            '`allow(subject)`'
           when :expect_any_instance_of
-            :allow_any_instance_of
+            '`allow_any_instance_of`'
+          else
+            'an allow statement'
           end
         end
       end

--- a/spec/rubocop/cop/rspec/stubbed_mock_spec.rb
+++ b/spec/rubocop/cop/rspec/stubbed_mock_spec.rb
@@ -126,12 +126,19 @@ RSpec.describe RuboCop::Cop::RSpec::StubbedMock do
     RUBY
   end
 
-  it 'tolerates passed arguments without parentheses' do
+  it 'flags even when passed arguments without parentheses' do
     expect_offense(<<~RUBY)
       expect(Foo)
       ^^^^^^^^^^^ Prefer `allow` over `expect` when configuring a response.
         .to receive(:new)
         .with(bar).and_return baz
+    RUBY
+  end
+
+  it 'flags `are_expected`' do
+    expect_offense(<<~RUBY)
+      are_expected.to receive(:bar).and_return(:baz)
+      ^^^^^^^^^^^^ Prefer an allow statement over `are_expected` when configuring a response.
     RUBY
   end
 end


### PR DESCRIPTION
Fix edge case for `StubbedMock` where it could return a blank suggestion for unhandled Expectation types.

Completes branch coverage for this file.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
