### PR TITLE
Fix EmptyMetadata for splat kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Deprecate `top_level_group?` method from `TopLevelGroup` mixin as all of its callers were intentionally removed from `Rubocop/RSpec`. ([@corsonknowles])
+- Fix false positive for RSpec/EmptyMetadata for splat kwargs. ([@pirj])
 
 ## 3.2.0 (2024-10-26)
 

--- a/lib/rubocop/cop/rspec/empty_metadata.rb
+++ b/lib/rubocop/cop/rspec/empty_metadata.rb
@@ -21,6 +21,7 @@ module RuboCop
 
         def on_metadata(_symbols, hash)
           return unless hash&.pairs&.empty?
+          return if hash.children.any?(&:kwsplat_type?)
 
           add_offense(hash) do |corrector|
             remove_empty_metadata(corrector, hash)

--- a/spec/rubocop/cop/rspec/empty_metadata_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_metadata_spec.rb
@@ -33,4 +33,11 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyMetadata do
       RUBY
     end
   end
+
+  it 'registers no offense for splat kwargs metadata' do
+    expect_no_offenses(<<~RUBY)
+      describe 'Something', **{ a: b } do
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #2004, when metadata is detected as empty when it's actually a kwargs splat.

cc @tylerhunt
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
