### PR TITLE
Use node groups in node patterns to replace unions of types

### DIFF
--- a/lib/rubocop/cop/rspec/be_eq.rb
+++ b/lib/rubocop/cop/rspec/be_eq.rb
@@ -31,7 +31,7 @@ module RuboCop
 
         # @!method eq_type_with_identity?(node)
         def_node_matcher :eq_type_with_identity?, <<~PATTERN
-          (send nil? :eq {true false nil})
+          (send nil? :eq {boolean nil})
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/be_eql.rb
+++ b/lib/rubocop/cop/rspec/be_eql.rb
@@ -45,7 +45,7 @@ module RuboCop
 
         # @!method eql_type_with_identity(node)
         def_node_matcher :eql_type_with_identity, <<~PATTERN
-          (send _ :to $(send nil? :eql {true false int float sym nil}))
+          (send _ :to $(send nil? :eql {boolean int float sym nil}))
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -43,7 +43,7 @@ module RuboCop
 
         # @!method be_bool?(node)
         def_node_matcher :be_bool?, <<~PATTERN
-          (send nil? {:be :eq :eql :equal} {true false})
+          (send nil? {:be :eq :eql :equal} boolean)
         PATTERN
 
         # @!method be_boolthy?(node)


### PR DESCRIPTION
`rubocop-ast` defines some node groups (https://github.com/rubocop/rubocop-ast/blob/85bfe84/lib/rubocop/ast/node.rb#L89-L116) that can be used in place of a union of node types.

rubocop-ast v1.38.0 is needed for `any_block`. I added it to the gemspec in this PR but if you'd prefer to handle it later, I can remove the `any_block` changes.