### PR TITLE
Tell SimpleCov to ignore unreachable code

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,7 +2,7 @@
 
 SimpleCov.start do
   enable_coverage :branch
-  minimum_coverage line: 100, branch: 98.44
+  minimum_coverage line: 100, branch: 100
   add_filter '/spec/'
   add_filter '/vendor/bundle/'
 end

--- a/lib/rubocop/cop/rspec/be_nil.rb
+++ b/lib/rubocop/cop/rspec/be_nil.rb
@@ -48,6 +48,10 @@ module RuboCop
             check_be_style(node)
           when :be_nil
             check_be_nil_style(node)
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
 

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -128,7 +128,7 @@ module RuboCop
             node.node_parts.map { |child_node| text(child_node) }.join
           when :str
             node.value
-          when :begin
+          else
             node.source
           end
         end

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -100,7 +100,7 @@ module RuboCop
             node.node_parts.map { |child_node| text(child_node) }.join
           when :str, :sym
             node.value
-          when :begin
+          else
             node.source
           end
         end

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -97,6 +97,7 @@ module RuboCop
 
         private
 
+        # rubocop:disable Metrics/MethodLength
         def autocorrect(corrector, node)
           case node.method_name
           when :expect
@@ -107,8 +108,13 @@ module RuboCop
             corrector.replace(node.location.selector, 'expect(subject).to')
           when :should_not
             corrector.replace(node.location.selector, 'expect(subject).not_to')
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
+        # rubocop:enable Metrics/MethodLength
 
         def message(_node)
           case style
@@ -119,6 +125,7 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Metrics/MethodLength
         def invalid?(node)
           case style
           when :require_implicit
@@ -129,8 +136,13 @@ module RuboCop
             implicit_subject_in_non_its_and_non_single_line?(node)
           when :single_statement_only
             implicit_subject_in_non_its_and_non_single_statement?(node)
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
+        # rubocop:enable Metrics/MethodLength
 
         def implicit_subject_in_non_its?(node)
           implicit_subject?(node) && !its?(node)

--- a/lib/rubocop/cop/rspec/message_spies.rb
+++ b/lib/rubocop/cop/rspec/message_spies.rb
@@ -80,6 +80,10 @@ module RuboCop
             MSG_RECEIVE
           when :have_received
             format(MSG_HAVE_RECEIVED, source: receiver.source)
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
       end

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -110,6 +110,7 @@ module RuboCop
           )
         end
 
+        # rubocop:disable Metrics/MethodLength
         def true?(to_symbol, matcher)
           result = case matcher.method_name
                    when :be, :eq, :eql, :equal
@@ -118,9 +119,14 @@ module RuboCop
                      true
                    when :be_falsey, :be_falsy, :a_falsey_value, :a_falsy_value
                      false
+                   else
+                     # :nocov:
+                     :noop
+                     # :nocov:
                    end
           to_symbol == :to ? result : !result
         end
+        # rubocop:enable Metrics/MethodLength
       end
 
       # A helper for `explicit` style
@@ -266,7 +272,7 @@ module RuboCop
             'be(false)'
           when [false, true]
             'be_truthy'
-          when [false, false]
+          else
             'be_falsey'
           end
         end
@@ -335,6 +341,10 @@ module RuboCop
             check_inflected(node)
           when :explicit
             check_explicit(node)
+          else
+            # :nocov:
+            :noop
+            # :nocov:
           end
         end
 


### PR DESCRIPTION
In some cases we know that a case statement is covering all possible branches, e.g. `case [foo?, bar?]` has four branches (if the predicate methods return booleans, of course), and `case style` has a know number of branches, depending on `SupportedStyles` in config/default.yml.

So, when to use `else ... raise ArgumentError`, and when to change the last `elsif` or `when` into an `else`? I don't know.

~To avoid conflicts with other PRs improving code coverage, the .simplecov file is not updated here.~

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).