### PR TITLE
Remove unused method matcher for pending steps without reason

### DIFF
--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -94,11 +94,6 @@ module RuboCop
           (send #rspec? ${#ExampleGroups.skipped} ...)
         PATTERN
 
-        # @!method pending_step_without_reason?(node)
-        def_node_matcher :pending_step_without_reason?, <<~PATTERN
-          (send nil? {:skip :pending})
-        PATTERN
-
         def on_send(node)
           on_pending_by_metadata(node)
           return unless (parent = parent_node(node))


### PR DESCRIPTION
Before:

```ruby
❯ find . -type f | xargs grep "pending_step_without_reason"
./lib/rubocop/cop/rspec/pending_without_reason.rb:        # @!method pending_step_without_reason?(node)
./lib/rubocop/cop/rspec/pending_without_reason.rb:        def_node_matcher :pending_step_without_reason?, <<~PATTERN
```

After:

```ruby
❯ find . -type f | xargs grep "pending_step_without_reason"

```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
