### PR TITLE
RSpec/ContextWording: Detect non-string in Prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Fix false positive in `RSpec/Pending`, where it would mark the default block `it` as an offense. ([@bquorning])
+- Fix issue when `Style/ContextWording` is configured with a Prefix being interpreted as a boolean, like `on`. ([@sakuro])
 
 ## 3.5.0 (2025-02-16)
 
@@ -1040,6 +1041,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@rrosenblum]: https://github.com/rrosenblum
 [@rspeicher]: https://github.com/rspeicher
 [@rst-j]: https://github.com/RST-J
+[@sakuro]: https://github.com/sakuro
 [@samrjenkins]: https://github.com/samrjenkins
 [@schmijos]: https://github.com/schmijos
 [@seanpdoyle]: https://github.com/seanpdoyle

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -115,7 +115,12 @@ module RuboCop
         end
 
         def prefixes
-          Array(cop_config.fetch('Prefixes', []))
+          Array(cop_config.fetch('Prefixes', [])).tap do |prefixes|
+            non_strings = prefixes.reject { |pre| pre.is_a?(String) }
+            unless non_strings.empty?
+              raise "Non-string prefixes #{non_strings.inspect} detected."
+            end
+          end
         end
       end
     end

--- a/spec/rubocop/cop/rspec/context_wording_spec.rb
+++ b/spec/rubocop/cop/rspec/context_wording_spec.rb
@@ -228,4 +228,38 @@ RSpec.describe RuboCop::Cop::RSpec::ContextWording do
       RUBY
     end
   end
+
+  context 'when `Prefixes: [on]' do
+    let(:cop_config) do
+      YAML.safe_load(<<-CONFIG)
+        Prefixes:
+          - on # evaluates to true
+      CONFIG
+    end
+
+    it 'fails' do
+      expect do
+        expect_no_offenses(<<~RUBY)
+          context 'on Linux' do
+          end
+        RUBY
+      end.to raise_error(/Non-string prefixes .+ detected/)
+    end
+  end
+
+  context 'when `Prefixes: ["on"]' do
+    let(:cop_config) do
+      YAML.safe_load(<<-CONFIG)
+        Prefixes:
+          - "on"
+      CONFIG
+    end
+
+    it 'does not fail' do
+      expect { expect_no_offenses(<<~RUBY) }.not_to raise_error
+        context 'on Linux' do
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2051

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
