### PR TITLE
RSpec/SpecFilePathFormat allow multiple values for same key in IgnoreMetadata

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5897,6 +5897,16 @@ my_class_spec.rb         # describe MyClass, '#method'
 whatever_spec.rb         # describe MyClass, type: :routing do; end
 ----
 
+[#_ignoremetadata_-_type___routing_models___-_default_-rspecspecfilepathformat]
+==== `IgnoreMetadata: {type=>[routing,models]}` (default)
+
+[source,ruby]
+----
+# good
+whatever_spec.rb         # describe MyClass, type: :routing do; end
+whatever_spec.rb         # describe MyClass, type: :models do; end
+----
+
 [#configurable-attributes-rspecspecfilepathformat]
 === Configurable attributes
 

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -32,6 +32,11 @@ module RuboCop
       #   # good
       #   whatever_spec.rb         # describe MyClass, type: :routing do; end
       #
+      # @example `IgnoreMetadata: {type=>[routing,models]}` (default)
+      #   # good
+      #   whatever_spec.rb         # describe MyClass, type: :routing do; end
+      #   whatever_spec.rb         # describe MyClass, type: :models do; end
+      #
       class SpecFilePathFormat < Base
         include TopLevelGroup
         include Namespace
@@ -73,7 +78,9 @@ module RuboCop
         def ignore_metadata?(arguments)
           arguments.any? do |argument|
             metadata_key_value(argument).any? do |key, value|
-              ignore_metadata.values_at(key.to_s).include?(value.to_s)
+              ignore_values = Array(ignore_metadata[key.to_s])
+
+              ignore_values.include?(value.to_s)
             end
           end
         end

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -281,4 +281,35 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
       RUBY
     end
   end
+
+  context \
+    'when configured with `IgnoreMetadata: { "foo" => ["bar", "baz"] }`' do
+    let(:cop_config) { { 'IgnoreMetadata' => { 'foo' => %w[bar baz] } } }
+
+    it 'registers no offense when including an ignored metadata value' do
+      expect_no_offenses(<<~RUBY, 'wrong_class_spec.rb')
+        describe MyClass, foo: :bar do; end
+      RUBY
+    end
+
+    it 'registers no offense when including another ignored metadata value' do
+      expect_no_offenses(<<~RUBY, 'wrong_class_spec.rb')
+        describe MyClass, foo: :baz do; end
+      RUBY
+    end
+
+    it 'registers an offense when the metadata is not to be ignored' do
+      expect_offense(<<~RUBY, 'wrong_class_spec.rb')
+        describe MyClass, foo: :quux do; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
+      RUBY
+    end
+
+    it 'registers an offense when no metadata is present' do
+      expect_offense(<<~RUBY, 'wrong_class_spec.rb')
+        describe MyClass do; end
+        ^^^^^^^^^^^^^^^^ Spec path should end with `my_class*_spec.rb`.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Retry of PR #2070  - I seem to have fat-fingered the rebase to master in the previous PR. So here is a fresh PR based off of the current master with all the change requests of the original included.

Description of original PR:

RSpec/SpecFilePathFormat allows ignoring certain values in rspec metadata through the IgnoreMetadata option, as given in the documentation:

```
      # @example `IgnoreMetadata: {type=>routing}` (default)
      #   # good
      #   whatever_spec.rb         # describe MyClass, type: :routing do; end
```

However the current implementation does not seem to allow supplying multiple values for the same key - e.g. if you have some specs marked `type: controller`, others as `type: :model`  etc, only one of `controller`, `model`, ... can be supplied to be ignored.

This is probably due to an oversight (or me not being able to figure out how to properly supply an array of values to be ignored).

The PR allows for either an array or a single value to be given for a key in the IgnoreMetadata option.

While it would also be desirable to give a `true` value to ignore all metadata, in the format that `IgnoreMethods` use, this should probably be part of a different PR.