### PR TITLE
Fix a bug in RSpec/PredicateMatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Don't let `RSpec/PredicateMatcher` replace `respond_to?` with two arguments with the RSpec `respond_to` matcher. ([@bquorning])
+
 ## 3.4.0 (2025-01-20)
 
 - Fix `RSpec/SortMetadata` cop to limit sorting to trailing metadata arguments. ([@cbliard])

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -15,6 +15,8 @@ module RuboCop
 
         def check_inflected(node)
           predicate_in_actual?(node) do |predicate, to, matcher|
+            next if cannot_replace_predicate?(predicate)
+
             msg = message_inflected(predicate)
             add_offense(node, message: msg) do |corrector|
               remove_predicate(corrector, predicate)
@@ -34,6 +36,10 @@ module RuboCop
             $#Runners.all
             $#boolean_matcher? ...)
         PATTERN
+
+        def cannot_replace_predicate?(send_node)
+          send_node.method?(:respond_to?) && send_node.arguments.length > 1
+        end
 
         # @!method be_bool?(node)
         def_node_matcher :be_bool?, <<~PATTERN

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -73,6 +73,12 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
         RUBY
       end
 
+      it 'accepts respond_to? with a second argument' do
+        expect_no_offenses(<<~RUBY)
+          expect(foo.respond_to?(:bar, true)).to be_truthy
+        RUBY
+      end
+
       it 'registers an offense for a predicate method with argument' do
         expect_offense(<<~RUBY)
           expect(foo.something?('foo')).to be_truthy


### PR DESCRIPTION
Don't let `RSpec/PredicateMatcher` replace `respond_to?` with two arguments with the RSpec `respond_to` matcher, since the 2nd argument has a different meaning in the two methods.

Fixes #2010

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
