### PR TITLE
Fix formatting in some markdown files

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Suggest new RuboCop RSpec features or improvements to existing features.
 
 ## Is your feature request related to a problem? Please describe.
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when \[...\]
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 ## Describe the solution you'd like
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -742,7 +742,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 ## 1.13.0 (2017-03-07)
 
 - Add repeated 'it' detection to `RSpec/ExampleWording` cop. ([@dgollahon])
-- Add \[observed_nesting/max_nesting\] info to `RSpec/NestedGroups` messages. ([@dgollahon])
+- Add [observed_nesting/max_nesting] info to `RSpec/NestedGroups` messages. ([@dgollahon])
 - Add `RSpec/ItBehavesLike` cop. ([@dgollahon])
 - Add `RSpec/SharedContext` cop. ([@Darhazer])
 - `RSpec/MultipleExpectations`: Count aggregate_failures block as single expectation. ([@Darhazer])


### PR DESCRIPTION
Follow up: https://github.com/rubocop/rubocop-rspec/pull/1998#issuecomment-2488619760

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
