### PR TITLE
Fewer inline disabled cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,9 @@ Metrics/BlockLength:
     - Rakefile
     - '**/*.rake'
 
+Metrics/MethodLength:
+  Max: 15
+
 Naming/FileName:
   Exclude:
     - lib/rubocop-rspec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,6 @@ AllCops:
     - 'tmp/**/*'
     - 'spec/smoke_tests/**/*.rb'
 
-
 # Enable when we require rubocop >= 1.71.1 or rubocop-ast >= 1.38.0
 InternalAffairs/NodePatternGroups:
   Enabled: false

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -101,7 +101,6 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/MethodLength
         def register_offense(node, change_node)
           if compound_expectations?(node)
             add_offense(node,
@@ -115,7 +114,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def compound_expectations?(node)
           node.parent.send_type? &&

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -67,7 +67,6 @@ module RuboCop
           } ...) ...)
         PATTERN
 
-        # rubocop:disable Metrics/MethodLength
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
           it_description(node) do |description_node, message|
             if message.match?(SHOULD_PREFIX)
@@ -82,7 +81,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         private
 

--- a/lib/rubocop/cop/rspec/expect_actual.rb
+++ b/lib/rubocop/cop/rspec/expect_actual.rb
@@ -65,7 +65,7 @@ module RuboCop
           )
         PATTERN
 
-        def on_send(node) # rubocop:disable Metrics/MethodLength
+        def on_send(node)
           expect_literal(node) do |actual, send_node, matcher, expected|
             next if SKIPPED_MATCHERS.include?(matcher)
 

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -69,13 +69,13 @@ module RuboCop
         def offending_expect(node)
           case implicit_expect(node)
           when :is_expected
-            is_expected_range(node.loc)
+            range_for_is_expected(node.loc)
           when :should, :should_not
             node.loc.selector
           end
         end
 
-        def is_expected_range(source_map) # rubocop:disable Naming/PredicateName
+        def range_for_is_expected(source_map)
           Parser::Source::Range.new(
             source_map.expression.source_buffer,
             source_map.expression.begin_pos,

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -46,7 +46,7 @@ module RuboCop
 
         ENFORCED_REPLACEMENTS = alternatives.merge(alternatives.invert).freeze
 
-        def on_send(node) # rubocop:disable Metrics/MethodLength
+        def on_send(node)
           return unless (source_range = offending_expect(node))
 
           expectation_source = source_range.source

--- a/lib/rubocop/cop/rspec/implicit_subject.rb
+++ b/lib/rubocop/cop/rspec/implicit_subject.rb
@@ -97,7 +97,6 @@ module RuboCop
 
         private
 
-        # rubocop:disable Metrics/MethodLength
         def autocorrect(corrector, node)
           case node.method_name
           when :expect
@@ -114,7 +113,6 @@ module RuboCop
             # :nocov:
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def message(_node)
           case style
@@ -125,7 +123,6 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Metrics/MethodLength
         def invalid?(node)
           case style
           when :require_implicit
@@ -142,7 +139,6 @@ module RuboCop
             # :nocov:
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def implicit_subject_in_non_its?(node)
           implicit_subject?(node) && !its?(node)

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -69,7 +69,6 @@ module RuboCop
                  matcher_name: to_predicate_matcher(predicate.method_name))
         end
 
-        # rubocop:disable Metrics/MethodLength
         def to_predicate_matcher(name)
           case name = name.to_s
           when 'is_a?'
@@ -86,7 +85,6 @@ module RuboCop
             "be_#{name[0..-2]}"
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def remove_predicate(corrector, predicate)
           range = predicate.loc.dot.with(
@@ -110,7 +108,6 @@ module RuboCop
           )
         end
 
-        # rubocop:disable Metrics/MethodLength
         def true?(to_symbol, matcher)
           result = case matcher.method_name
                    when :be, :eq, :eql, :equal
@@ -126,7 +123,6 @@ module RuboCop
                    end
           to_symbol == :to ? result : !result
         end
-        # rubocop:enable Metrics/MethodLength
       end
 
       # A helper for `explicit` style
@@ -245,7 +241,6 @@ module RuboCop
           corrector.insert_after(actual, ".#{predicate}" + args + block)
         end
 
-        # rubocop:disable Metrics/MethodLength
         def to_predicate_method(matcher)
           case matcher = matcher.to_s
           when 'be_a', 'be_an', 'be_a_kind_of', 'a_kind_of', 'be_kind_of'
@@ -262,7 +257,6 @@ module RuboCop
             "#{matcher[/\Abe_(.+)/, 1]}?"
           end
         end
-        # rubocop:enable Metrics/MethodLength
 
         def replacement_matcher(node)
           case [cop_config['Strict'], node.method?(:to)]

--- a/lib/rubocop/cop/rspec/return_from_stub.rb
+++ b/lib/rubocop/cop/rspec/return_from_stub.rb
@@ -80,10 +80,10 @@ module RuboCop
 
         def check_block_body(block)
           body = block.body
-          unless dynamic?(body) # rubocop:disable Style/GuardClause
-            add_offense(block.loc.begin, message: MSG_AND_RETURN) do |corrector|
-              BlockBodyCorrector.new(block).call(corrector)
-            end
+          return if dynamic?(body)
+
+          add_offense(block.loc.begin, message: MSG_AND_RETURN) do |corrector|
+            BlockBodyCorrector.new(block).call(corrector)
           end
         end
 

--- a/lib/rubocop/rspec/wording.rb
+++ b/lib/rubocop/rspec/wording.rb
@@ -17,7 +17,6 @@ module RuboCop
         @replacements = replace
       end
 
-      # rubocop:disable Metrics/MethodLength
       def rewrite
         case text
         when SHOULDNT_BE_PREFIX
@@ -32,7 +31,6 @@ module RuboCop
           remove_should_and_pluralize
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_left_let_brace_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
-  # rubocop:disable RSpec/ExampleLength
   it 'registers offense for unaligned braces' do
     expect_offense(<<~RUBY)
       let(:foo) { bar }
@@ -41,7 +40,6 @@ RSpec.describe RuboCop::Cop::RSpec::AlignLeftLetBrace do
       end
     RUBY
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'does not register an offense for let with proc argument' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
+++ b/spec/rubocop/cop/rspec/align_right_let_brace_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
-  # rubocop:disable RSpec/ExampleLength
   it 'registers offense for unaligned braces' do
     expect_offense(<<~RUBY)
       let(:foo)      { a }
@@ -41,7 +40,6 @@ RSpec.describe RuboCop::Cop::RSpec::AlignRightLetBrace do
       end
     RUBY
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'does not register an offense for let with proc argument' do
     expect_no_offenses(<<~RUBY)

--- a/spec/rubocop/cop/rspec/focus_spec.rb
+++ b/spec/rubocop/cop/rspec/focus_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::Focus do
-  # rubocop:disable RSpec/ExampleLength
   it 'flags all rspec example blocks with that include `focus: true`' do
     expect_offense(<<~RUBY)
       example 'test', meta: true, focus: true do; end
@@ -131,7 +130,6 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
       shared_context 'test' do; end
     RUBY
   end
-  # rubocop:enable RSpec/ExampleLength
 
   it 'does not flag unfocused specs' do
     expect_no_offenses(<<~RUBY)
@@ -175,7 +173,7 @@ RSpec.describe RuboCop::Cop::RSpec::Focus do
     RUBY
   end
 
-  it 'flags focused block types' do # rubocop:disable RSpec/ExampleLength
+  it 'flags focused block types' do
     expect_offense(<<~RUBY)
       fdescribe 'test' do; end
       ^^^^^^^^^^^^^^^^ Focused spec found.


### PR DESCRIPTION
The first commit removes a few unnecessary RuboCop disables. This includes fixing a `Naming/PredicateName` offense, and one `Style/GuardClause` offense.

I am not sure why `Lint/RedundantCopDisableDirective` didn't find the unnecessary disabling of `RSpec/ExampleLength` 🤷🏼 

The second commit loosens `Metrics/MethodLength` Max to 15. The default is 10, which seems to be just a bit too low for our code.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
