### PR TITLE
Add eql/equal support to RSpec/PredicateMatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Don't let `RSpec/PredicateMatcher` replace `respond_to?` with two arguments with the RSpec `respond_to` matcher. ([@bquorning])
+- Fix `RSpec/PredicateMatcher` support for `eql` and `equal` matchers. ([@bquorning])
 
 ## 3.4.0 (2025-01-20)
 

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -112,7 +112,7 @@ module RuboCop
 
         def true?(to_symbol, matcher)
           result = case matcher.method_name
-                   when :be, :eq
+                   when :be, :eq, :eql, :equal
                      matcher.first_argument.true_type?
                    when :be_truthy, :a_truthy_value
                      true

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -211,6 +211,10 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `be_empty` matcher over `empty?`.
           expect(foo.empty?).to eq(true), 'fail'
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `be_empty` matcher over `empty?`.
+          expect(foo.empty?).to eql(true)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `be_empty` matcher over `empty?`.
+          expect(foo.empty?).to equal(true), 'whoops'
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `be_empty` matcher over `empty?`.
           expect(foo.empty?).not_to be(true)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `be_empty` matcher over `empty?`.
           expect(foo.empty?).to be(true)
@@ -226,6 +230,8 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
         expect_correction(<<~RUBY)
           expect(foo).to be_empty
           expect(foo).to be_empty, 'fail'
+          expect(foo).to be_empty
+          expect(foo).to be_empty, 'whoops'
           expect(foo).not_to be_empty
           expect(foo).to be_empty
           expect(foo).not_to be_empty


### PR DESCRIPTION
The `be_bool?` node matcher was already finding nodes using `eql` and `equal`, but then didn't properly handle them.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
