### PR TITLE
Update default_config_spec.rb

### DIFF
--- a/spec/project/default_config_spec.rb
+++ b/spec/project/default_config_spec.rb
@@ -106,6 +106,8 @@ RSpec.describe 'config/default.yml' do
   it 'is expected that all cops documented with `@safety` are `Safe: false` ' \
      'or `SafeAutoCorrect: false`' do
     unsafe_cop_names.each do |cop_name|
+      next if default_config[cop_name].nil?
+
       unsafe = default_config[cop_name]['Safe'] == false ||
         default_config[cop_name]['SafeAutoCorrect'] == false
       expect(unsafe).to(


### PR DESCRIPTION
@bquorning I started seeing a failure on the master branch. This solves the failure, but maybe there's something in the config to fix instead?


```bash

Failures:

  1) config/default.yml is expected that all cops documented with `@safety` are `Safe: false` or `SafeAutoCorrect: false`
     Failure/Error:
       unsafe = default_config[cop_name]['Safe'] == false ||
         default_config[cop_name]['SafeAutoCorrect'] == false
     
     NoMethodError:
       undefined method `[]' for nil
     # ./spec/project/default_config_spec.rb:109:in `block (3 levels) in <top (required)>'
     # ./spec/project/default_config_spec.rb:108:in `each'
     # ./spec/project/default_config_spec.rb:108:in `block (2 levels) in <top (required)>'

Finished in 4.73 seconds (files took 1.35 seconds to load)
2193 examples, 1 failure, 1 pending

```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
