### PR TITLE
Mark `RSpec/LetSetup` as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Mark `RSpec/LetSetup` as unsafe. ([@r7kamura])
+
 ## 3.4.0 (2025-01-20)
 
 - Fix `RSpec/SortMetadata` cop to limit sorting to trailing metadata arguments. ([@cbliard])

--- a/config/default.yml
+++ b/config/default.yml
@@ -606,7 +606,9 @@ RSpec/LetBeforeExamples:
 RSpec/LetSetup:
   Description: Checks unreferenced `let!` calls being used for test setup.
   Enabled: true
+  Safe: false
   VersionAdded: '1.7'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetSetup
 
 RSpec/MatchArray:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3327,13 +3327,19 @@ end
 | Enabled by default | Safe | Supports autocorrection | Version Added | Version Changed
 
 | Enabled
-| Yes
+| No
 | No
 | 1.7
-| -
+| <<next>>
 |===
 
 Checks unreferenced `let!` calls being used for test setup.
+
+[#safety-rspecletsetup]
+=== Safety
+
+This cop is unsafe because it may result in a false positive
+if you intentionally write `let!` for an override.
 
 [#examples-rspecletsetup]
 === Examples

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -5,6 +5,10 @@ module RuboCop
     module RSpec
       # Checks unreferenced `let!` calls being used for test setup.
       #
+      # @safety
+      #   This cop is unsafe because it may result in a false positive
+      #   if you intentionally write `let!` for an override.
+      #
       # @example
       #   # bad
       #   let!(:my_widget) { create(:widget) }


### PR DESCRIPTION
For the reasons mentioned, I thought it might be better to consider this cop as unsafe.

For example, in cases like the following, `let!(:foo)` is used to override the original definition, and there is no code directly referencing `foo` within the surrounding AST. However, I believe this usage of `let!` is valid because it is difficult to substitute this with other methods, such as `before` or `let`.

```ruby
let!(:foo) { ... }

...

context 'when foo is something' do
  let!(:foo) { ... }

  it { is_expected.to be false }
end
```

What do you think?




