### PR TITLE
Remove an example which is a syntax error in Ruby's parser

### DIFF
--- a/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_without_reason_spec.rb
@@ -300,35 +300,6 @@ RSpec.describe RuboCop::Cop::RSpec::PendingWithoutReason, :ruby27 do
         end
       RUBY
     end
-
-    context 'with a numblock' do
-      it 'registers offense' do
-        expect_offense(<<~RUBY)
-          RSpec.describe Foo do
-            pending
-            ^^^^^^^ Give the reason for pending.
-            skip
-            ^^^^ Give the reason for skip.
-            _1
-            context 'when something' do
-              _1
-              pending
-              ^^^^^^^ Give the reason for pending.
-              skip
-              ^^^^ Give the reason for skip.
-              it 'does something' do
-                _1
-                skip
-                ^^^^ Give the reason for skip.
-                pending
-                ^^^^^^^ Give the reason for pending.
-                _1
-              end
-            end
-          end
-        RUBY
-      end
-    end
   end
 
   context 'when pending/skip inside conditional' do


### PR DESCRIPTION
This code generates a syntax error as follows:
```ruby
❯ ruby -e '[1].each { put _1; [1].each { put _1 } }'
-e: -e:1: syntax error found (SyntaxError)
> 1 | ... _1 } }
    |     ^~ numbered parameter is already used in outer block
```

When numbered parameters are used in nested blocks, it is not possible to use numbered parameters in multiple different hierarchies.

While it was considered to split these up, we discussed below. 
https://github.com/rubocop/rubocop-rspec/pull/2014#discussion_r1897371078

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
