### PR TITLE
Remove `Reference` from config

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -116,33 +116,28 @@ RSpec/AlignLeftLetBrace:
   Description: Checks that left braces for adjacent single line lets are aligned.
   Enabled: false
   VersionAdded: '1.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignLeftLetBrace
 
 RSpec/AlignRightLetBrace:
   Description: Checks that right braces for adjacent single line lets are aligned.
   Enabled: false
   VersionAdded: '1.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignRightLetBrace
 
 RSpec/AnyInstance:
   Description: Check that instances are not being stubbed globally.
   Enabled: true
   VersionAdded: '1.4'
   StyleGuide: https://rspec.rubystyle.guide/#any_instance_of
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AnyInstance
 
 RSpec/AroundBlock:
   Description: Checks that around blocks actually run the test.
   Enabled: true
   VersionAdded: '1.11'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AroundBlock
 
 RSpec/Be:
   Description: Check for expectations where `be` is used without argument.
   Enabled: true
   VersionAdded: '1.25'
   StyleGuide: https://rspec.rubystyle.guide/#be-matcher
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Be
 
 RSpec/BeEmpty:
   Description: Prefer using `be_empty` when checking for an empty array.
@@ -150,7 +145,6 @@ RSpec/BeEmpty:
   AutoCorrect: contextual
   VersionAdded: '2.20'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEmpty
 
 RSpec/BeEq:
   Description: Check for expectations where `be(...)` can replace `eq(...)`.
@@ -158,7 +152,6 @@ RSpec/BeEq:
   Safe: false
   VersionAdded: 2.9.0
   VersionChanged: '2.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEq
 
 RSpec/BeEql:
   Description: Check for expectations where `be(...)` can replace `eql(...)`.
@@ -166,7 +159,6 @@ RSpec/BeEql:
   Safe: false
   VersionAdded: '1.7'
   VersionChanged: '2.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEql
 
 RSpec/BeNil:
   Description: Ensures a consistent style is used when matching `nil`.
@@ -177,7 +169,6 @@ RSpec/BeNil:
     - be_nil
   VersionAdded: 2.9.0
   VersionChanged: 2.10.0
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeNil
 
 RSpec/BeforeAfterAll:
   Description: Check that before/after(:all/:context) isn't being used.
@@ -189,14 +180,12 @@ RSpec/BeforeAfterAll:
   VersionAdded: '1.12'
   VersionChanged: '2.23'
   StyleGuide: https://rspec.rubystyle.guide/#avoid-hooks-with-context-scope
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll
 
 RSpec/ChangeByZero:
   Description: Prefer negated matchers over `to change.by(0)`.
   Enabled: true
   VersionAdded: '2.11'
   VersionChanged: '2.14'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ChangeByZero
   NegatedMatcher: ~
 
 RSpec/ClassCheck:
@@ -208,20 +197,17 @@ RSpec/ClassCheck:
   SupportedStyles:
     - be_a
     - be_kind_of
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ClassCheck
 
 RSpec/ContainExactly:
   Description: Checks where `contain_exactly` is used.
   Enabled: true
   VersionAdded: '2.19'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContainExactly
 
 RSpec/ContextMethod:
   Description: "`context` should not be used for specifying methods."
   Enabled: true
   VersionAdded: '1.36'
   StyleGuide: https://rspec.rubystyle.guide/#example-group-naming
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextMethod
 
 RSpec/ContextWording:
   Description: Checks that `context` docstring starts with an allowed prefix.
@@ -234,7 +220,6 @@ RSpec/ContextWording:
   VersionAdded: '1.20'
   VersionChanged: '2.13'
   StyleGuide: https://rspec.rubystyle.guide/#context-descriptions
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
 
 RSpec/DescribeClass:
   Description: Check that the first argument to the top-level describe is a constant.
@@ -263,19 +248,16 @@ RSpec/DescribeClass:
       - task
   VersionAdded: '1.0'
   VersionChanged: '2.7'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
 
 RSpec/DescribeMethod:
   Description: Checks that the second argument to `describe` specifies a method.
   Enabled: true
   VersionAdded: '1.0'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeMethod
 
 RSpec/DescribeSymbol:
   Description: Avoid describing symbols.
   Enabled: true
   VersionAdded: '1.15'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeSymbol
 
 RSpec/DescribedClass:
   Description: Checks that tests use `described_class`.
@@ -289,26 +271,22 @@ RSpec/DescribedClass:
   SafeAutoCorrect: false
   VersionAdded: '1.0'
   VersionChanged: '2.27'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass
 
 RSpec/DescribedClassModuleWrapping:
   Description: Avoid opening modules and defining specs within them.
   Enabled: false
   VersionAdded: '1.37'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClassModuleWrapping
 
 RSpec/Dialect:
   Description: Enforces custom RSpec dialects.
   Enabled: false
   PreferredMethods: {}
   VersionAdded: '1.33'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Dialect
 
 RSpec/DuplicatedMetadata:
   Description: Avoid duplicated metadata.
   Enabled: true
   VersionAdded: '2.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DuplicatedMetadata
 
 RSpec/EmptyExampleGroup:
   Description: Checks if an example group does not include any tests.
@@ -317,7 +295,6 @@ RSpec/EmptyExampleGroup:
   SafeAutoCorrect: false
   VersionAdded: '1.7'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
 
 RSpec/EmptyHook:
   Description: Checks for empty before and after hooks.
@@ -325,7 +302,6 @@ RSpec/EmptyHook:
   AutoCorrect: contextual
   VersionAdded: '1.39'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyHook
 
 RSpec/EmptyLineAfterExample:
   Description: Checks if there is an empty line after example blocks.
@@ -333,21 +309,18 @@ RSpec/EmptyLineAfterExample:
   AllowConsecutiveOneLiners: true
   VersionAdded: '1.36'
   StyleGuide: https://rspec.rubystyle.guide/#empty-lines-around-examples
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExample
 
 RSpec/EmptyLineAfterExampleGroup:
   Description: Checks if there is an empty line after example group blocks.
   Enabled: true
   VersionAdded: '1.27'
   StyleGuide: https://rspec.rubystyle.guide/#empty-lines-between-describes
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExampleGroup
 
 RSpec/EmptyLineAfterFinalLet:
   Description: Checks if there is an empty line after the last let block.
   Enabled: true
   VersionAdded: '1.14'
   StyleGuide: https://rspec.rubystyle.guide/#empty-line-after-let
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterFinalLet
 
 RSpec/EmptyLineAfterHook:
   Description: Checks if there is an empty line after hook blocks.
@@ -355,7 +328,6 @@ RSpec/EmptyLineAfterHook:
   VersionAdded: '1.27'
   VersionChanged: '2.13'
   StyleGuide: https://rspec.rubystyle.guide/#empty-line-after-let
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterHook
   AllowConsecutiveOneLiners: true
 
 RSpec/EmptyLineAfterSubject:
@@ -363,7 +335,6 @@ RSpec/EmptyLineAfterSubject:
   Enabled: true
   VersionAdded: '1.14'
   StyleGuide: https://rspec.rubystyle.guide/#empty-line-after-let
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterSubject
 
 RSpec/EmptyMetadata:
   Description: Avoid empty metadata hash.
@@ -371,19 +342,16 @@ RSpec/EmptyMetadata:
   AutoCorrect: contextual
   VersionAdded: '2.24'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyMetadata
 
 RSpec/EmptyOutput:
   Description: Check that the `output` matcher is not called with an empty string.
   Enabled: true
   VersionAdded: '2.29'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyOutput
 
 RSpec/Eq:
   Description: Use `eq` instead of `be ==` to compare objects.
   Enabled: true
   VersionAdded: '2.24'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Eq
 
 RSpec/ExampleLength:
   Description: Checks for long examples.
@@ -392,7 +360,6 @@ RSpec/ExampleLength:
   CountAsOne: []
   VersionAdded: '1.5'
   VersionChanged: '2.3'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength
 
 RSpec/ExampleWithoutDescription:
   Description: Checks for examples without a description.
@@ -404,7 +371,6 @@ RSpec/ExampleWithoutDescription:
     - disallow
   VersionAdded: '1.22'
   StyleGuide: https://rspec.rubystyle.guide/#it-and-specify
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWithoutDescription
 
 RSpec/ExampleWording:
   Description: Checks for common mistakes in example descriptions.
@@ -420,13 +386,11 @@ RSpec/ExampleWording:
   VersionAdded: '1.0'
   VersionChanged: '2.13'
   StyleGuide: https://rspec.rubystyle.guide/#should-in-example-docstrings
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
 
 RSpec/ExcessiveDocstringSpacing:
   Description: Checks for excessive whitespace in example descriptions.
   Enabled: true
   VersionAdded: '2.5'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExcessiveDocstringSpacing
 
 RSpec/ExpectActual:
   Description: Checks for `expect(...)` calls containing literal values.
@@ -435,7 +399,6 @@ RSpec/ExpectActual:
     - "**/spec/routing/**/*"
   VersionAdded: '1.7'
   VersionChanged: '2.23'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectActual
 
 RSpec/ExpectChange:
   Description: Checks for consistent style of change matcher.
@@ -447,25 +410,21 @@ RSpec/ExpectChange:
   SafeAutoCorrect: false
   VersionAdded: '1.22'
   VersionChanged: '2.5'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
 
 RSpec/ExpectInHook:
   Description: Do not use `expect` in hooks such as `before`.
   Enabled: true
   VersionAdded: '1.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook
 
 RSpec/ExpectInLet:
   Description: Do not use `expect` in let.
   Enabled: true
   VersionAdded: '2.30'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInLet
 
 RSpec/ExpectOutput:
   Description: Checks for opportunities to use `expect { ... }.to output`.
   Enabled: true
   VersionAdded: '1.10'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectOutput
 
 RSpec/Focus:
   Description: Checks if examples are focused.
@@ -473,7 +432,6 @@ RSpec/Focus:
   AutoCorrect: contextual
   VersionAdded: '1.5'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Focus
 
 RSpec/HookArgument:
   Description: Checks the arguments passed to `before`, `around`, and `after`.
@@ -485,7 +443,6 @@ RSpec/HookArgument:
     - example
   VersionAdded: '1.7'
   StyleGuide: https://rspec.rubystyle.guide/#redundant-beforeeach
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HookArgument
 
 RSpec/HooksBeforeExamples:
   Description: Checks for before/around/after hooks that come after an example.
@@ -493,20 +450,17 @@ RSpec/HooksBeforeExamples:
   AutoCorrect: contextual
   VersionAdded: '1.29'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HooksBeforeExamples
 
 RSpec/IdenticalEqualityAssertion:
   Description: Checks for equality assertions with identical expressions on both sides.
   Enabled: true
   VersionAdded: '2.4'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IdenticalEqualityAssertion
 
 RSpec/ImplicitBlockExpectation:
   Description: Check that implicit block expectation syntax is not used.
   Enabled: true
   VersionAdded: '1.35'
   StyleGuide: https://rspec.rubystyle.guide/#implicit-block-expectations
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitBlockExpectation
 
 RSpec/ImplicitExpect:
   Description: Check that a consistent implicit expectation style is used.
@@ -517,7 +471,6 @@ RSpec/ImplicitExpect:
     - should
   VersionAdded: '1.8'
   StyleGuide: https://rspec.rubystyle.guide/#use-expect
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitExpect
 
 RSpec/ImplicitSubject:
   Description: Checks for usage of implicit subject (`is_expected` / `should`).
@@ -530,14 +483,12 @@ RSpec/ImplicitSubject:
     - require_implicit
   VersionAdded: '1.29'
   VersionChanged: '2.13'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitSubject
 
 RSpec/IndexedLet:
   Description: Do not set up test data using indexes (e.g., `item_1`, `item_2`).
   Enabled: true
   VersionAdded: '2.20'
   VersionChanged: '2.23'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IndexedLet
   Max: 1
   AllowedIdentifiers: []
   AllowedPatterns: []
@@ -546,7 +497,6 @@ RSpec/InstanceSpy:
   Description: Checks for `instance_double` used with `have_received`.
   Enabled: true
   VersionAdded: '1.12'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceSpy
 
 RSpec/InstanceVariable:
   Description: Checks for instance variable usage in specs.
@@ -555,14 +505,12 @@ RSpec/InstanceVariable:
   VersionAdded: '1.0'
   VersionChanged: '1.7'
   StyleGuide: https://rspec.rubystyle.guide/#instance-variables
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceVariable
 
 RSpec/IsExpectedSpecify:
   Description: Check for `specify` with `is_expected` and one-liner expectations.
   Enabled: true
   VersionAdded: '2.27'
   StyleGuide: https://rspec.rubystyle.guide/#it-and-specify
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IsExpectedSpecify
 
 RSpec/ItBehavesLike:
   Description: Checks that only one `it_behaves_like` style is used.
@@ -572,13 +520,11 @@ RSpec/ItBehavesLike:
     - it_behaves_like
     - it_should_behave_like
   VersionAdded: '1.13'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ItBehavesLike
 
 RSpec/IteratedExpectation:
   Description: Check that `all` matcher is used instead of iterating over an array.
   Enabled: true
   VersionAdded: '1.14'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IteratedExpectation
 
 RSpec/LeadingSubject:
   Description: Enforce that subject is the first definition in the test.
@@ -586,14 +532,12 @@ RSpec/LeadingSubject:
   VersionAdded: '1.7'
   VersionChanged: '1.14'
   StyleGuide: https://rspec.rubystyle.guide/#leading-subject
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeadingSubject
 
 RSpec/LeakyConstantDeclaration:
   Description: Checks that no class, module, or constant is declared.
   Enabled: true
   VersionAdded: '1.35'
   StyleGuide: https://rspec.rubystyle.guide/#declare-constants
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration
 
 RSpec/LetBeforeExamples:
   Description: Checks for `let` definitions that come after an example.
@@ -601,25 +545,21 @@ RSpec/LetBeforeExamples:
   AutoCorrect: contextual
   VersionAdded: '1.16'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetBeforeExamples
 
 RSpec/LetSetup:
   Description: Checks unreferenced `let!` calls being used for test setup.
   Enabled: true
   VersionAdded: '1.7'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetSetup
 
 RSpec/MatchArray:
   Description: Checks where `match_array` is used.
   Enabled: true
   VersionAdded: '2.19'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MatchArray
 
 RSpec/MessageChain:
   Description: Check that chains of messages are not being stubbed.
   Enabled: true
   VersionAdded: '1.7'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageChain
 
 RSpec/MessageExpectation:
   Description: Checks for consistent message expectation style.
@@ -630,7 +570,6 @@ RSpec/MessageExpectation:
     - expect
   VersionAdded: '1.7'
   VersionChanged: '1.8'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageExpectation
 
 RSpec/MessageSpies:
   Description: Checks that message expectations are set using spies.
@@ -640,7 +579,6 @@ RSpec/MessageSpies:
     - have_received
     - receive
   VersionAdded: '1.9'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageSpies
 
 RSpec/MetadataStyle:
   Description: Use consistent metadata style.
@@ -650,25 +588,21 @@ RSpec/MetadataStyle:
     - hash
     - symbol
   VersionAdded: '2.24'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MetadataStyle
 
 RSpec/MissingExampleGroupArgument:
   Description: Checks that the first argument to an example group is not empty.
   Enabled: true
   VersionAdded: '1.28'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExampleGroupArgument
 
 RSpec/MissingExpectationTargetMethod:
   Description: Checks if `.to`, `not_to` or `to_not` are used.
   Enabled: true
   VersionAdded: '3.0'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExpectationTargetMethod
 
 RSpec/MultipleDescribes:
   Description: Checks for multiple top-level example groups.
   Enabled: true
   VersionAdded: '1.0'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleDescribes
 
 RSpec/MultipleExpectations:
   Description: Checks if examples contain too many `expect` calls.
@@ -677,7 +611,6 @@ RSpec/MultipleExpectations:
   VersionAdded: '1.7'
   VersionChanged: '1.21'
   StyleGuide: https://rspec.rubystyle.guide/#expectation-per-example
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 
 RSpec/MultipleMemoizedHelpers:
   Description: Checks if example groups contain too many `let` and `subject` calls.
@@ -686,13 +619,11 @@ RSpec/MultipleMemoizedHelpers:
   Max: 5
   VersionAdded: '1.43'
   StyleGuide: https://rspec.rubystyle.guide/#let-blocks
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleMemoizedHelpers
 
 RSpec/MultipleSubjects:
   Description: Checks if an example group defines `subject` multiple times.
   Enabled: true
   VersionAdded: '1.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleSubjects
 
 RSpec/NamedSubject:
   Description: Checks for explicitly referenced test subjects.
@@ -705,7 +636,6 @@ RSpec/NamedSubject:
   VersionAdded: 1.5.3
   VersionChanged: '2.15'
   StyleGuide: https://rspec.rubystyle.guide/#use-subject
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
 RSpec/NestedGroups:
   Description: Checks for nested example groups.
@@ -714,7 +644,6 @@ RSpec/NestedGroups:
   AllowedGroups: []
   VersionAdded: '1.7'
   VersionChanged: '2.13'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NestedGroups
 
 RSpec/NoExpectationExample:
   Description: Checks if an example contains any expectation.
@@ -722,7 +651,6 @@ RSpec/NoExpectationExample:
   Safe: false
   VersionAdded: '2.13'
   VersionChanged: '2.14'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NoExpectationExample
   AllowedPatterns:
     - "^expect_"
     - "^assert_"
@@ -735,25 +663,21 @@ RSpec/NotToNot:
     - not_to
     - to_not
   VersionAdded: '1.4'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NotToNot
 
 RSpec/OverwritingSetup:
   Description: Checks if there is a let/subject that overwrites an existing one.
   Enabled: true
   VersionAdded: '1.14'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/OverwritingSetup
 
 RSpec/Pending:
   Description: Checks for any pending or skipped examples.
   Enabled: false
   VersionAdded: '1.25'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Pending
 
 RSpec/PendingWithoutReason:
   Description: Checks for pending or skipped examples without reason.
   Enabled: true
   VersionAdded: '2.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PendingWithoutReason
 
 RSpec/PredicateMatcher:
   Description: Prefer using predicate matcher over using predicate method directly.
@@ -767,80 +691,67 @@ RSpec/PredicateMatcher:
   SafeAutoCorrect: false
   VersionAdded: '1.16'
   StyleGuide: https://rspec.rubystyle.guide/#predicate-matchers
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
 
 RSpec/ReceiveCounts:
   Description: Check for `once` and `twice` receive counts matchers usage.
   Enabled: true
   VersionAdded: '1.26'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveCounts
 
 RSpec/ReceiveMessages:
   Description: Checks for multiple messages stubbed on the same object.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '2.23'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveMessages
 
 RSpec/ReceiveNever:
   Description: Prefer `not_to receive(...)` over `receive(...).never`.
   Enabled: true
   VersionAdded: '1.28'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveNever
 
 RSpec/RedundantAround:
   Description: Remove redundant `around` hook.
   Enabled: true
   VersionAdded: '2.19'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RedundantAround
 
 RSpec/RedundantPredicateMatcher:
   Description: Checks for redundant predicate matcher.
   Enabled: true
   VersionAdded: '2.26'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RedundantPredicateMatcher
 
 RSpec/RemoveConst:
   Description: Checks that `remove_const` is not used in specs.
   Enabled: true
   VersionAdded: '2.26'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RemoveConst
 
 RSpec/RepeatedDescription:
   Description: Check for repeated description strings in example groups.
   Enabled: true
   VersionAdded: '1.9'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedDescription
 
 RSpec/RepeatedExample:
   Description: Check for repeated examples within example groups.
   Enabled: true
   VersionAdded: '1.10'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExample
 
 RSpec/RepeatedExampleGroupBody:
   Description: Check for repeated describe and context block body.
   Enabled: true
   VersionAdded: '1.38'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupBody
 
 RSpec/RepeatedExampleGroupDescription:
   Description: Check for repeated example group descriptions.
   Enabled: true
   VersionAdded: '1.38'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupDescription
 
 RSpec/RepeatedIncludeExample:
   Description: Check for repeated include of shared examples.
   Enabled: true
   VersionAdded: '1.44'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedIncludeExample
 
 RSpec/RepeatedSubjectCall:
   Description: Checks for repeated calls to subject missing that it is memoized.
   Enabled: true
   VersionAdded: '2.27'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedSubjectCall
 
 RSpec/ReturnFromStub:
   Description: Checks for consistent style of stub's return setting.
@@ -851,7 +762,6 @@ RSpec/ReturnFromStub:
     - block
   VersionAdded: '1.16'
   VersionChanged: '1.22'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReturnFromStub
 
 RSpec/ScatteredLet:
   Description: Checks for let scattered across the example group.
@@ -859,7 +769,6 @@ RSpec/ScatteredLet:
   AutoCorrect: contextual
   VersionAdded: '1.14'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet
 
 RSpec/ScatteredSetup:
   Description: Checks for setup scattered across multiple hooks in an example group.
@@ -867,13 +776,11 @@ RSpec/ScatteredSetup:
   AutoCorrect: contextual
   VersionAdded: '1.10'
   VersionChanged: '2.31'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredSetup
 
 RSpec/SharedContext:
   Description: Checks for proper shared_context and shared_examples usage.
   Enabled: true
   VersionAdded: '1.13'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedContext
 
 RSpec/SharedExamples:
   Description: Checks for consistent style for shared example names.
@@ -884,26 +791,22 @@ RSpec/SharedExamples:
     - symbol
   VersionAdded: '1.25'
   VersionChanged: '2.26'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples
 
 RSpec/SingleArgumentMessageChain:
   Description: Checks that chains of messages contain more than one element.
   Enabled: true
   VersionAdded: '1.9'
   VersionChanged: '1.10'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SingleArgumentMessageChain
 
 RSpec/SkipBlockInsideExample:
   Description: Checks for passing a block to `skip` within examples.
   Enabled: true
   VersionAdded: '2.19'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SkipBlockInsideExample
 
 RSpec/SortMetadata:
   Description: Sort RSpec metadata alphabetically.
   Enabled: true
   VersionAdded: '2.14'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SortMetadata
 
 RSpec/SpecFilePathFormat:
   Description: Checks that spec file paths are consistent and well-formed.
@@ -919,7 +822,6 @@ RSpec/SpecFilePathFormat:
   IgnoreMetadata:
     type: routing
   VersionAdded: '2.24'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SpecFilePathFormat
 
 RSpec/SpecFilePathSuffix:
   Description: Checks that spec file paths suffix are consistent and well-formed.
@@ -928,19 +830,16 @@ RSpec/SpecFilePathSuffix:
   Include:
     - "**/*_spec*rb*"
     - "**/spec/**/*"
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SpecFilePathSuffix
 
 RSpec/StubbedMock:
   Description: Checks that message expectations do not have a configured response.
   Enabled: true
   VersionAdded: '1.44'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/StubbedMock
 
 RSpec/SubjectDeclaration:
   Description: Ensure that subject is defined using subject helper.
   Enabled: true
   VersionAdded: '2.5'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectDeclaration
 
 RSpec/SubjectStub:
   Description: Checks for stubbed test subjects.
@@ -948,19 +847,16 @@ RSpec/SubjectStub:
   VersionAdded: '1.7'
   VersionChanged: '2.8'
   StyleGuide: https://rspec.rubystyle.guide/#dont-stub-subject
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
 
 RSpec/UndescriptiveLiteralsDescription:
   Description: Description should be descriptive.
   Enabled: true
   VersionAdded: '2.29'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/UndescriptiveLiteralsDescription
 
 RSpec/UnspecifiedException:
   Description: Checks for a specified error in checking raised errors.
   Enabled: true
   VersionAdded: '1.30'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/UnspecifiedException
 
 RSpec/VariableDefinition:
   Description: Checks that memoized helpers names are symbols or strings.
@@ -970,7 +866,6 @@ RSpec/VariableDefinition:
     - symbols
     - strings
   VersionAdded: '1.40'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableDefinition
 
 RSpec/VariableName:
   Description: Checks that memoized helper names use the configured style.
@@ -982,7 +877,6 @@ RSpec/VariableName:
   AllowedPatterns: []
   VersionAdded: '1.40'
   VersionChanged: '2.13'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableName
 
 RSpec/VerifiedDoubleReference:
   Description: Checks for consistent verified double reference style.
@@ -990,7 +884,6 @@ RSpec/VerifiedDoubleReference:
   SafeAutoCorrect: false
   VersionAdded: 2.10.0
   VersionChanged: '3.4'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubleReference
 
 RSpec/VerifiedDoubles:
   Description: Prefer using verifying doubles over normal doubles.
@@ -1000,16 +893,13 @@ RSpec/VerifiedDoubles:
   VersionAdded: 1.2.1
   VersionChanged: '1.5'
   StyleGuide: https://rspec.rubystyle.guide/#doubles
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
 
 RSpec/VoidExpect:
   Description: Checks void `expect()`.
   Enabled: true
   VersionAdded: '1.16'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VoidExpect
 
 RSpec/Yield:
   Description: Checks for calling a block within a stub.
   Enabled: true
   VersionAdded: '1.32'
-  Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Yield

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -37,11 +37,6 @@ let(:baz)    { bar }
 let(:a)      { b }
 ----
 
-[#references-rspecalignleftletbrace]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignLeftLetBrace
-
 [#rspecalignrightletbrace]
 == RSpec/AlignRightLetBrace
 
@@ -72,11 +67,6 @@ let(:foobar) { blahblah }
 let(:baz)    { bar      }
 let(:a)      { b        }
 ----
-
-[#references-rspecalignrightletbrace]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AlignRightLetBrace
 
 [#rspecanyinstance]
 == RSpec/AnyInstance
@@ -120,7 +110,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#any_instance_of
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AnyInstance
 
 [#rspecaroundblock]
 == RSpec/AroundBlock
@@ -163,11 +152,6 @@ around do |test|
 end
 ----
 
-[#references-rspecaroundblock]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/AroundBlock
-
 [#rspecbe]
 == RSpec/Be
 
@@ -205,7 +189,6 @@ expect(foo).to be(true)
 === References
 
 * https://rspec.rubystyle.guide/#be-matcher
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Be
 
 [#rspecbeempty]
 == RSpec/BeEmpty
@@ -234,11 +217,6 @@ expect(array).to match_array([])
 # good
 expect(array).to be_empty
 ----
-
-[#references-rspecbeempty]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEmpty
 
 [#rspecbeeq]
 == RSpec/BeEq
@@ -279,11 +257,6 @@ expect(foo).to be(true)
 expect(foo).to be(false)
 expect(foo).to be(nil)
 ----
-
-[#references-rspecbeeq]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEq
 
 [#rspecbeeql]
 == RSpec/BeEql
@@ -338,11 +311,6 @@ expect(foo).to be(false)
 expect(foo).to be(:bar)
 expect(foo).to be(nil)
 ----
-
-[#references-rspecbeeql]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeEql
 
 [#rspecbenil]
 == RSpec/BeNil
@@ -402,11 +370,6 @@ expect(foo).to be(nil)
 | `be`, `be_nil`
 |===
 
-[#references-rspecbenil]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeNil
-
 [#rspecbeforeafterall]
 == RSpec/BeforeAfterAll
 
@@ -455,7 +418,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#avoid-hooks-with-context-scope
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/BeforeAfterAll
 
 [#rspecchangebyzero]
 == RSpec/ChangeByZero
@@ -548,11 +510,6 @@ expect { run }
 | 
 |===
 
-[#references-rspecchangebyzero]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ChangeByZero
-
 [#rspecclasscheck]
 == RSpec/ClassCheck
 
@@ -614,7 +571,6 @@ expect(object).to be_a_kind_of(String)
 === References
 
 * https://rubystyle.guide#is-a-vs-kind-of
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ClassCheck
 
 [#rspeccontainexactly]
 == RSpec/ContainExactly
@@ -650,11 +606,6 @@ it { is_expected.to match_array(array1 + array2) }
 # good
 it { is_expected.to contain_exactly(content, *array) }
 ----
-
-[#references-rspeccontainexactly]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContainExactly
 
 [#rspeccontextmethod]
 == RSpec/ContextMethod
@@ -699,7 +650,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#example-group-naming
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextMethod
 
 [#rspeccontextwording]
 == RSpec/ContextWording
@@ -802,7 +752,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#context-descriptions
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ContextWording
 * http://www.betterspecs.org/#contexts
 
 [#rspecdescribeclass]
@@ -874,11 +823,6 @@ end
 | 
 |===
 
-[#references-rspecdescribeclass]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeClass
-
 [#rspecdescribemethod]
 == RSpec/DescribeMethod
 
@@ -910,11 +854,6 @@ end
 describe MyClass, '.my_class_method' do
 end
 ----
-
-[#references-rspecdescribemethod]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeMethod
 
 [#rspecdescribesymbol]
 == RSpec/DescribeSymbol
@@ -950,7 +889,6 @@ end
 [#references-rspecdescribesymbol]
 === References
 
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribeSymbol
 * https://github.com/rspec/rspec-core/issues/1610
 
 [#rspecdescribedclass]
@@ -1078,11 +1016,6 @@ end
 | Boolean
 |===
 
-[#references-rspecdescribedclass]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClass
-
 [#rspecdescribedclassmodulewrapping]
 == RSpec/DescribedClassModuleWrapping
 
@@ -1119,7 +1052,6 @@ end
 [#references-rspecdescribedclassmodulewrapping]
 === References
 
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DescribedClassModuleWrapping
 * https://github.com/rubocop/rubocop-rspec/issues/735
 
 [#rspecdialect]
@@ -1203,11 +1135,6 @@ end
 | 
 |===
 
-[#references-rspecdialect]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Dialect
-
 [#rspecduplicatedmetadata]
 == RSpec/DuplicatedMetadata
 
@@ -1234,11 +1161,6 @@ describe 'Something', :a, :a
 # good
 describe 'Something', :a
 ----
-
-[#references-rspecduplicatedmetadata]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/DuplicatedMetadata
 
 [#rspecemptyexamplegroup]
 == RSpec/EmptyExampleGroup
@@ -1293,11 +1215,6 @@ describe Bacon do
 end
 ----
 
-[#references-rspecemptyexamplegroup]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyExampleGroup
-
 [#rspecemptyhook]
 == RSpec/EmptyHook
 
@@ -1335,11 +1252,6 @@ before(:all) do
 end
 after(:all) { cleanup_feed }
 ----
-
-[#references-rspecemptyhook]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyHook
 
 [#rspecemptylineafterexample]
 == RSpec/EmptyLineAfterExample
@@ -1416,7 +1328,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#empty-lines-around-examples
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExample
 
 [#rspecemptylineafterexamplegroup]
 == RSpec/EmptyLineAfterExampleGroup
@@ -1460,7 +1371,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#empty-lines-between-describes
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterExampleGroup
 
 [#rspecemptylineafterfinallet]
 == RSpec/EmptyLineAfterFinalLet
@@ -1498,7 +1408,6 @@ it { does_something }
 === References
 
 * https://rspec.rubystyle.guide/#empty-line-after-let
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterFinalLet
 
 [#rspecemptylineafterhook]
 == RSpec/EmptyLineAfterHook
@@ -1585,7 +1494,6 @@ it { does_something }
 === References
 
 * https://rspec.rubystyle.guide/#empty-line-after-let
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterHook
 
 [#rspecemptylineaftersubject]
 == RSpec/EmptyLineAfterSubject
@@ -1621,7 +1529,6 @@ let(:foo) { bar }
 === References
 
 * https://rspec.rubystyle.guide/#empty-line-after-let
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyLineAfterSubject
 
 [#rspecemptymetadata]
 == RSpec/EmptyMetadata
@@ -1653,11 +1560,6 @@ describe 'Something', {}
 describe 'Something'
 ----
 
-[#references-rspecemptymetadata]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyMetadata
-
 [#rspecemptyoutput]
 == RSpec/EmptyOutput
 
@@ -1687,11 +1589,6 @@ expect { foo }.not_to output.to_stdout
 expect { bar }.to output.to_stderr
 ----
 
-[#references-rspecemptyoutput]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/EmptyOutput
-
 [#rspeceq]
 == RSpec/Eq
 
@@ -1718,11 +1615,6 @@ expect(foo).to be == 42
 # good
 expect(foo).to eq 42
 ----
-
-[#references-rspeceq]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Eq
 
 [#rspecexamplelength]
 == RSpec/ExampleLength
@@ -1811,11 +1703,6 @@ end               # 6 points
 | `[]`
 | Array
 |===
-
-[#references-rspecexamplelength]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleLength
 
 [#rspecexamplewithoutdescription]
 == RSpec/ExampleWithoutDescription
@@ -1918,7 +1805,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#it-and-specify
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWithoutDescription
 
 [#rspecexamplewording]
 == RSpec/ExampleWording
@@ -2010,7 +1896,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#should-in-example-docstrings
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExampleWording
 * http://betterspecs.org/#should
 
 [#rspecexcessivedocstringspacing]
@@ -2052,11 +1937,6 @@ end
 context 'when a condition is met' do
 end
 ----
-
-[#references-rspecexcessivedocstringspacing]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExcessiveDocstringSpacing
 
 [#rspecexpectactual]
 == RSpec/ExpectActual
@@ -2104,11 +1984,6 @@ expect(false).to eq(true)
 | `+**/spec/routing/**/*+`
 | Array
 |===
-
-[#references-rspecexpectactual]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectActual
 
 [#rspecexpectchange]
 == RSpec/ExpectChange
@@ -2173,11 +2048,6 @@ expect { run }.to change { Foo.bar }
 | `method_call`, `block`
 |===
 
-[#references-rspecexpectchange]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectChange
-
 [#rspecexpectinhook]
 == RSpec/ExpectInHook
 
@@ -2214,11 +2084,6 @@ it do
 end
 ----
 
-[#references-rspecexpectinhook]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInHook
-
 [#rspecexpectinlet]
 == RSpec/ExpectInLet
 
@@ -2250,11 +2115,6 @@ it do
 end
 ----
 
-[#references-rspecexpectinlet]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectInLet
-
 [#rspecexpectoutput]
 == RSpec/ExpectOutput
 
@@ -2284,11 +2144,6 @@ expect($stdout.string).to eq('Hello World')
 # good
 expect { my_app.print_report }.to output('Hello World').to_stdout
 ----
-
-[#references-rspecexpectoutput]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ExpectOutput
 
 [#rspecfocus]
 == RSpec/Focus
@@ -2347,11 +2202,6 @@ shared_context 'test' do; end
 # bad (does not support autocorrection)
 focus 'test' do; end
 ----
-
-[#references-rspecfocus]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Focus
 
 [#rspechookargument]
 == RSpec/HookArgument
@@ -2454,7 +2304,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#redundant-beforeeach
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HookArgument
 
 [#rspechooksbeforeexamples]
 == RSpec/HooksBeforeExamples
@@ -2493,11 +2342,6 @@ it 'checks what foo does' do
 end
 ----
 
-[#references-rspechooksbeforeexamples]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/HooksBeforeExamples
-
 [#rspecidenticalequalityassertion]
 == RSpec/IdenticalEqualityAssertion
 
@@ -2526,11 +2370,6 @@ expect(foo.bar).to eql(foo.bar)
 expect(foo.bar).to eq(2)
 expect(foo.bar).to eql(2)
 ----
-
-[#references-rspecidenticalequalityassertion]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IdenticalEqualityAssertion
 
 [#rspecimplicitblockexpectation]
 == RSpec/ImplicitBlockExpectation
@@ -2568,7 +2407,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#implicit-block-expectations
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitBlockExpectation
 
 [#rspecimplicitexpect]
 == RSpec/ImplicitExpect
@@ -2630,7 +2468,6 @@ it { should be_truthy }
 === References
 
 * https://rspec.rubystyle.guide/#use-expect
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitExpect
 
 [#rspecimplicitsubject]
 == RSpec/ImplicitSubject
@@ -2738,11 +2575,6 @@ it { expect(named_subject).to be_truthy }
 | `single_line_only`, `single_statement_only`, `disallow`, `require_implicit`
 |===
 
-[#references-rspecimplicitsubject]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ImplicitSubject
-
 [#rspecindexedlet]
 == RSpec/IndexedLet
 
@@ -2839,11 +2671,6 @@ let(:item_2) { create(:item) }
 | Array
 |===
 
-[#references-rspecindexedlet]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IndexedLet
-
 [#rspecinstancespy]
 == RSpec/InstanceSpy
 
@@ -2876,11 +2703,6 @@ it do
   expect(foo).to have_received(:bar)
 end
 ----
-
-[#references-rspecinstancespy]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceSpy
 
 [#rspecinstancevariable]
 == RSpec/InstanceVariable
@@ -2962,7 +2784,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#instance-variables
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/InstanceVariable
 
 [#rspecisexpectedspecify]
 == RSpec/IsExpectedSpecify
@@ -3001,7 +2822,6 @@ specify { expect(sqrt(4)).to eq(2) }
 === References
 
 * https://rspec.rubystyle.guide/#it-and-specify
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IsExpectedSpecify
 
 [#rspecitbehaveslike]
 == RSpec/ItBehavesLike
@@ -3056,11 +2876,6 @@ it_should_behave_like 'a foo'
 | `it_behaves_like`, `it_should_behave_like`
 |===
 
-[#references-rspecitbehaveslike]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ItBehavesLike
-
 [#rspeciteratedexpectation]
 == RSpec/IteratedExpectation
 
@@ -3091,11 +2906,6 @@ it 'validates users' do
   expect([user1, user2, user3]).to all(be_valid)
 end
 ----
-
-[#references-rspeciteratedexpectation]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/IteratedExpectation
 
 [#rspecleadingsubject]
 == RSpec/LeadingSubject
@@ -3146,7 +2956,6 @@ it { expect_something_else }
 === References
 
 * https://rspec.rubystyle.guide/#leading-subject
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeadingSubject
 
 [#rspecleakyconstantdeclaration]
 == RSpec/LeakyConstantDeclaration
@@ -3266,7 +3075,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#declare-constants
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LeakyConstantDeclaration
 * https://rspec.info/features/3-12/rspec-mocks/mutating-constants
 
 [#rspecletbeforeexamples]
@@ -3315,11 +3123,6 @@ it 'checks what some does' do
 end
 ----
 
-[#references-rspecletbeforeexamples]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetBeforeExamples
-
 [#rspecletsetup]
 == RSpec/LetSetup
 
@@ -3361,11 +3164,6 @@ it 'counts widgets' do
 end
 ----
 
-[#references-rspecletsetup]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/LetSetup
-
 [#rspecmatcharray]
 == RSpec/MatchArray
 
@@ -3404,11 +3202,6 @@ it { is_expected.to match_array([content] + array) }
 it { is_expected.to match_array(%w(tremble in fear foolish mortals)) }
 ----
 
-[#references-rspecmatcharray]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MatchArray
-
 [#rspecmessagechain]
 == RSpec/MessageChain
 
@@ -3436,11 +3229,6 @@ allow(foo).to receive_message_chain(:bar, :baz).and_return(42)
 thing = Thing.new(baz: 42)
 allow(foo).to receive(:bar).and_return(thing)
 ----
-
-[#references-rspecmessagechain]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageChain
 
 [#rspecmessageexpectation]
 == RSpec/MessageExpectation
@@ -3497,11 +3285,6 @@ expect(foo).to receive(:bar)
 | `allow`
 | `allow`, `expect`
 |===
-
-[#references-rspecmessageexpectation]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageExpectation
 
 [#rspecmessagespies]
 == RSpec/MessageSpies
@@ -3565,11 +3348,6 @@ do_something
 | `have_received`, `receive`
 |===
 
-[#references-rspecmessagespies]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MessageSpies
-
 [#rspecmetadatastyle]
 == RSpec/MetadataStyle
 
@@ -3627,11 +3405,6 @@ describe 'Something', a: true
 | `hash`, `symbol`
 |===
 
-[#references-rspecmetadatastyle]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MetadataStyle
-
 [#rspecmissingexamplegroupargument]
 == RSpec/MissingExampleGroupArgument
 
@@ -3667,11 +3440,6 @@ describe "A feature example" do
 end
 ----
 
-[#references-rspecmissingexamplegroupargument]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExampleGroupArgument
-
 [#rspecmissingexpectationtargetmethod]
 == RSpec/MissingExpectationTargetMethod
 
@@ -3705,11 +3473,6 @@ expect(something).to be_a Foo
 is_expected.to eq 42
 expect{something}.to raise_error BarError
 ----
-
-[#references-rspecmissingexpectationtargetmethod]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MissingExpectationTargetMethod
 
 [#rspecmultipledescribes]
 == RSpec/MultipleDescribes
@@ -3748,11 +3511,6 @@ describe MyClass do
   end
 end
 ----
-
-[#references-rspecmultipledescribes]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleDescribes
 
 [#rspecmultipleexpectations]
 == RSpec/MultipleExpectations
@@ -3868,7 +3626,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#expectation-per-example
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleExpectations
 * http://betterspecs.org/#single
 
 [#rspecmultiplememoizedhelpers]
@@ -3996,7 +3753,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#let-blocks
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleMemoizedHelpers
 
 [#rspecmultiplesubjects]
 == RSpec/MultipleSubjects
@@ -4060,11 +3816,6 @@ describe Foo do
   end
 end
 ----
-
-[#references-rspecmultiplesubjects]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/MultipleSubjects
 
 [#rspecnamedsubject]
 == RSpec/NamedSubject
@@ -4185,7 +3936,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#use-subject
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NamedSubject
 
 [#rspecnestedgroups]
 == RSpec/NestedGroups
@@ -4328,11 +4078,6 @@ end
 | Array
 |===
 
-[#references-rspecnestedgroups]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NestedGroups
-
 [#rspecnoexpectationexample]
 == RSpec/NoExpectationExample
 
@@ -4420,11 +4165,6 @@ end
 | Array
 |===
 
-[#references-rspecnoexpectationexample]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NoExpectationExample
-
 [#rspecnottonot]
 == RSpec/NotToNot
 
@@ -4486,11 +4226,6 @@ end
 | `not_to`, `to_not`
 |===
 
-[#references-rspecnottonot]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/NotToNot
-
 [#rspecoverwritingsetup]
 == RSpec/OverwritingSetup
 
@@ -4527,11 +4262,6 @@ let(:foo) { bar }
 let(:baz) { baz }
 let!(:other) { other }
 ----
-
-[#references-rspecoverwritingsetup]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/OverwritingSetup
 
 [#rspecpending]
 == RSpec/Pending
@@ -4579,11 +4309,6 @@ end
 describe MyClass do
 end
 ----
-
-[#references-rspecpending]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Pending
 
 [#rspecpendingwithoutreason]
 == RSpec/PendingWithoutReason
@@ -4656,11 +4381,6 @@ end
 it 'does something', skip: 'reason' do
 end
 ----
-
-[#references-rspecpendingwithoutreason]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PendingWithoutReason
 
 [#rspecpredicatematcher]
 == RSpec/PredicateMatcher
@@ -4770,7 +4490,6 @@ expect(foo.something?).to be_truthy
 === References
 
 * https://rspec.rubystyle.guide/#predicate-matchers
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/PredicateMatcher
 
 [#rspecreceivecounts]
 == RSpec/ReceiveCounts
@@ -4808,11 +4527,6 @@ expect(foo).to receive(:bar).at_least(:twice)
 expect(foo).to receive(:bar).at_most(:once)
 expect(foo).to receive(:bar).at_most(:twice).times
 ----
-
-[#references-rspecreceivecounts]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveCounts
 
 [#rspecreceivemessages]
 == RSpec/ReceiveMessages
@@ -4859,11 +4573,6 @@ before do
 end
 ----
 
-[#references-rspecreceivemessages]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveMessages
-
 [#rspecreceivenever]
 == RSpec/ReceiveNever
 
@@ -4890,11 +4599,6 @@ expect(foo).to receive(:bar).never
 # good
 expect(foo).not_to receive(:bar)
 ----
-
-[#references-rspecreceivenever]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveNever
 
 [#rspecredundantaround]
 == RSpec/RedundantAround
@@ -4923,11 +4627,6 @@ end
 
 # good
 ----
-
-[#references-rspecredundantaround]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RedundantAround
 
 [#rspecredundantpredicatematcher]
 == RSpec/RedundantPredicateMatcher
@@ -4960,11 +4659,6 @@ expect(foo).not_to include(bar)
 expect(foo).to all be(bar)
 ----
 
-[#references-rspecredundantpredicatematcher]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RedundantPredicateMatcher
-
 [#rspecremoveconst]
 == RSpec/RemoveConst
 
@@ -4994,11 +4688,6 @@ before do
   SomeClass.send(:remove_const, :SomeConstant)
 end
 ----
-
-[#references-rspecremoveconst]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RemoveConst
 
 [#rspecrepeateddescription]
 == RSpec/RepeatedDescription
@@ -5054,11 +4743,6 @@ RSpec.describe User do
 end
 ----
 
-[#references-rspecrepeateddescription]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedDescription
-
 [#rspecrepeatedexample]
 == RSpec/RepeatedExample
 
@@ -5087,11 +4771,6 @@ it 'validates the user' do
   expect(user).to be_valid
 end
 ----
-
-[#references-rspecrepeatedexample]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExample
 
 [#rspecrepeatedexamplegroupbody]
 == RSpec/RepeatedExampleGroupBody
@@ -5150,11 +4829,6 @@ context Hash do
 end
 ----
 
-[#references-rspecrepeatedexamplegroupbody]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupBody
-
 [#rspecrepeatedexamplegroupdescription]
 == RSpec/RepeatedExampleGroupDescription
 
@@ -5211,11 +4885,6 @@ context 'when another case' do
   # example group
 end
 ----
-
-[#references-rspecrepeatedexamplegroupdescription]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedExampleGroupDescription
 
 [#rspecrepeatedincludeexample]
 == RSpec/RepeatedIncludeExample
@@ -5277,11 +4946,6 @@ context 'foo' do
 end
 ----
 
-[#references-rspecrepeatedincludeexample]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedIncludeExample
-
 [#rspecrepeatedsubjectcall]
 == RSpec/RepeatedSubjectCall
 
@@ -5325,11 +4989,6 @@ it do
   expect { subject.b }.to not_change { A.count }
 end
 ----
-
-[#references-rspecrepeatedsubjectcall]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RepeatedSubjectCall
 
 [#rspecreturnfromstub]
 == RSpec/ReturnFromStub
@@ -5398,11 +5057,6 @@ allow(Foo).to receive(:bar).and_return(bar.baz)
 | `and_return`, `block`
 |===
 
-[#references-rspecreturnfromstub]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReturnFromStub
-
 [#rspecscatteredlet]
 == RSpec/ScatteredLet
 
@@ -5444,11 +5098,6 @@ describe Foo do
 end
 ----
 
-[#references-rspecscatteredlet]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredLet
-
 [#rspecscatteredsetup]
 == RSpec/ScatteredSetup
 
@@ -5485,11 +5134,6 @@ describe Foo do
   end
 end
 ----
-
-[#references-rspecscatteredsetup]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ScatteredSetup
 
 [#rspecsharedcontext]
 == RSpec/SharedContext
@@ -5557,11 +5201,6 @@ RSpec.shared_context 'only setup here' do
   end
 end
 ----
-
-[#references-rspecsharedcontext]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedContext
 
 [#rspecsharedexamples]
 == RSpec/SharedExamples
@@ -5636,11 +5275,6 @@ include_examples :foo_bar_baz
 | `string`, `symbol`
 |===
 
-[#references-rspecsharedexamples]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples
-
 [#rspecsingleargumentmessagechain]
 == RSpec/SingleArgumentMessageChain
 
@@ -5671,11 +5305,6 @@ allow(foo).to receive(:bar).and_return(42)
 allow(foo).to receive(:bar, :baz)
 allow(foo).to receive("bar.baz")
 ----
-
-[#references-rspecsingleargumentmessagechain]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SingleArgumentMessageChain
 
 [#rspecskipblockinsideexample]
 == RSpec/SkipBlockInsideExample
@@ -5715,11 +5344,6 @@ skip 'not yet implemented' do
 end
 ----
 
-[#references-rspecskipblockinsideexample]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SkipBlockInsideExample
-
 [#rspecsortmetadata]
 == RSpec/SortMetadata
 
@@ -5756,11 +5380,6 @@ it 'works', :a, :b, baz: true, foo: 'bar'
 describe 'Something', 'description', :a, :b, :z
 context 'Something', :z, variable, :a, :b
 ----
-
-[#references-rspecsortmetadata]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SortMetadata
 
 [#rspecspecfilepathformat]
 == RSpec/SpecFilePathFormat
@@ -5856,11 +5475,6 @@ whatever_spec.rb         # describe MyClass, type: :routing do; end
 | 
 |===
 
-[#references-rspecspecfilepathformat]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SpecFilePathFormat
-
 [#rspecspecfilepathsuffix]
 == RSpec/SpecFilePathSuffix
 
@@ -5904,11 +5518,6 @@ spec/models/user.rb       # shared_examples_for 'foo'
 | Array
 |===
 
-[#references-rspecspecfilepathsuffix]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SpecFilePathSuffix
-
 [#rspecstubbedmock]
 == RSpec/StubbedMock
 
@@ -5936,11 +5545,6 @@ expect(foo).to receive(:bar).with(42).and_return("hello world")
 allow(foo).to receive(:bar).with(42).and_return("hello world")
 expect(foo).to receive(:bar).with(42)
 ----
-
-[#references-rspecstubbedmock]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/StubbedMock
 
 [#rspecsubjectdeclaration]
 == RSpec/SubjectDeclaration
@@ -5975,11 +5579,6 @@ let(:subject, &block)
 # good
 subject(:test_subject) { foo }
 ----
-
-[#references-rspecsubjectdeclaration]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectDeclaration
 
 [#rspecsubjectstub]
 == RSpec/SubjectStub
@@ -6042,7 +5641,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#dont-stub-subject
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SubjectStub
 * https://robots.thoughtbot.com/don-t-stub-the-system-under-test
 * https://penelope.zone/2015/12/27/introducing-rspec-smells-and-where-to-find-them.html#smell-1-stubjec
 
@@ -6105,11 +5703,6 @@ it 'does something' do
 end
 ----
 
-[#references-rspecundescriptiveliteralsdescription]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/UndescriptiveLiteralsDescription
-
 [#rspecunspecifiedexception]
 == RSpec/UnspecifiedException
 
@@ -6154,11 +5747,6 @@ expect {
 
 expect { do_something }.not_to raise_error
 ----
-
-[#references-rspecunspecifiedexception]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/UnspecifiedException
 
 [#rspecvariabledefinition]
 == RSpec/VariableDefinition
@@ -6216,11 +5804,6 @@ let('user_name') { 'Adam' }
 | `symbols`
 | `symbols`, `strings`
 |===
-
-[#references-rspecvariabledefinition]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableDefinition
 
 [#rspecvariablename]
 == RSpec/VariableName
@@ -6305,11 +5888,6 @@ let(:userFood_2) { 'fettuccine' }
 | Array
 |===
 
-[#references-rspecvariablename]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VariableName
-
 [#rspecverifieddoublereference]
 == RSpec/VerifiedDoubleReference
 
@@ -6362,7 +5940,6 @@ end
 [#references-rspecverifieddoublereference]
 === References
 
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubleReference
 * https://rspec.info/features/3-12/rspec-mocks/verifying-doubles
 
 [#rspecverifieddoubles]
@@ -6420,7 +5997,6 @@ end
 === References
 
 * https://rspec.rubystyle.guide/#doubles
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VerifiedDoubles
 * https://rspec.info/features/3-12/rspec-mocks/verifying-doubles
 
 [#rspecvoidexpect]
@@ -6450,11 +6026,6 @@ expect(something)
 expect(something).to be(1)
 ----
 
-[#references-rspecvoidexpect]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/VoidExpect
-
 [#rspecyield]
 == RSpec/Yield
 
@@ -6481,8 +6052,3 @@ allow(foo).to receive(:bar) { |&block| block.call(1) }
 # good
 expect(foo).to receive(:bar).and_yield(1)
 ----
-
-[#references-rspecyield]
-=== References
-
-* https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Yield

--- a/lib/rubocop/rspec/config_formatter.rb
+++ b/lib/rubocop/rspec/config_formatter.rb
@@ -7,7 +7,6 @@ module RuboCop
     # Builds a YAML config file from two config hashes
     class ConfigFormatter
       EXTENSION_ROOT_DEPARTMENT = %r{^RSpec/}.freeze
-      COP_DOC_BASE_URL = 'https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/'
 
       def initialize(config, descriptions)
         @config       = config
@@ -27,7 +26,6 @@ module RuboCop
         cops.each_with_object(config.dup) do |cop, unified|
           replace_nil(unified[cop])
           unified[cop].merge!(descriptions.fetch(cop))
-          unified[cop]['Reference'] = reference(cop)
         end
       end
 
@@ -39,10 +37,6 @@ module RuboCop
         config.each do |key, value|
           config[key] = '~' if value.nil?
         end
-      end
-
-      def reference(cop)
-        COP_DOC_BASE_URL + cop
       end
 
       attr_reader :config, :descriptions

--- a/spec/rubocop/rspec/config_formatter_spec.rb
+++ b/spec/rubocop/rspec/config_formatter_spec.rb
@@ -61,20 +61,17 @@ RSpec.describe RuboCop::RSpec::ConfigFormatter do
         Config: 2
         Enabled: true
         Description: Blah
-        Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Foo
 
       RSpec/Bar:
         Enabled: true
         Nullable: ~
         Description: Wow
-        Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Bar
 
       RSpec/Baz:
         Enabled: true
         NegatedMatcher: ~
         StyleGuide: "#buzz"
         Description: Woof
-        Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/Baz
     YAML
   end
 end


### PR DESCRIPTION
On https://docs.rubocop.org/rubocop-rspec/3.5/cops_rspec.html, every cop has a reference section, linking to the same text on rubydoc. It also doesn't render very well, ` for example is just taken as is.

The reference section is intended for style guide urls and other extra reading for specific cops. I don't think linking to rubydoc provides much value, it just dilutes the actual references, so maybe we can just remove them?

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
