### PR TITLE
Always use `expect_correction` or `expect_no_corrections` when autocorrect is supported

### DIFF
--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        describe MyClass do
+          controller(ApplicationController) do
+            bar = MyClass
+          end
+
+          before do
+            described_class
+
+            Foo.custom_block do
+              MyClass
+            end
+          end
+        end
+      RUBY
     end
   end
 
@@ -42,6 +58,22 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
             Foo.custom_block do
               MyClass
               ^^^^^^^ Use `described_class` instead of `MyClass`.
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        describe MyClass do
+          controller(ApplicationController) do
+            bar = described_class
+          end
+
+          before do
+            described_class
+
+            Foo.custom_block do
+              described_class
             end
           end
         end
@@ -95,6 +127,12 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
                     ^^^^^^^ Use `described_class` instead of `MyClass`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        describe MyClass, some: :metadata do
+          subject { described_class }
+        end
+      RUBY
     end
 
     it 'ignores described class as string' do
@@ -146,6 +184,16 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        describe MyClass do
+          describe MyClass::Foo do
+            subject { described_class }
+
+            let(:foo) { MyClass }
+          end
+        end
+      RUBY
     end
 
     it 'ignores non-matching namespace defined on `describe` level' do
@@ -172,6 +220,12 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
         describe MyNamespace::MyClass do
           subject { MyNamespace::MyClass }
                     ^^^^^^^^^^^^^^^^^^^^ Use `described_class` instead of `MyNamespace::MyClass`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        describe MyNamespace::MyClass do
+          subject { described_class }
         end
       RUBY
     end
@@ -243,6 +297,22 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
                             ^^^^ Use `described_class` instead of `D::E`.
                 let(:ten) { E }
                             ^ Use `described_class` instead of `E`.
+              end
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        module A
+          class B::C
+            module D
+              describe E do
+                subject { described_class }
+                let(:one) { described_class }
+                let(:two) { described_class }
+                let(:six) { described_class }
+                let(:ten) { described_class }
               end
             end
           end

--- a/spec/rubocop/cop/rspec/empty_example_group_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_example_group_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
         end
       end
     RUBY
+
+    expect_correction("\n\n")
   end
 
   it 'ignores example group with examples defined in `if` branches' do
@@ -123,6 +125,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
         end
       end
     RUBY
+
+    expect_correction("\n\n")
   end
 
   it 'ignores example group with examples defined in `case` branches' do
@@ -186,6 +190,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
         end
       end
     RUBY
+
+    expect_correction("\n\n")
   end
 
   it 'ignores example group with examples defined in iterator' do
@@ -222,6 +228,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
         more_surroundings
       end
     RUBY
+
+    expect_correction('')
   end
 
   it 'ignores example group with examples defined in `if` branch ' \
@@ -407,6 +415,8 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyExampleGroup do
         end
       end
     RUBY
+
+    expect_correction('')
   end
 
   context 'when a custom include method is specified' do

--- a/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
+++ b/spec/rubocop/cop/rspec/empty_line_after_example_spec.rb
@@ -99,6 +99,19 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
         it { }
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.context 'foo' do
+        it { }
+        it { }
+
+        it 'does this' do
+        end
+
+        it { }
+        it { }
+      end
+    RUBY
   end
 
   it 'does not register an offense for a comment followed by an empty line' do
@@ -255,6 +268,14 @@ RSpec.describe RuboCop::Cop::RSpec::EmptyLineAfterExample do
         RSpec.describe Foo do
           it { one }
           ^^^^^^^^^^ Add an empty line after `it`.
+          it { two }
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describe Foo do
+          it { one }
+
           it { two }
         end
       RUBY

--- a/spec/rubocop/cop/rspec/example_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/example_wording_spec.rb
@@ -329,6 +329,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
       DESC
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'flags an unclear description' do
@@ -337,6 +339,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
           ^^^^^ Your example description is insufficient.
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'flags an unclear description despite extra spaces' do
@@ -345,6 +349,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
           ^^^^^^^^^^^ Your example description is insufficient.
       end
     RUBY
+
+    expect_no_corrections
   end
 
   it 'flags an unclear description despite uppercase and lowercase strings' do
@@ -353,6 +359,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
           ^^^^^^ Your example description is insufficient.
       end
     RUBY
+
+    expect_no_corrections
   end
 
   context 'when `DisallowedExamples: Workz`' do
@@ -373,6 +381,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
           " " do
         end
       RUBY
+
+      expect_no_corrections
     end
 
     it 'flags an unclear description' do
@@ -381,6 +391,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
             ^^^^^ Your example description is insufficient.
         end
       RUBY
+
+      expect_no_corrections
     end
 
     it 'flags an unclear description despite uppercase and lowercase strings' do
@@ -389,6 +401,8 @@ RSpec.describe RuboCop::Cop::RSpec::ExampleWording do
             ^^^^^^ Your example description is insufficient.
         end
       RUBY
+
+      expect_no_corrections
     end
   end
 end

--- a/spec/rubocop/cop/rspec/expect_change_spec.rb
+++ b/spec/rubocop/cop/rspec/expect_change_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
                          ^^^^^^^^^^^^^^^^^^^^^ Prefer `change(User, :count)`.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        it do
+          expect(run).to change(User, :count).by(1)
+        end
+      RUBY
     end
 
     it 'ignores the usage that adheres to the enforced style' do
@@ -254,6 +260,12 @@ RSpec.describe RuboCop::Cop::RSpec::ExpectChange do
         it do
           expect(run).to change(User, :count).by(1)
                          ^^^^^^^^^^^^^^^^^^^^ Prefer `change { User.count }`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it do
+          expect(run).to change { User.count }.by(1)
         end
       RUBY
     end

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -257,6 +257,13 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           expect(foo).to have_something
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `has_something?` over `have_something` matcher.
         RUBY
+
+        expect_correction(<<~RUBY)
+          expect(foo.empty?).to #{matcher_true}
+          expect(foo.empty?).to #{matcher_true}, 'fail'
+          expect(foo.empty?).to #{matcher_false}
+          expect(foo.has_something?).to #{matcher_true}
+        RUBY
       end
 
       it 'registers an offense for a predicate mather with argument' do
@@ -265,6 +272,11 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
           expect(foo).to have_key(1)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `has_key?` over `have_key` matcher.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect(foo.something?(1, 2)).to #{matcher_true}
+          expect(foo.has_key?(1)).to #{matcher_true}
         RUBY
       end
 
@@ -278,6 +290,13 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `all?` over `be_all` matcher.
           expect(foo).to be_something(x) { |y| y.present? }
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `something?` over `be_something` matcher.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          expect(foo.all?(&:present?)).to #{matcher_true}
+          expect(foo.all? { |x| x.present? }).to #{matcher_true}
+          expect(foo.all? { present }).to #{matcher_true}
+          expect(foo.something?(x) { |y| y.present? }).to #{matcher_true}
         RUBY
       end
 

--- a/spec/rubocop/cop/rspec/return_from_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/return_from_stub_spec.rb
@@ -218,6 +218,12 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
                                       ^^^^^^^^^^ Use block for static values.
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        it do
+          allow(Foo).to receive(:bar) { 42 }
+        end
+      RUBY
     end
 
     it 'registers an offense for static values returned from chained method' do
@@ -225,6 +231,12 @@ RSpec.describe RuboCop::Cop::RSpec::ReturnFromStub do
         it do
           allow(Foo).to receive(:bar).with(1).and_return(42)
                                               ^^^^^^^^^^ Use block for static values.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it do
+          allow(Foo).to receive(:bar).with(1) { 42 }
         end
       RUBY
     end

--- a/spec/rubocop/cop/rspec/sort_metadata_spec.rb
+++ b/spec/rubocop/cop/rspec/sort_metadata_spec.rb
@@ -269,6 +269,16 @@ RSpec.describe RuboCop::Cop::RSpec::SortMetadata do
           end
         end
       RUBY
+
+      expect_correction(<<~RUBY)
+        RSpec.describan "Algo", :a, :b do
+          contexto_compartido 'una situación complicada', baz: true, foo: 'bar' do
+          end
+
+          ejemplo "hablando español", baz: true, foo: 'bar' do
+          end
+        end
+      RUBY
     end
   end
 end


### PR DESCRIPTION
In https://github.com/rubocop/rubocop/pull/13183 I want to add a cop that enforces this automatically. This fixes offenses here in anticipation of that.