### PR TITLE
Only run publish workflow on upstream repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ jobs:
   publish:
     name: Publish to RubyGems
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'rubocop'
     permissions:
       actions: write
       contents: write


### PR DESCRIPTION
When syncing forks, they also try to publish (which doesn't make a lot of sense and doesn't work)

https://github.com/Earlopain/rubocop-rspec/actions/runs/13419581185/job/37488734637