### PR TITLE
Update Ruby version in GitHub Actions workflow to 3.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - run: bundle exec rake confirm_config documentation_syntax_check confirm_documentation
 
@@ -32,6 +32,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
           - ruby-head
           - jruby-9.4
         task:
@@ -53,7 +54,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - run: bundle exec rake spec
 
@@ -73,7 +74,7 @@ jobs:
           cat Gemfile.local
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - run: bundle exec rubocop -V
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
@@ -94,7 +95,7 @@ jobs:
           cat Gemfile.local
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - run: bundle exec rubocop -V
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
@@ -116,7 +117,7 @@ jobs:
           EOF
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - run: NO_COVERAGE=true bundle exec rake spec
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -870,7 +870,7 @@ end
 | Array
 
 | IgnoredMetadata
-| `{"type"=>["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox", "aruba", "task"]}`
+| `{"type" => ["channel", "controller", "helper", "job", "mailer", "model", "request", "routing", "view", "feature", "system", "mailbox", "aruba", "task"]}`
 | 
 |===
 
@@ -1994,7 +1994,7 @@ end
 | Name | Default value | Configurable values
 
 | CustomTransform
-| `{"be"=>"is", "BE"=>"IS", "have"=>"has", "HAVE"=>"HAS"}`
+| `{"be" => "is", "BE" => "IS", "have" => "has", "HAVE" => "HAS"}`
 | 
 
 | IgnoredWords
@@ -5838,7 +5838,7 @@ whatever_spec.rb         # describe MyClass, type: :routing do; end
 | Array
 
 | CustomTransform
-| `{"RuboCop"=>"rubocop", "RSpec"=>"rspec"}`
+| `{"RuboCop" => "rubocop", "RSpec" => "rspec"}`
 | 
 
 | IgnoreMethods
@@ -5846,7 +5846,7 @@ whatever_spec.rb         # describe MyClass, type: :routing do; end
 | Boolean
 
 | IgnoreMetadata
-| `{"type"=>"routing"}`
+| `{"type" => "routing"}`
 | 
 |===
 


### PR DESCRIPTION
Ruby 3.4 has been released🎉
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-0-released/

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
