### PR TITLE
Revert "CI: Use arm64 runners"

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   codespell:
     name: CodeSpell
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: CodeSpell

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ concurrency:
 jobs:
   yamllint:
     name: Yamllint
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Yamllint
@@ -20,7 +20,7 @@ jobs:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   mdformat:
     name: Mdformat
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Mdformat

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   confirm_config_and_documentation:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     name: Confirm config and documentation
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
       - run: bundle exec rake confirm_config documentation_syntax_check confirm_documentation
 
   main:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:
@@ -48,7 +48,7 @@ jobs:
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
   coverage:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     name: "Test coverage"
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
       - run: bundle exec rake spec
 
   edge-rubocop:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         task:
@@ -80,7 +80,7 @@ jobs:
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
   oldest-rubocop:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         task:
@@ -101,7 +101,7 @@ jobs:
       - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
 
   rspec4:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     name: RSpec 4
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     name: Publish to RubyGems
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-latest
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
Reverts rubocop/rubocop-rspec#1955

The ARM runners are not really stable yet. See an example of CI failure here: https://github.com/rubocop/rubocop-rspec/actions/runs/13168117650/job/36752960471

<img width="554" alt="image" src="https://github.com/user-attachments/assets/f5e09e82-b856-41ce-86c4-e8fc347a3b06" />

The issue is also mentioned at https://github.com/orgs/community/discussions/148648#discussioncomment-11866202