### PR TITLE
[Fix #2044] Fix unintended document changes caused by default Rake task

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -12,7 +12,10 @@ end
 
 desc 'Generate docs of all cops departments'
 task generate_cops_documentation: :yard_for_generate_documentation do
-  RuboCop::ConfigLoader.inject_defaults!("#{__dir__}/../config/default.yml")
+  loaded_plugins = RuboCop::ConfigLoader.default_configuration.loaded_plugins
+  if loaded_plugins.none? { |plugin| plugin.about.name == 'rubocop-rspec' }
+    RuboCop::ConfigLoader.inject_defaults!("#{__dir__}/../config/default.yml")
+  end
 
   generator = CopsDocumentationGenerator.new(
     departments: %w[RSpec]


### PR DESCRIPTION
This PR fixes unintended document changes caused by  default Rake task.

## Problem

The default task causes `RuboCop::Config` to end up in an unexpected state when `internal_investigation` task is executed before `generate_cops_documentation` task. This is due to the fact that plugins are already loaded when RuboCop is executed as part of `internal_investigation`.

## Solution

This change preemptively determines whether configuration adjustments are necessary based on whether `rubocop-rspec` plugin has already been loaded.

## Additional Information

Since this logic should ideally be encapsulated within `CopsDocumentationGenerator`, it is expected to become unnecessary in the future once the API design and implementation of `CopsDocumentationGenerator` class are complete. For now, this serves as a temporary workaround.

Fixes #2044.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
