### PR TITLE
Add explanation for ExpectChange unsafe autocorrection

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2125,10 +2125,31 @@ expect(false).to eq(true)
 
 Checks for consistent style of change matcher.
 
-Enforces either passing object and attribute as arguments to the matcher
-or passing a block that reads the attribute value.
+Enforces either passing a receiver and message as method arguments,
+or a block.
 
 This cop can be configured using the `EnforcedStyle` option.
+
+[#safety-rspecexpectchange]
+=== Safety
+
+Autocorrection is unsafe because `method_call` style calls the
+receiver *once* and sends the message to it before and after
+calling the `expect` block, whereas `block` style calls the
+expression *twice*, including the receiver.
+
+If your receiver is dynamic (e.g., the result of a method call) and
+you expect it to be called before and after the `expect` block,
+changing from `block` to `method_call` style may break your test.
+
+[source,ruby]
+----
+expect { run }.to change { my_method.message }
+# `my_method` is called before and after `run`
+
+expect { run }.to change(my_method, :message)
+# `my_method` is called once, but `message` is called on it twice
+----
 
 [#examples-rspecexpectchange]
 === Examples

--- a/lib/rubocop/cop/rspec/expect_change.rb
+++ b/lib/rubocop/cop/rspec/expect_change.rb
@@ -5,10 +5,29 @@ module RuboCop
     module RSpec
       # Checks for consistent style of change matcher.
       #
-      # Enforces either passing object and attribute as arguments to the matcher
-      # or passing a block that reads the attribute value.
+      # Enforces either passing a receiver and message as method arguments,
+      # or a block.
       #
       # This cop can be configured using the `EnforcedStyle` option.
+      #
+      # @safety
+      #   Autocorrection is unsafe because `method_call` style calls the
+      #   receiver *once* and sends the message to it before and after
+      #   calling the `expect` block, whereas `block` style calls the
+      #   expression *twice*, including the receiver.
+      #
+      #   If your receiver is dynamic (e.g., the result of a method call) and
+      #   you expect it to be called before and after the `expect` block,
+      #   changing from `block` to `method_call` style may break your test.
+      #
+      #   [source,ruby]
+      #   ----
+      #   expect { run }.to change { my_method.message }
+      #   # `my_method` is called before and after `run`
+      #
+      #   expect { run }.to change(my_method, :message)
+      #   # `my_method` is called once, but `message` is called on it twice
+      #   ----
       #
       # @example `EnforcedStyle: method_call` (default)
       #   # bad


### PR DESCRIPTION
https://github.com/rubocop/rubocop-rspec/pull/1178 marked `RSpec/ExpectChange`'s autocorrection as unsafe, but it didn't update the docs. This PR adds an explanation for the cop's unsafe autocorrection. 

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
