### PR TITLE
Fix rubocop offense

### DIFF
--- a/lib/rubocop/rspec/hook.rb
+++ b/lib/rubocop/rspec/hook.rb
@@ -64,7 +64,7 @@ module RuboCop
       end
 
       def transform_true(node)
-        node.true_type? ? true : node
+        node.true_type? || node
       end
 
       def scope_name


### PR DESCRIPTION
```
❯ bundle exec rubocop -A
Inspecting 278 files
........................................................................................................................................C.............................................................................................................................................

Offenses:

lib/rubocop/rspec/hook.rb:67:25: C: [Corrected] Style/RedundantCondition: Use double pipes || instead.
        node.true_type? ? true : node
                        ^^^^^^^^

278 files inspected, 1 offense detected, 1 offense corrected
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
