### PR TITLE
Consider prism in coverage results

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,6 +5,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
+  internal_investigation:
+    runs-on: ubuntu-latest
+    name: Internal Investigation
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby # Latest stable CRuby version
+          bundler-cache: true
+      - run: bundle exec rake internal_investigation
+
   yamllint:
     name: Yamllint
     runs-on: ubuntu-latest
@@ -18,6 +29,7 @@ jobs:
           yamllint_comment: true
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   mdformat:
     name: Mdformat
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,17 +35,14 @@ jobs:
           - "3.4"
           - ruby-head
           - jruby-9.4
-        task:
-          - internal_investigation
-          - spec
-    name: "Ruby ${{ matrix.ruby }}: ${{ matrix.task }}"
+    name: "Ruby ${{ matrix.ruby }} - Spec"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
-      - run: NO_COVERAGE=true bundle exec rake ${{ matrix.task }}
+      - run: NO_COVERAGE=true bundle exec rake spec
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,20 +47,33 @@ jobs:
         with:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
-      - run: NO_COVERAGE=true bundle exec rake spec
+      - run: bundle exec rake spec
         env:
           PARSER_ENGINE: ${{ matrix.parser_engine }}
+      - name: Upload Coverage Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-ubuntu-${{ matrix.ruby }}-${{ matrix.parser_engine }}
+          path: coverage/.resultset.json
+          include-hidden-files: true
 
   coverage:
+    name: Check Coverage
+    needs: main
     runs-on: ubuntu-latest
-    name: "Test coverage"
+
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        name: Download Coverage Artifacts
+        with:
+          pattern: coverage-*
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.4"
+          ruby-version: ruby # Latest stable CRuby version
           bundler-cache: true
-      - run: bundle exec rake spec
+
+      - run: bundle exec rake coverage:ci
 
   edge-rubocop:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,12 @@ jobs:
           - "3.4"
           - ruby-head
           - jruby-9.4
-    name: "Ruby ${{ matrix.ruby }} - Spec"
+        parser_engine:
+          - parser_whitequark
+        include:
+          - ruby: "2.7" # Minimum version required for Prism to run.
+            parser_engine: parser_prism
+    name: "Ruby ${{ matrix.ruby }} - Spec (${{ matrix.parser_engine }})"
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
@@ -43,6 +48,8 @@ jobs:
           ruby-version: "${{ matrix.ruby }}"
           bundler-cache: true
       - run: NO_COVERAGE=true bundle exec rake spec
+        env:
+          PARSER_ENGINE: ${{ matrix.parser_engine }}
 
   coverage:
     runs-on: ubuntu-latest
@@ -119,24 +126,3 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
       - run: NO_COVERAGE=true bundle exec rake spec
-
-  prism:
-    runs-on: ubuntu-latest
-    name: Prism
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use prism parser
-        run: |
-          cat << EOF > Gemfile.local
-            gem 'prism'
-          EOF
-      - name: set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          # Specify the minimum Ruby version 2.7 required for Prism to run.
-          ruby-version: "2.7"
-          bundler-cache: true
-      - env:
-          NO_COVERAGE: true
-          PARSER_ENGINE: parser_prism
-        run: bundle exec rake spec

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'rubocop'
 require 'rubocop/rspec/support'
 
-require 'simplecov' unless ENV['NO_COVERAGE']
+require 'simplecov' unless ENV['NO_COVERAGE'] || RUBY_ENGINE == 'jruby'
 
 module SpecHelper
   ROOT = Pathname.new(__dir__).parent.freeze

--- a/tasks/coverage.rake
+++ b/tasks/coverage.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :coverage do
+  desc 'Report Coverage from merged CI runs'
+  task :ci do
+    require 'simplecov'
+
+    SimpleCov.collate Dir['coverage-*/.resultset.json']
+  end
+end


### PR DESCRIPTION
In https://github.com/rubocop/rubocop-rspec/pull/2077, I want to add prism-only logic that won't be executed by the `parser` gem. Coverage complains, because it thinks some code is unreachable.

This PR fixes this by making a few changes to CI, with the goal to merge the coverage results so it can get back to 100%.

I made the following changes:
* Move internal_investigation out of the matrix and run it only once. `internal_investigtion` is not really for catching `rubocop-rspec` errors, there's the test suite for that. So running it only once is ok (I made the same change in `rubocop` a while ago). Doing this simplifies merging since only a single task is executed.
* Move prism to the main workflow. There's nothing that needs to be considered separately anymore, `rubocop-ast` pulls prism in. Also simplifies merging coverage
* Add a new rake task to merge coverage results. These are uploaded per each matrix job, and when all is done a separate job merges them and checks for coverage drops etc.

If this is merged, I can rebase https://github.com/rubocop/rubocop-rspec/pull/2077 and CI should be green there. I tested this locally with coverage results from the different parser engines and it reports 100% coverage after merging and behaves like I would expect it to.