### PR TITLE
Fix current RuboCop offense

### DIFF
--- a/lib/rubocop/rspec/hook.rb
+++ b/lib/rubocop/rspec/hook.rb
@@ -64,7 +64,9 @@ module RuboCop
       end
 
       def transform_true(node)
-        node.true_type? ? true : node
+        return true if node.true_type?
+
+        node
       end
 
       def scope_name


### PR DESCRIPTION
Autocorrect would have been `node.true_type? || node` but I don't think that preserves the intention

```
$ bundle exec rubocop
Inspecting 278 files
........................................................................................................................................C.............................................................................................................................................

Offenses:

lib/rubocop/rspec/hook.rb:67:25: C: [Correctable] Style/RedundantCondition: Use double pipes || instead.
        node.true_type? ? true : node
                        ^^^^^^^^

278 files inspected, 1 offense detected, 1 offense autocorrectable
```
