### PR TITLE
Config formatter coverage

### DIFF
--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -16,9 +16,9 @@ module RuboCop
 
       def dump
         YAML.dump(unified_config)
-          .gsub(%r{^\w+/}, "\n\\0")
-          .gsub(/^(\s+)- /, '\1  - ')
-          .gsub('"~"', '~')
+          .gsub(%r{^\w+/}, "\n\\0")   # Add an extra newline before each cop.
+          .gsub(/^(\s+)- /, '\1  - ') # Add 2 spaces before each array element.
+          .gsub('"~"', '~')           # Don't quote tilde, YAML's null value.
       end
 
       private

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -6,8 +6,7 @@ module RuboCop
   module RSpec
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
-      EXTENSION_ROOT_DEPARTMENT = %r{^(RSpec/)}.freeze
-      AMENDMENTS = %(Metrics/BlockLength)
+      EXTENSION_ROOT_DEPARTMENT = %r{^RSpec/}.freeze
       COP_DOC_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/'
 
       def initialize(config, descriptions)
@@ -17,8 +16,7 @@ module RuboCop
 
       def dump
         YAML.dump(unified_config)
-          .gsub(EXTENSION_ROOT_DEPARTMENT, "\n\\1")
-          .gsub(*AMENDMENTS, "\n\\0")
+          .gsub(%r{^\w+/}, "\n\\0")
           .gsub(/^(\s+)- /, '\1  - ')
           .gsub('"~"', '~')
       end
@@ -27,8 +25,6 @@ module RuboCop
 
       def unified_config
         cops.each_with_object(config.dup) do |cop, unified|
-          next if AMENDMENTS.include?(cop)
-
           replace_nil(unified[cop])
           unified[cop].merge!(descriptions.fetch(cop))
           unified[cop]['Reference'] = reference(cop)

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -7,7 +7,6 @@ module RuboCop
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
       EXTENSION_ROOT_DEPARTMENT = %r{^(RSpec/)}.freeze
-      SUBDEPARTMENTS = [].freeze
       AMENDMENTS = %(Metrics/BlockLength)
       COP_DOC_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/'
 
@@ -28,7 +27,7 @@ module RuboCop
 
       def unified_config
         cops.each_with_object(config.dup) do |cop, unified|
-          next if SUBDEPARTMENTS.include?(cop) || AMENDMENTS.include?(cop)
+          next if AMENDMENTS.include?(cop)
 
           replace_nil(unified[cop])
           unified[cop].merge!(descriptions.fetch(cop))

--- a/spec/rubocop/rspec/config_formatter_spec.rb
+++ b/spec/rubocop/rspec/config_formatter_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
       'AllCops' => {
         'Setting' => 'forty two'
       },
+      'Metrics/BlockLength' => {
+        'Exclude' => [
+          '**/*_spec.rb',
+          '**/spec/**/*'
+        ]
+      },
       'RSpec/Foo' => {
         'Config' => 2,
         'Enabled' => true
@@ -18,6 +24,7 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
       },
       'RSpec/Baz' => {
         'Enabled' => true,
+        'NegatedMatcher' => '~',
         'StyleGuide' => '#buzz'
       }
     }
@@ -45,6 +52,11 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
       AllCops:
         Setting: forty two
 
+      Metrics/BlockLength:
+        Exclude:
+          - "**/*_spec.rb"
+          - "**/spec/**/*"
+
       RSpec/Foo:
         Config: 2
         Enabled: true
@@ -59,6 +71,7 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
 
       RSpec/Baz:
         Enabled: true
+        NegatedMatcher: ~
         StyleGuide: "#buzz"
         Description: Woof
         Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Baz


### PR DESCRIPTION
`SUBDEPARTMENTS` was last used in ConfigFormatter before we released v3.0.0, before `RSpec/Capybara` was extracted. It’s being removed in this PR.

Also, initially wanting to improve spec branch coverage for ConfigFormatter, ~I found that `AMENDMENTS` was defined as a String, not an Array. And splatting the array into `#gsub` doesn't work if there is more than one element - we need to use `Regexp.union` instead.~ Actually I ended up removing `AMENDMENDS` altogether.

To avoid conflicts with other PRs improving code coverage, the .simplecov file is not updated here.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [ ] ~Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.~
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
