### PR TITLE
Fix a false positive for `RSpec/DescribedClass` when `SkipBlocks` is true and numblocks are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add new `RSpec/IncludeExamples` cop to enforce using `it_behaves_like` over `include_examples`. ([@dvandersluis])
 - Change `RSpec/ScatteredSetup` to allow `around` hooks to be scattered. ([@ydah])
 - Fix an error `RSpec/ChangeByZero` cop when without expect block. ([@lee266])
+- Fix a false positive for `RSpec/DescribedClass` when `SkipBlocks` is true and numblocks are used. ([@earlopain])
 
 ## 3.5.0 (2025-02-16)
 

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -153,7 +153,9 @@ module RuboCop
         end
 
         def skippable_block?(node)
-          node.block_type? && !rspec_block?(node) && cop_config['SkipBlocks']
+          return false unless cop_config['SkipBlocks']
+
+          node.any_block_type? && !rspec_block?(node)
         end
 
         def only_static_constants?

--- a/spec/rubocop/cop/rspec/described_class_spec.rb
+++ b/spec/rubocop/cop/rspec/described_class_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       expect_offense(<<~RUBY)
         describe MyClass do
           controller(ApplicationController) do
-            bar = MyClass
+            self.bar = MyClass
           end
 
           before do
@@ -27,13 +27,34 @@ RSpec.describe RuboCop::Cop::RSpec::DescribedClass do
       expect_correction(<<~RUBY)
         describe MyClass do
           controller(ApplicationController) do
-            bar = MyClass
+            self.bar = MyClass
           end
 
           before do
             described_class
 
             Foo.custom_block do
+              MyClass
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'ignores offenses within non-rspec numblocks' do
+      expect_offense(<<~RUBY)
+        describe MyClass do
+          controller(ApplicationController) do
+            do_some_work(_1)
+            self.bar = MyClass
+          end
+
+          before do
+            MyClass
+            ^^^^^^^ Use `described_class` instead of `MyClass`.
+
+            Foo.custom_block do
+              do_some_work(_1)
               MyClass
             end
           end


### PR DESCRIPTION
I will probably make a few more of these. I don't particularly care about numblocks, this just future-proofs it for `itblock`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

