### PR TITLE
Change `RSpec/ScatteredSetup` to allow `around` hooks to be scattered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix false positive in `RSpec/Pending`, where it would mark the default block `it` as an offense. ([@bquorning])
 - Fix issue when `Style/ContextWording` is configured with a Prefix being interpreted as a boolean, like `on`. ([@sakuro])
 - Add new `RSpec/IncludeExamples` cop to enforce using `it_behaves_like` over `include_examples`. ([@dvandersluis])
+- Change `RSpec/ScatteredSetup` to allow `around` hooks to be scattered. ([@ydah])
 
 ## 3.5.0 (2025-02-16)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5524,7 +5524,9 @@ end
 
 Checks for setup scattered across multiple hooks in an example group.
 
-Unify `before`, `after`, and `around` hooks when possible.
+Unify `before` and `after` hooks when possible.
+However, `around` hooks are allowed to be defined multiple times,
+as unifying them would typically make the code harder to read.
 
 [#examples-rspecscatteredsetup]
 === Examples
@@ -5543,6 +5545,12 @@ describe Foo do
     setup1
     setup2
   end
+end
+
+# good
+describe Foo do
+  around { |example| before1; example.call; after1 }
+  around { |example| before2; example.call; after2 }
 end
 ----
 

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -58,6 +58,15 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
     RUBY
   end
 
+  it 'ignores around hooks' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        around { bar }
+        around { baz }
+      end
+    RUBY
+  end
+
   it 'ignores different hooks' do
     expect_no_offenses(<<~RUBY)
       describe Foo do


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rspec/issues/1943

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
