### PR TITLE
Offend `allow_any_instance_of` and `expect_any_instance_of` in `RSpec/SubjectStub`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Mark `RSpec/IncludeExamples` as `SafeAutoCorrect: false`. ([@yujideveloper])
 - Fix a false positive for `RSpec/LeakyConstantDeclaration` when defining constants in explicit namespaces. ([@naveg])
+- Offend `allow_any_instance_of` and `expect_any_instance_of` in `RSpec/SubjectStub`. ([@lovro-bikic])
 
 ## 3.6.0 (2025-04-18)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -6150,6 +6150,17 @@ describe Article do
   end
 end
 
+# bad
+describe Article do
+  subject { Article }
+
+  it 'indicates that the author is unknown' do
+    allow_any_instance_of(subject).to receive(:author).and_return(nil)
+
+    expect(subject.new.description).to include('by an unknown author')
+  end
+end
+
 # good
 describe Article do
   subject(:article) { Article.new(author: nil) }

--- a/lib/rubocop/cop/rspec/subject_stub.rb
+++ b/lib/rubocop/cop/rspec/subject_stub.rb
@@ -38,6 +38,17 @@ module RuboCop
       #     end
       #   end
       #
+      #   # bad
+      #   describe Article do
+      #     subject { Article }
+      #
+      #     it 'indicates that the author is unknown' do
+      #       allow_any_instance_of(subject).to receive(:author).and_return(nil)
+      #
+      #       expect(subject.new.description).to include('by an unknown author')
+      #     end
+      #   end
+      #
       #   # good
       #   describe Article do
       #     subject(:article) { Article.new(author: nil) }
@@ -93,11 +104,13 @@ module RuboCop
         #     expect(foo).to receive(:bar)
         #     expect(foo).to receive(:bar).with(1)
         #     expect(foo).to receive(:bar).with(1).and_return(2)
+        #     expect_any_instance_of(foo).to receive(:bar)
+        #     allow_any_instance_of(foo).to receive(:bar)
         #
         def_node_matcher :message_expectation?, <<~PATTERN
           (send
             {
-              (send nil? { :expect :allow } (send nil? %))
+              (send nil? { :expect :allow :expect_any_instance_of :allow_any_instance_of } (send nil? %))
               (send nil? :is_expected)
             }
             #Runners.all

--- a/spec/rubocop/cop/rspec/subject_stub_spec.rb
+++ b/spec/rubocop/cop/rspec/subject_stub_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
     RUBY
   end
 
+  it 'flags when any instance of subject is stubbed' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        subject(:foo) { described_class }
+
+        before do
+          allow_any_instance_of(foo).to receive(:bar).and_return(baz)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+
+        it 'uses expect twice' do
+          expect(foo.bar).to eq(baz)
+        end
+      end
+    RUBY
+  end
+
   it 'flags when subject is mocked' do
     expect_offense(<<~RUBY)
       describe Foo do
@@ -121,6 +138,19 @@ RSpec.describe RuboCop::Cop::RSpec::SubjectStub do
         it 'uses unnamed subject' do
           expect(subject).to receive(:bar)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
+        end
+      end
+    RUBY
+  end
+
+  it 'flags when any instance of subject is mocked' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        subject(:foo) { described_class }
+
+        it 'uses named subject' do
+          expect_any_instance_of(foo).to receive(:bar).and_return(baz)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not stub methods of the object under test.
         end
       end
     RUBY


### PR DESCRIPTION
Expands `RSpec/SubjectStub` to offend `allow_any_instance_of` and `expect_any_instance_of` on the subject (useful in case the subject is a class):
```ruby
allow_any_instance_of(subject).to receive(:foo)
expect_any_instance_of(subject).to receive(:bar)
```

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
