### PR TITLE
RSpec/SpecFilePathFormat allow multiple values for same key in IgnoreMetadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix false positive in `RSpec/Pending`, where it would mark the default block `it` as an offense. ([@bquorning])
 - Fix issue when `Style/ContextWording` is configured with a Prefix being interpreted as a boolean, like `on`. ([@sakuro])
 - Add new `RSpec/IncludeExamples` cop to enforce using `it_behaves_like` over `include_examples`. ([@dvandersluis])
+- Change `RSpec/ScatteredSetup` to allow `around` hooks to be scattered. ([@ydah])
 
 ## 3.5.0 (2025-02-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Fix false positive in `RSpec/Pending`, where it would mark the default block `it` as an offense. ([@bquorning])
 - Fix issue when `Style/ContextWording` is configured with a Prefix being interpreted as a boolean, like `on`. ([@sakuro])
 - Add new `RSpec/IncludeExamples` cop to enforce using `it_behaves_like` over `include_examples`. ([@dvandersluis])
-- Change `RSpec/ScatteredSetup` to allow `around` hooks to be scattered. ([@ydah])
 - Fix an error `RSpec/ChangeByZero` cop when without expect block. ([@lee266])
 
 ## 3.5.0 (2025-02-16)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix issue when `Style/ContextWording` is configured with a Prefix being interpreted as a boolean, like `on`. ([@sakuro])
 - Add new `RSpec/IncludeExamples` cop to enforce using `it_behaves_like` over `include_examples`. ([@dvandersluis])
 - Change `RSpec/ScatteredSetup` to allow `around` hooks to be scattered. ([@ydah])
+- Fix an error `RSpec/ChangeByZero` cop when without expect block. ([@lee266])
 
 ## 3.5.0 (2025-02-16)
 
@@ -1003,6 +1004,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@krororo]: https://github.com/krororo
 [@kuahyeow]: https://github.com/kuahyeow
 [@lazycoder9]: https://github.com/lazycoder9
+[@lee266]: https://github.com/lee266
 [@leoarnold]: https://github.com/leoarnold
 [@liberatys]: https://github.com/Liberatys
 [@lokhi]: https://github.com/lokhi

--- a/config/default.yml
+++ b/config/default.yml
@@ -925,6 +925,7 @@ RSpec/SpecFilePathFormat:
   IgnoreMetadata:
     type: routing
   VersionAdded: '2.24'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SpecFilePathFormat
 
 RSpec/SpecFilePathSuffix:

--- a/config/default.yml
+++ b/config/default.yml
@@ -925,7 +925,6 @@ RSpec/SpecFilePathFormat:
   IgnoreMetadata:
     type: routing
   VersionAdded: '2.24'
-  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/SpecFilePathFormat
 
 RSpec/SpecFilePathSuffix:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5524,7 +5524,9 @@ end
 
 Checks for setup scattered across multiple hooks in an example group.
 
-Unify `before`, `after`, and `around` hooks when possible.
+Unify `before` and `after` hooks when possible.
+However, `around` hooks are allowed to be defined multiple times,
+as unifying them would typically make the code harder to read.
 
 [#examples-rspecscatteredsetup]
 === Examples
@@ -5543,6 +5545,12 @@ describe Foo do
     setup1
     setup2
   end
+end
+
+# good
+describe Foo do
+  around { |example| before1; example.call; after1 }
+  around { |example| before2; example.call; after2 }
 end
 ----
 

--- a/lib/rubocop/cop/rspec/change_by_zero.rb
+++ b/lib/rubocop/cop/rspec/change_by_zero.rb
@@ -102,6 +102,8 @@ module RuboCop
         private
 
         def register_offense(node, change_node)
+          return unless node.parent.send_type?
+
           if compound_expectations?(node)
             add_offense(node,
                         message: message_compound(change_node)) do |corrector|
@@ -116,8 +118,7 @@ module RuboCop
         end
 
         def compound_expectations?(node)
-          node.parent.send_type? &&
-            %i[and or & |].include?(node.parent.method_name)
+          %i[and or & |].include?(node.parent.method_name)
         end
 
         def message(change_node)

--- a/lib/rubocop/cop/rspec/empty_example_group.rb
+++ b/lib/rubocop/cop/rspec/empty_example_group.rb
@@ -137,7 +137,7 @@ module RuboCop
         PATTERN
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler
-          return if node.each_ancestor(:def, :defs).any?
+          return if node.each_ancestor(:any_def).any?
           return if node.each_ancestor(:block).any? { |block| example?(block) }
 
           example_group_body(node) do |body|

--- a/lib/rubocop/cop/rspec/focus.rb
+++ b/lib/rubocop/cop/rspec/focus.rb
@@ -73,7 +73,7 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          return if node.chained? || node.each_ancestor(:def, :defs).any?
+          return if node.chained? || node.each_ancestor(:any_def).any?
 
           if focused_block?(node)
             on_focused_block(node)

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -32,6 +32,11 @@ module RuboCop
       #   # good
       #   whatever_spec.rb         # describe MyClass, type: :routing do; end
       #
+      # @example `IgnoreMetadata: {type=>[routing,models]}` (default)
+      #   # good
+      #   whatever_spec.rb         # describe MyClass, type: :routing do; end
+      #   whatever_spec.rb         # describe MyClass, type: :models do; end
+      #
       class SpecFilePathFormat < Base
         include TopLevelGroup
         include Namespace
@@ -73,7 +78,10 @@ module RuboCop
         def ignore_metadata?(arguments)
           arguments.any? do |argument|
             metadata_key_value(argument).any? do |key, value|
-              ignore_metadata.values_at(key.to_s).include?(value.to_s)
+              ignore_values = ignore_metadata[key.to_s]
+              ignore_values = [ignore_values] unless ignore_values.is_a?(Array)
+
+              ignore_values.include?(value.to_s)
             end
           end
         end

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -78,8 +78,7 @@ module RuboCop
         def ignore_metadata?(arguments)
           arguments.any? do |argument|
             metadata_key_value(argument).any? do |key, value|
-              ignore_values = ignore_metadata[key.to_s]
-              ignore_values = [ignore_values] unless ignore_values.is_a?(Array)
+              ignore_values = Array(ignore_metadata[key.to_s])
 
               ignore_values.include?(value.to_s)
             end

--- a/spec/rubocop/cop/rspec/change_by_zero_spec.rb
+++ b/spec/rubocop/cop/rspec/change_by_zero_spec.rb
@@ -366,4 +366,12 @@ RSpec.describe RuboCop::Cop::RSpec::ChangeByZero do
       end
     RUBY
   end
+
+  it 'does not register an offense when without expect block' do
+    expect_no_offenses(<<~RUBY)
+      it do
+        change(foo, :bar).by(0)
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -58,6 +58,15 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
     RUBY
   end
 
+  it 'ignores around hooks' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        around { bar }
+        around { baz }
+      end
+    RUBY
+  end
+
   it 'ignores different hooks' do
     expect_no_offenses(<<~RUBY)
       describe Foo do

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -281,4 +281,14 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
       RUBY
     end
   end
+
+  context 'when configured with `IgnoreMetadata: { "foo" => ["bar"] }`' do
+    let(:cop_config) { { 'IgnoreMetadata' => { 'foo' => ['bar'] } } }
+
+    it 'does not register an offense when include ignored metadata' do
+      expect_no_offenses(<<~RUBY, 'wrong_class_spec.rb')
+        describe MyClass, foo: :bar do; end
+      RUBY
+    end
+  end
 end

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -282,12 +282,33 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     end
   end
 
-  context 'when configured with `IgnoreMetadata: { "foo" => ["bar"] }`' do
-    let(:cop_config) { { 'IgnoreMetadata' => { 'foo' => ['bar'] } } }
+  context \
+    'when configured with `IgnoreMetadata: { "foo" => ["bar", "baz"] }`' do
+    let(:cop_config) { { 'IgnoreMetadata' => { 'foo' => %w[bar baz] } } }
 
-    it 'does not register an offense when include ignored metadata' do
+    it 'registers no offense when including an ignored metadata value' do
       expect_no_offenses(<<~RUBY, 'wrong_class_spec.rb')
         describe MyClass, foo: :bar do; end
+      RUBY
+    end
+
+    it 'registers no offense when including another ignored metadata value' do
+      expect_no_offenses(<<~RUBY, 'wrong_class_spec.rb')
+        describe MyClass, foo: :baz do; end
+      RUBY
+    end
+
+    it 'registers an offense when the metadata is not to be ignored' do
+      expect_offense(<<~RUBY, 'wrong_class_spec.rb')
+        describe MyClass, foo: :quux do; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
+      RUBY
+    end
+
+    it 'registers an offense when no metadata is present' do
+      expect_offense(<<~RUBY, 'wrong_class_spec.rb')
+        describe MyClass do; end
+        ^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
       RUBY
     end
   end


### PR DESCRIPTION
RSpec/SpecFilePathFormat allows ignoring certain values in rspec metadata through the IgnoreMetadata option, as given in the documentation:

```
      # @example `IgnoreMetadata: {type=>routing}` (default)
      #   # good
      #   whatever_spec.rb         # describe MyClass, type: :routing do; end
```

However the current implementation does not seem to allow supplying multiple values for the same key - e.g. if you have some specs marked `type: controller`, others as `type: :model`  etc, only one of `controller`, `model`, ... can be supplied to be ignored.

This is probably due to an oversight (or me not being able to figure out how to properly supply an array of values to be ignored).

The PR allows for either an array or a single value to be given for a key in the IgnoreMetadata option.

While it would also be desirable to give a `true` value to ignore all metadata, in the format that `IgnoreMethods` use, this should probably be part of a different PR.