### PR TITLE
Update `RSpec/SharedExamples` to allow specifying a preferred method to use for defining and including shared examples and context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix false positive in `RSpec/Pending`, where it would mark the default block `it` as an offense. ([@bquorning])
 - Fix issue when `Style/ContextWording` is configured with a Prefix being interpreted as a boolean, like `on`. ([@sakuro])
+- Update `RSpec/SharedExamples` to allow specifying a preferred method to use for defining and including shared examples and context. ([@dvandersluis])
 
 ## 3.5.0 (2025-02-16)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -876,14 +876,18 @@ RSpec/SharedContext:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedContext
 
 RSpec/SharedExamples:
-  Description: Checks for consistent style for shared example names.
+  Description: Checks for consistent style for shared examples.
   Enabled: true
   EnforcedStyle: string
   SupportedStyles:
     - string
     - symbol
+  PreferredExamplesMethod: ~
+  PreferredContextMethod: ~
+  PreferredIncludeExamplesMethod: ~
+  PreferredIncludeContextMethod: ~
   VersionAdded: '1.25'
-  VersionChanged: '2.26'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SharedExamples
 
 RSpec/SingleArgumentMessageChain:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5573,14 +5573,30 @@ end
 | Yes
 | Always
 | 1.25
-| 2.26
+| <<next>>
 |===
 
-Checks for consistent style for shared example names.
+Checks for consistent style for shared examples.
 
-Enforces either `string` or `symbol` for shared example names.
+Enforces either `string` or `symbol` for shared example names. This
+can be configured using the `EnforcedStyle` option.
 
-This cop can be configured using the `EnforcedStyle` option
+Can also be used to enforce the preferred method name to use for
+defining and including shared examples and contexts. Each can get a
+different value.
+
+[source,yaml]
+----
+RSpec/SharedExamples:
+  PreferredExamplesMethod: shared_examples
+  PreferredContextMethod: shared_context
+  PreferredIncludeExamplesMethod: it_behaves_like
+  PreferredIncludeContextMethod: include_context
+----
+
+By default, no preference is set, so any methods provided in the
+`Language/SharedGroups` and `Language/Includes` configuration are
+allowed.
 
 [#examples-rspecsharedexamples]
 === Examples
@@ -5634,6 +5650,22 @@ include_examples :foo_bar_baz
 | EnforcedStyle
 | `string`
 | `string`, `symbol`
+
+| PreferredExamplesMethod
+| `<none>`
+| 
+
+| PreferredContextMethod
+| `<none>`
+| 
+
+| PreferredIncludeExamplesMethod
+| `<none>`
+| 
+
+| PreferredIncludeContextMethod
+| `<none>`
+| 
 |===
 
 [#references-rspecsharedexamples]

--- a/spec/rubocop/cop/rspec/shared_examples_spec.rb
+++ b/spec/rubocop/cop/rspec/shared_examples_spec.rb
@@ -164,4 +164,111 @@ RSpec.describe RuboCop::Cop::RSpec::SharedExamples do
       end
     end
   end
+
+  context 'with preferred methods' do
+    shared_examples 'preferred method unset' do |config_key, methods|
+      context "when #{config_key} is unset" do
+        let(:config_val) { nil }
+
+        methods.each do |method|
+          it "does not register an offense for `#{method}`" do
+            expect_no_offenses(<<~RUBY)
+              #{method} 'desc'
+            RUBY
+          end
+        end
+
+        it 'does not register an offense for another method' do
+          expect_no_offenses(<<~RUBY)
+            describe
+          RUBY
+        end
+      end
+    end
+
+    shared_examples 'preferred method set' do |config_key, methods, preferred|
+      context "when #{config_key} is set" do
+        let(:config_val) { preferred }
+
+        it "does not register an offense for `#{preferred}`" do
+          expect_no_offenses(<<~RUBY)
+            #{preferred} 'desc'
+          RUBY
+        end
+
+        (methods - [preferred]).each do |method|
+          it "registers an offense and corrects for #{method}" do
+            expect_offense(<<~RUBY, method: method, preferred: preferred)
+              %{method} 'desc'
+              ^{method} Prefer `%{preferred}` over `%{method}`.
+            RUBY
+
+            expect_correction(<<~RUBY)
+              #{preferred} 'desc'
+            RUBY
+          end
+        end
+
+        it 'does not register an offense for another method' do
+          expect_no_offenses(<<~RUBY)
+            describe
+          RUBY
+        end
+
+        it 'registers offenses and corrects for both issues ' \
+           'when `EnforcedStyle` also offends' do
+          method = (methods - [preferred]).first
+          expect_offense(<<~RUBY, method: method, preferred: preferred)
+            %{method} :desc
+            ^{method} Prefer `%{preferred}` over `%{method}`.
+            _{method} ^^^^^ Prefer 'desc' over `:desc` to titleize shared examples.
+          RUBY
+
+          expect_correction(<<~RUBY)
+            #{preferred} 'desc'
+          RUBY
+        end
+      end
+    end
+
+    shared_examples 'preferred method' do |config_key, methods, preferred|
+      context "with #{config_key}" do
+        let(:cop_config) do
+          { 'EnforcedStyle' => 'string', config_key => config_val }
+        end
+
+        it_behaves_like 'preferred method unset', config_key, methods
+        it_behaves_like 'preferred method set', config_key, methods, preferred
+      end
+    end
+
+    before do
+      # Set up custom aliases
+      other_cops.dig('RSpec', 'Language', 'SharedGroups', 'Examples')
+        .push('shared_scenarios')
+      other_cops.dig('RSpec', 'Language', 'SharedGroups', 'Context')
+        .push('shared_state')
+      other_cops.dig('RSpec', 'Language', 'Includes', 'Examples')
+        .push('include_scenarios')
+      other_cops.dig('RSpec', 'Language', 'Includes', 'Context')
+        .push('include_state')
+    end
+
+    it_behaves_like 'preferred method', 'PreferredExamplesMethod',
+                    %w[shared_examples shared_examples_for shared_scenarios],
+                    'shared_scenarios'
+
+    it_behaves_like 'preferred method', 'PreferredContextMethod',
+                    %w[shared_context shared_state],
+                    'shared_state'
+
+    it_behaves_like 'preferred method', 'PreferredIncludeExamplesMethod',
+                    %w[it_behaves_like it_should_behave_like include_examples
+                       include_scenarios],
+                    'include_scenarios'
+
+    it_behaves_like 'preferred method', 'PreferredIncludeContextMethod',
+                    %w[include_context include_state],
+                    'include_state'
+  end
 end


### PR DESCRIPTION
Allows `RSpec/SharedExamples` to be configured with preferred methods for defining and including shared examples and context, so that consistency can be enforced.

Follows rubocop/rubocop#14033.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
