### PR TITLE
Remove runtime dependency on lint_roller

### DIFF
--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -38,6 +38,5 @@ Gem::Specification.new do |spec|
     'default_lint_roller_plugin' => 'RuboCop::RSpec::Plugin'
   }
 
-  spec.add_dependency 'lint_roller', '~> 1.1'
   spec.add_dependency 'rubocop', '~> 1.72', '>= 1.72.1'
 end


### PR DESCRIPTION
rubocop-rspec should not need to have a runtime dependency on lint_roller. And since RuboCop v1.72.1 already has a dependency on lint_roller `~> 1.1.0`, it should be safe to remove from our gemspec.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).