### PR TITLE
Fix false positive for `RSpec/EmptyExampleGroup` cop with iterator and simple conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `RSpec/SortMetadata` cop to limit sorting to trailing metadata arguments. ([@cbliard])
 - Replace `RSpec/StringAsInstanceDoubleConstant` with `RSpec/VerifiedDoubleReference` configured to only support constant class references. ([@corsonknowles])
+- Fix `Rspec/EmptyExampleGroup` cop false positive when a simple conditional is used inside an iterator. ([@lovro-bikic])
 
 ## 3.3.0 (2024-12-12)
 
@@ -992,6 +993,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@leoarnold]: https://github.com/leoarnold
 [@liberatys]: https://github.com/Liberatys
 [@lokhi]: https://github.com/lokhi
+[@lovro-bikic]: https://github.com/lovro-bikic
 [@luke-hill]: https://github.com/luke-hill
 [@m-yamashita01]: https://github.com/M-Yamashita01
 [@marocchino]: https://github.com/marocchino

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -130,6 +130,7 @@ module RuboCop
         def_node_matcher :examples?, <<~PATTERN
           {
             #examples_directly_or_in_block?
+            #examples_in_branches?
             (begin <#examples_directly_or_in_block? ...>)
             (begin <#examples_in_branches? ...>)
           }
@@ -170,6 +171,7 @@ module RuboCop
         end
 
         def examples_in_branches?(condition_node)
+          return false unless condition_node
           return false if !condition_node.if_type? && !condition_node.case_type?
 
           condition_node.branches.any? { |branch| examples?(branch) }

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -225,14 +225,29 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
   end
 
   it 'ignores example group with examples defined in `if` branch ' \
-     'inside iterator' do
+     'inside iterator with begin block' do
     expect_no_offenses(<<~RUBY)
       describe 'RuboCop monthly' do
         [1, 2, 3].each do |page|
           version = 2.3
 
           if RUBY_VERSION >= version
-            it { expect(use_safe_navigation_operator?(code)).to be(true) }
+            it { expect(newspaper(page)).to have_ads }
+          else
+            warn 'Ruby < 2.3 is barely supported, please use a newer version for development.'
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores example group with examples defined in `if` branch ' \
+     'inside iterator without begin block' do
+    expect_no_offenses(<<~RUBY)
+      describe 'RuboCop monthly' do
+        [1, 2, 3].each do |page|
+          if RUBY_VERSION >= 2.3
+            it { expect(newspaper(page)).to have_ads }
           else
             warn 'Ruby < 2.3 is barely supported, please use a newer version for development.'
           end


### PR DESCRIPTION
Fixes a false positive for `RSpec/EmptyExampleGroup` with iterator and simple conditional (one that doesn't have multiple statements, so it's not wrapped in a `begin` node).

Previously, code such as:
```ruby
context 'foo' do
  [1, 2, 3].each do |x|
    if x.odd?
      it { expect(x).to be_odd }
    else
      it { expect(x).to be_even }
    end
  end
end
```
would register as an offense. With this patch, the offense isn't registered anymore.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
