### PR TITLE
Fix a false negative for `RSpec/PendingWithoutReason` cop when pending/skip without reason inside a numblock in a deeply nested example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false negative for `RSpec/PendingWithoutReason` cop when pending/skip without reason inside a numblock in a deeply nested example. ([@ydah])
+
 ## 3.3.0 (2024-12-12)
 
 - Deprecate `top_level_group?` method from `TopLevelGroup` mixin as all of its callers were intentionally removed from `Rubocop/RSpec`. ([@corsonknowles])

--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -108,6 +108,7 @@ module RuboCop
             on_skipped_by_example_group_method(node)
           elsif example?(parent)
             on_skipped_by_in_example_method(node)
+            on_skipped_by_example_group_method(node)
           end
         end
 

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -46,7 +46,8 @@ module RuboCop
       PATTERN
 
       # @!method example?(node)
-      def_node_matcher :example?, '(block (send nil? #Examples.all ...) ...)'
+      def_node_matcher :example?,
+                       '({block numblock} (send nil? #Examples.all ...) ...)'
 
       # @!method hook?(node)
       def_node_matcher :hook?, <<~PATTERN

--- a/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
@@ -301,21 +301,43 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason, :ruby27 do
       RUBY
     end
 
-    context 'with a numblock' do
+    context 'with a numblock at the top level' do
       it 'registers offense' do
         expect_offense(<<~RUBY)
           RSpec.describe Foo do
+            _1
             pending
             ^^^^^^^ Give the reason for pending.
             skip
             ^^^^ Give the reason for skip.
             _1
+          end
+        RUBY
+      end
+    end
+
+    context 'with a numblock in a nested context' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
             context 'when something' do
               _1
               pending
               ^^^^^^^ Give the reason for pending.
               skip
               ^^^^ Give the reason for skip.
+              _1
+            end
+          end
+        RUBY
+      end
+    end
+
+    context 'with a numblock in a deeply nested example' do
+      it 'registers offense' do
+        expect_offense(<<~RUBY)
+          RSpec.describe Foo do
+            context 'when something' do
               it 'does something' do
                 _1
                 skip


### PR DESCRIPTION
The following will cause a violation to be generated for skip/pending without reason inside examples.

```ruby
RSpec.describe Foo do
  context 'when something' do
    it 'does something' do
      _1
      skip
      ^^^^ Give the reason for skip.
      pending
      ^^^^^^^ Give the reason for pending.
      _1
    end
  end
end
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
