### PR TITLE
Fix false positive in RSpec/Pending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix false positive in `RSpec/Pending`, where it would mark the default block `it` as an offense. ([@bquorning])
+
 ## 3.5.0 (2025-02-16)
 
 - Don't let `RSpec/PredicateMatcher` replace `respond_to?` with two arguments with the RSpec `respond_to` matcher. ([@bquorning])

--- a/lib/rubocop/cop/rspec/pending.rb
+++ b/lib/rubocop/cop/rspec/pending.rb
@@ -47,7 +47,7 @@ module RuboCop
 
         # @!method skippable_example?(node)
         def_node_matcher :skippable_example?, <<~PATTERN
-          (send nil? #Examples.regular ...)
+          (send nil? #Examples.regular _ ...)
         PATTERN
 
         # @!method pending_block?(node)

--- a/spec/rubocop/cop/rspec/pending_spec.rb
+++ b/spec/rubocop/cop/rspec/pending_spec.rb
@@ -225,4 +225,12 @@ RSpec.describe RuboCop::Cop::RSpec::Pending do
       subject { Project.pending }
     RUBY
   end
+
+  it 'ignores default block parameter' do
+    expect_no_offenses(<<~RUBY)
+      expect(
+        foo.map { it.reverse }
+      ).to include(:bar)
+    RUBY
+  end
 end


### PR DESCRIPTION
Let `#skippable_example?` only return true if at least one argument is being passed to the `it` call.

Fixes #2053

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
