### PR TITLE
Use new ast features

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,15 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# This cop supports safe autocorrection (--autocorrect).
-InternalAffairs/NodeTypeMultiplePredicates:
-  Exclude:
-    - 'lib/rubocop/cop/rspec/empty_example_group.rb'
-    - 'lib/rubocop/cop/rspec/predicate_matcher.rb'
-    - 'lib/rubocop/cop/rspec/receive_messages.rb'
-    - 'lib/rubocop/cop/rspec/variable_definition.rb'
-    - 'lib/rubocop/cop/rspec/variable_name.rb'
-
 Rake/MethodDefinitionInTask:
   Exclude:
     - 'tasks/cut_release.rake'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,18 +7,6 @@
 # versions of RuboCop, may require this file to be generated again.
 
 # This cop supports safe autocorrection (--autocorrect).
-InternalAffairs/NodePatternGroups:
-  Exclude:
-    - 'lib/rubocop/cop/rspec/described_class.rb'
-    - 'lib/rubocop/cop/rspec/described_class_module_wrapping.rb'
-    - 'lib/rubocop/cop/rspec/hook_argument.rb'
-    - 'lib/rubocop/cop/rspec/hooks_before_examples.rb'
-    - 'lib/rubocop/cop/rspec/no_expectation_example.rb'
-    - 'lib/rubocop/cop/rspec/pending_without_reason.rb'
-    - 'lib/rubocop/cop/rspec/redundant_around.rb'
-    - 'lib/rubocop/rspec/language.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 InternalAffairs/NodeTypeMultiplePredicates:
   Exclude:
     - 'lib/rubocop/cop/rspec/empty_example_group.rb'

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -83,7 +83,7 @@ module RuboCop
 
         # @!method rspec_block?(node)
         def_node_matcher :rspec_block?,
-                         '({block numblock} (send #rspec? #ALL.all ...) ...)'
+                         '(any_block (send #rspec? #ALL.all ...) ...)'
 
         # @!method scope_changing_syntax?(node)
         def_node_matcher :scope_changing_syntax?, '{def class module}'

--- a/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
+++ b/lib/rubocop/cop/rspec/described_class_module_wrapping.rb
@@ -24,7 +24,7 @@ module RuboCop
 
         # @!method include_rspec_blocks?(node)
         def_node_search :include_rspec_blocks?, <<~PATTERN
-          ({block numblock} (send #explicit_rspec? #ExampleGroups.all ...) ...)
+          (any_block (send #explicit_rspec? #ExampleGroups.all ...) ...)
         PATTERN
 
         def on_module(node)

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -155,7 +155,7 @@ module RuboCop
           return true unless body
           return false if conditionals_with_examples?(body)
 
-          if body.if_type? || body.case_type?
+          if body.type?(:if, :case)
             !examples_in_branches?(body)
           else
             !examples?(body)
@@ -163,7 +163,7 @@ module RuboCop
         end
 
         def conditionals_with_examples?(body)
-          return false unless body.begin_type? || body.case_type?
+          return false unless body.type?(:begin, :case)
 
           body.each_descendant(:if, :case).any? do |condition_node|
             examples_in_branches?(condition_node)
@@ -172,7 +172,7 @@ module RuboCop
 
         def examples_in_branches?(condition_node)
           return false unless condition_node
-          return false if !condition_node.if_type? && !condition_node.case_type?
+          return false unless condition_node.type?(:if, :case)
 
           condition_node.branches.any? { |branch| examples?(branch) }
         end

--- a/lib/rubocop/cop/rspec/hook_argument.rb
+++ b/lib/rubocop/cop/rspec/hook_argument.rb
@@ -67,12 +67,12 @@ module RuboCop
 
         # @!method scoped_hook(node)
         def_node_matcher :scoped_hook, <<~PATTERN
-          ({block numblock} $(send _ #Hooks.all (sym ${:each :example})) ...)
+          (any_block $(send _ #Hooks.all (sym ${:each :example})) ...)
         PATTERN
 
         # @!method unscoped_hook(node)
         def_node_matcher :unscoped_hook, <<~PATTERN
-          ({block numblock} $(send _ #Hooks.all) ...)
+          (any_block $(send _ #Hooks.all) ...)
         PATTERN
 
         def on_block(node)

--- a/lib/rubocop/cop/rspec/hooks_before_examples.rb
+++ b/lib/rubocop/cop/rspec/hooks_before_examples.rb
@@ -30,7 +30,7 @@ module RuboCop
         # @!method example_or_group?(node)
         def_node_matcher :example_or_group?, <<~PATTERN
           {
-            ({block numblock} {
+            (any_block {
               (send #rspec? #ExampleGroups.all ...)
               (send nil? #Examples.all ...)
             } ...)

--- a/lib/rubocop/cop/rspec/no_expectation_example.rb
+++ b/lib/rubocop/cop/rspec/no_expectation_example.rb
@@ -65,7 +65,7 @@ module RuboCop
         # @param [RuboCop::AST::Node] node
         # @return [Boolean]
         def_node_matcher :regular_or_focused_example?, <<~PATTERN
-          ({block numblock} (send nil? {#Examples.regular #Examples.focused} ...) ...)
+          (any_block (send nil? {#Examples.regular #Examples.focused} ...) ...)
         PATTERN
 
         # @!method includes_expectation?(node)

--- a/lib/rubocop/cop/rspec/pending_without_reason.rb
+++ b/lib/rubocop/cop/rspec/pending_without_reason.rb
@@ -63,8 +63,7 @@ module RuboCop
         def_node_matcher :skipped_in_example?, <<~PATTERN
           {
             (send nil? ${#Examples.skipped #Examples.pending})
-            (block (send nil? ${#Examples.skipped}) ...)
-            (numblock (send nil? ${#Examples.skipped}) ...)
+            (any_block (send nil? ${#Examples.skipped}) ...)
           }
         PATTERN
 
@@ -75,7 +74,7 @@ module RuboCop
 
         # @!method skipped_by_example_method_with_block?(node)
         def_node_matcher :skipped_by_example_method_with_block?, <<~PATTERN
-          ({block numblock} (send nil? ${#Examples.skipped #Examples.pending} ...) ...)
+          (any_block (send nil? ${#Examples.skipped #Examples.pending} ...) ...)
         PATTERN
 
         # @!method metadata_without_reason?(node)

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -182,7 +182,7 @@ module RuboCop
 
         def heredoc_argument?(matcher)
           matcher.arguments.select do |arg|
-            arg.str_type? || arg.dstr_type? || arg.xstr_type?
+            arg.type?(:str, :dstr, :xstr)
           end.any?(&:heredoc?)
         end
 

--- a/lib/rubocop/cop/rspec/receive_messages.rb
+++ b/lib/rubocop/cop/rspec/receive_messages.rb
@@ -148,8 +148,7 @@ module RuboCop
         end
 
         def heredoc_or_splat?(node)
-          ((node.str_type? || node.dstr_type?) && node.heredoc?) ||
-            node.splat_type?
+          (node.type?(:str, :dstr) && node.heredoc?) || node.splat_type?
         end
 
         def requires_quotes?(value)

--- a/lib/rubocop/cop/rspec/redundant_around.rb
+++ b/lib/rubocop/cop/rspec/redundant_around.rb
@@ -41,7 +41,7 @@ module RuboCop
 
         # @!method match_redundant_around_hook_block?(node)
         def_node_matcher :match_redundant_around_hook_block?, <<~PATTERN
-          ({block numblock} (send _ :around ...) ... (send _ :run))
+          (any_block (send _ :around ...) ... (send _ :run))
         PATTERN
 
         # @!method match_redundant_around_hook_send?(node)

--- a/lib/rubocop/cop/rspec/variable_definition.rb
+++ b/lib/rubocop/cop/rspec/variable_definition.rb
@@ -69,7 +69,7 @@ module RuboCop
         end
 
         def symbol?(node)
-          node.sym_type? || node.dsym_type?
+          node.type?(:sym, :dsym)
         end
       end
     end

--- a/lib/rubocop/cop/rspec/variable_name.rb
+++ b/lib/rubocop/cop/rspec/variable_name.rb
@@ -50,7 +50,7 @@ module RuboCop
           return unless inside_example_group?(node)
 
           variable_definition?(node) do |variable|
-            return if variable.dstr_type? || variable.dsym_type?
+            return if variable.type?(:dstr, :dsym)
             return if matches_allowed_pattern?(variable.value)
 
             check_name(node, variable.value, variable.source_range)

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -26,7 +26,7 @@ module RuboCop
 
       # @!method example_group?(node)
       def_node_matcher :example_group?, <<~PATTERN
-        ({block numblock} (send #rspec? #ExampleGroups.all ...) ...)
+        (any_block (send #rspec? #ExampleGroups.all ...) ...)
       PATTERN
 
       # @!method shared_group?(node)
@@ -35,7 +35,7 @@ module RuboCop
 
       # @!method spec_group?(node)
       def_node_matcher :spec_group?, <<~PATTERN
-        ({block numblock} (send #rspec?
+        (any_block (send #rspec?
              {#SharedGroups.all #ExampleGroups.all}
           ...) ...)
       PATTERN
@@ -50,10 +50,7 @@ module RuboCop
 
       # @!method hook?(node)
       def_node_matcher :hook?, <<~PATTERN
-        {
-          (numblock (send nil? #Hooks.all ...) ...)
-          (block (send nil? #Hooks.all ...) ...)
-        }
+        (any_block (send nil? #Hooks.all ...) ...)
       PATTERN
 
       # @!method let?(node)


### PR DESCRIPTION
Now that we depend on a more recent rubocop-ast version, we can use the features that @dvandersluis mentioned in #2025:

- Use `any_block` in node patterns.
- Use `Node#type?` with multiple arguments.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
