### PR TITLE
Fix `Style/RedundantParentheses` offense on edge rubocop

### DIFF
--- a/lib/rubocop/cop/rspec/nested_groups.rb
+++ b/lib/rubocop/cop/rspec/nested_groups.rb
@@ -133,8 +133,8 @@ module RuboCop
 
         def count_up_nesting?(node, example_group)
           example_group &&
-            (node.block_type? &&
-            !allowed_groups.include?(node.method_name.to_s))
+            node.block_type? &&
+            !allowed_groups.include?(node.method_name.to_s)
         end
 
         def message(nesting)


### PR DESCRIPTION
Follows https://github.com/rubocop/rubocop/pull/14024.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
