### PR TITLE
Improve PredicateMatcher recommendations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix false positive in `RSpec/Pending`, where it would mark the default block `it` as an offense. ([@bquorning])
 - Fix issue when `Style/ContextWording` is configured with a Prefix being interpreted as a boolean, like `on`. ([@sakuro])
 - Add new `RSpec/IncludeExamples` cop to enforce using `it_behaves_like` over `include_examples`. ([@dvandersluis])
+- Fix `RSpec/PredicateMatcher` sometimes suggesting the `be_key` matcher instead of `have_key`. ([@bquorning])
 
 ## 3.5.0 (2025-02-16)
 

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -75,6 +75,7 @@ module RuboCop
           include?:     'include',
           instance_of?: 'be_an_instance_of',
           is_a?:        'be_a',
+          key?:         'have_key',
           respond_to?:  'respond_to'
         }.freeze
         private_constant :TO_PREDICATE_MATCHER_MAP

--- a/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/predicate_matcher_spec.rb
@@ -91,6 +91,8 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `be_something` matcher over `something?`.
           expect(foo.has_key?('foo')).to be_truthy
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `have_key` matcher over `has_key?`.
+          expect(foo.key?('foo')).to be_truthy
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `have_key` matcher over `key?`.
           expect(foo.is_a?(Array)).to be_truthy
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer using `be_a` matcher over `is_a?`.
           expect(foo.instance_of?(Array)).to be_truthy
@@ -102,6 +104,7 @@ RSpec.describe RuboCop::Cop::RSpec::PredicateMatcher do
           expect(foo).to be_something('foo'), 'fail'
           expect(foo).to be_something('foo', 'bar')
           expect(foo).to be_something 1, 2
+          expect(foo).to have_key('foo')
           expect(foo).to have_key('foo')
           expect(foo).to be_a(Array)
           expect(foo).to be_an_instance_of(Array)


### PR DESCRIPTION
PredicateMatcher should not recommend changing `#key?` to `be_key`, but will now instead suggest using `have_key`.

Fixes #2067

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
