### PR TITLE
Add mdformat configuration file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ We are running [mdformat](https://github.com/executablebooks/mdformat) for forma
 `mdformat` is written in [Python](https://www.python.org/) and you can run it with:
 
 ```console
-$ mdformat . --number
+$ mdformat .
 ```
 
 ## Creating new cops

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Suggest new RuboCop RSpec features or improvements to existing features.
 
 ## Is your feature request related to a problem? Please describe.
 
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. Ex. I'm always frustrated when \[...\]
 
 ## Describe the solution you'd like
 

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,4 @@
+# Use consecutive numbering in ordered lists. The default (always use 1.) does
+# indeed make smaller diffs, but the point of MarkDown files is they are also
+# readable by humans. Consecutive numbering is easier to read.
+number = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -753,7 +753,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 ## 1.13.0 (2017-03-07)
 
 - Add repeated 'it' detection to `RSpec/ExampleWording` cop. ([@dgollahon])
-- Add [observed_nesting/max_nesting] info to `RSpec/NestedGroups` messages. ([@dgollahon])
+- Add \[observed_nesting/max_nesting\] info to `RSpec/NestedGroups` messages. ([@dgollahon])
 - Add `RSpec/ItBehavesLike` cop. ([@dgollahon])
 - Add `RSpec/SharedContext` cop. ([@Darhazer])
 - `RSpec/MultipleExpectations`: Count aggregate_failures block as single expectation. ([@Darhazer])


### PR DESCRIPTION
It's easier to run mdformat when we have a config file: `mdformat .` instead of `mdformat . --number`.
