### PR TITLE
Adjust `RSpec/ReceiveMessages` description

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -782,7 +782,7 @@ RSpec/ReceiveCounts:
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/ReceiveCounts
 
 RSpec/ReceiveMessages:
-  Description: Checks for multiple messages stubbed on the same object.
+  Description: Prefer `receive_messages` over multiple `receive`s on the same object.
   Enabled: true
   SafeAutoCorrect: false
   VersionAdded: '2.23'

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -4887,7 +4887,7 @@ expect(foo).to receive(:bar).at_most(:twice).times
 | -
 |===
 
-Checks for multiple messages stubbed on the same object.
+Prefer `receive_messages` over multiple `receive`s on the same object.
 
 [#safety-rspecreceivemessages]
 === Safety

--- a/lib/rubocop/cop/rspec/receive_messages.rb
+++ b/lib/rubocop/cop/rspec/receive_messages.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module RSpec
-      # Checks for multiple messages stubbed on the same object.
+      # Prefer `receive_messages` over multiple `receive`s on the same object.
       #
       # @safety
       #   The autocorrection is marked as unsafe, because it may change the


### PR DESCRIPTION
Adjusts `RSpec/ReceiveMessages` description to make it better understood it's a "style" cop.

I was adding this cop to a codebase and from the description I couldn't understand what's the rationale for it, i.e. does it fix a faulty setup, does it improve performance, or something else. Then I git blamed it and found out from the original issue https://github.com/rubocop/rubocop-rspec/issues/1254 it's for stylistic consistency.

I adjusted the description to hopefully make that clearer with "prefer" language. Let me know if there's a better way to document the rationale!
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
