### PR TITLE
Recognize stubbing of `described_class` in `RSpec/SubjectStub`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Recognize stubbing of `described_class` in `RSpec/SubjectStub`. ([@lovro-bikic])
+
 ## 3.6.0 (2025-04-18)
 
 - Fix false positive in `RSpec/Pending`, where it would mark the default block `it` as an offense. ([@bquorning])

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -6096,6 +6096,16 @@ describe Article do
   end
 end
 
+# bad - described_class stubs are recognized as well
+describe Article do
+  it 'indicates that the author is unknown' do
+    article = double(Article, description: 'by an unknown author')
+    allow(described_class).to receive(:new).and_return(article)
+
+    expect(Article.new.description).to include('by an unknown author')
+  end
+end
+
 # good
 describe Article do
   subject(:article) { Article.new(author: nil) }

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -38,6 +38,16 @@ module RuboCop
       #     end
       #   end
       #
+      #   # bad - described_class stubs are recognized as well
+      #   describe Article do
+      #     it 'indicates that the author is unknown' do
+      #       article = double(Article, description: 'by an unknown author')
+      #       allow(described_class).to receive(:new).and_return(article)
+      #
+      #       expect(Article.new.description).to include('by an unknown author')
+      #     end
+      #   end
+      #
       #   # good
       #   describe Article do
       #     subject(:article) { Article.new(author: nil) }
@@ -141,7 +151,7 @@ module RuboCop
           subject_names = [*subject_names, *@explicit_subjects[node]]
           subject_names -= @subject_overrides[node] if @subject_overrides[node]
 
-          names = Set[*subject_names, :subject]
+          names = Set[*subject_names, :subject, :described_class]
           expectation_detected = message_expectation?(node, names)
           return yield(node) if expectation_detected
 

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -364,6 +364,17 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
     RUBY
   end
 
+  it 'flags when described_class is mocked' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        it 'uses described_class' do
+          expect(described_class).to receive(:bar).and_return(baz)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
+
   it 'flags when there are several top level example groups' do
     expect_offense(<<~RUBY)
       RSpec.describe Foo do


### PR DESCRIPTION
This PR makes stubbing of `described_class` register an offense for `RSpec/SubjectStub` cop. I think this fits under this cop since its purpose is to prevent stubbing the system under test, and `described_class` is just that.

To give a production code example offense: I recently noticed a spec for a module that had a `allow(described_class).to receive(:some_module_method)`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
