### PR TITLE
Add branch coverage for `RSpec/ImplicitSubject`

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,7 +2,7 @@
 
 SimpleCov.start do
   enable_coverage :branch
-  minimum_coverage line: 100, branch: 97.94
+  minimum_coverage line: 100, branch: 98.44
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
 end

--- a/spec/rubocop/cop/rspec/implicit_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_subject_spec.rb
@@ -114,6 +114,20 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitSubject do
         end
       RUBY
     end
+
+    it 'does not flag is_expected in describe blocks (non-example contexts)' do
+      expect_no_offenses(<<~RUBY)
+        describe 'something' do
+          is_expected.to be_valid
+        end
+      RUBY
+    end
+
+    it 'does not flag an empty example' do
+      expect_no_offenses(<<~RUBY)
+        it('is valid') { }
+      RUBY
+    end
   end
 
   context 'with EnforcedStyle `disallow`' do


### PR DESCRIPTION
Add branch coverage for `RSpec/ImplicitSubject`

Note: This does not complete branch coverage for either of the 2 case statements in the same file. Both of those never fall through, so it seems to be logically unreachable code.

Focus:
<img width="375" alt="Screenshot 2025-02-08 at 5 19 37 PM" src="https://github.com/user-attachments/assets/50902d61-7f87-4a8a-8a97-779ae7dc03f5" />

Result:
<img width="336" alt="Screenshot 2025-02-08 at 5 14 31 PM" src="https://github.com/user-attachments/assets/b2df427e-4188-4b43-973a-fe635110509b" />

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
