### PR TITLE
Finish branch coverage for `RSpec/DescribedClass`

### DIFF
--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -338,6 +338,14 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
         RUBY
       end
     end
+
+    it 'ignores parenthesized namespaces - begin_types' do
+      expect_no_offenses(<<~RUBY)
+        describe MyClass do
+          subject { (MyNamespace)::MyClass }
+        end
+      RUBY
+    end
   end
 
   context 'when EnforcedStyle is :explicit' do


### PR DESCRIPTION
Finish branch coverage for `RSpec/DescribedClass`

Showing that the tested code evaluates:
```ruby
zenpayroll(dev)* class MyClass3
zenpayroll(dev)> end
=> nil
zenpayroll(dev)> ("MyClass" + "3").constantize
=> MyClass3

zenpayroll(dev)* class MyClass3; class MyClass; end;
zenpayroll(dev)> end
=> nil
zenpayroll(dev)> (("MyClass" + "3").constantize)::MyClass
=> MyClass3::MyClass
```

Although at this point the math is superfluous -- `(method_that_returns_a_class)::MyClass` will cover this branch while `method_that_returns_a_class::MyClass`  will not


Before:
<img width="499" alt="Screenshot 2025-02-08 at 10 25 14 PM" src="https://github.com/user-attachments/assets/25c1f242-5f33-4a60-8d66-f0df3ad85b0f" />
After:
<img width="484" alt="Screenshot 2025-02-08 at 10 25 31 PM" src="https://github.com/user-attachments/assets/8a83e35e-1cb5-4e5c-9701-a73c49e4a817" />

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
