### PR TITLE
Add explanation why RSpec/DescribedClass autocorrection is unsafe

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -985,6 +985,13 @@ To narrow down this setting to only a specific directory, it is
 possible to use an overriding configuration file local to that
 directory.
 
+[#safety-rspecdescribedclass]
+=== Safety
+
+Autocorrection is unsafe when `SkipBlocks: false` because
+`described_class` might not be available within the block (for
+example, in rspec-rails's `controller` helper).
+
 [#examples-rspecdescribedclass]
 === Examples
 

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -13,6 +13,20 @@ module RuboCop
       # `OnlyStaticConstants` is only relevant when `EnforcedStyle` is
       # `described_class`.
       #
+      # There's a known caveat with rspec-rails's `controller` helper that
+      # runs its block in a different context, and `described_class` is not
+      # available to it. `SkipBlocks` option excludes detection in all
+      # non-RSpec related blocks.
+      #
+      # To narrow down this setting to only a specific directory, it is
+      # possible to use an overriding configuration file local to that
+      # directory.
+      #
+      # @safety
+      #   Autocorrection is unsafe when `SkipBlocks: false` because
+      #   `described_class` might not be available within the block (for
+      #   example, in rspec-rails's `controller` helper).
+      #
       # @example `EnforcedStyle: described_class` (default)
       #   # bad
       #   describe MyClass do
@@ -46,15 +60,6 @@ module RuboCop
       #   describe MyClass do
       #     subject { MyClass.do_something }
       #   end
-      #
-      # There's a known caveat with rspec-rails's `controller` helper that
-      # runs its block in a different context, and `described_class` is not
-      # available to it. `SkipBlocks` option excludes detection in all
-      # non-RSpec related blocks.
-      #
-      # To narrow down this setting to only a specific directory, it is
-      # possible to use an overriding configuration file local to that
-      # directory.
       #
       # @example `SkipBlocks: true`
       #   # spec/controllers/.rubocop.yml


### PR DESCRIPTION
Adds missing safety info on `RSpec/DescribedClass`. This cop has [unsafe autocorrection](https://github.com/rubocop/rubocop-rspec/blob/47f03308fd1402d22a7e9b906c49852c062c1301/config/default.yml#L289).

The cop was made unsafe in https://github.com/rubocop/rubocop-rspec/commit/357488829d3e903a4f729b07b9215a2a5d633916. The reason for marking it as unsafe is documented in https://github.com/rubocop/rubocop-rspec/issues/795.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [ ] Feature branch is up-to-date with `master` (if not - rebase it).
- [ ] Squashed related commits together.
- [ ] Added tests.
- [ ] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [ ] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
