### PR TITLE
Add support for error matchers to `RSpec/Dialect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Mark `RSpec/IncludeExamples` as `SafeAutoCorrect: false`. ([@yujideveloper])
 - Fix a false positive for `RSpec/LeakyConstantDeclaration` when defining constants in explicit namespaces. ([@naveg])
+- Add support for error matchers (`raise_exception` and `raise_error`) to `RSpec/Dialect`. ([@lovro-bikic])
 
 ## 3.6.0 (2025-04-18)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -79,6 +79,9 @@ RSpec:
       - prepend_after
       - after
       - append_after
+    ErrorMatchers:
+      - raise_error
+      - raise_exception
     Includes:
       inherit_mode:
         merge:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1153,6 +1153,7 @@ A dialect can be based on the following RSpec methods:
 - let, let!
 - subject, subject!
 - expect, is_expected, expect_any_instance_of
+- raise_error, raise_exception
 
 By default all of the RSpec methods and aliases are allowed. By setting
 a config like:

--- a/lib/rubocop/cop/rspec/dialect.rb
+++ b/lib/rubocop/cop/rspec/dialect.rb
@@ -21,6 +21,7 @@ module RuboCop
       # - let, let!
       # - subject, subject!
       # - expect, is_expected, expect_any_instance_of
+      # - raise_error, raise_exception
       #
       # By default all of the RSpec methods and aliases are allowed. By setting
       # a config like:

--- a/lib/rubocop/rspec/language.rb
+++ b/lib/rubocop/rspec/language.rb
@@ -72,6 +72,12 @@ module RuboCop
       # @!method subject?(node)
       def_node_matcher :subject?, '(block (send nil? #Subjects.all ...) ...)'
 
+      module ErrorMatchers # :nodoc:
+        def self.all(element)
+          Language.config['ErrorMatchers'].include?(element.to_s)
+        end
+      end
+
       module ExampleGroups # :nodoc:
         class << self
           def all(element)
@@ -200,14 +206,14 @@ module RuboCop
       # This is used in Dialect and DescribeClass cops to detect RSpec blocks.
       module ALL # :nodoc:
         def self.all(element)
-          [ExampleGroups, Examples, Expectations, Helpers, Hooks, Includes,
-           Runners, SharedGroups, Subjects]
+          [ErrorMatchers, ExampleGroups, Examples, Expectations, Helpers, Hooks,
+           Includes, Runners, SharedGroups, Subjects]
             .find { |concept| concept.all(element) }
         end
       end
 
-      private_constant :ExampleGroups, :Examples, :Expectations, :Hooks,
-                       :Includes, :Runners, :SharedGroups, :ALL
+      private_constant :ErrorMatchers, :ExampleGroups, :Examples, :Expectations,
+                       :Hooks, :Includes, :Runners, :SharedGroups, :ALL
     end
   end
 end

--- a/spec/rubocop/cop/rspec/dialect_spec.rb
+++ b/spec/rubocop/cop/rspec/dialect_spec.rb
@@ -73,4 +73,29 @@ RSpec.describe RuboCop::Cop::RSpec::Dialect do
       RUBY
     end
   end
+
+  context 'with error matchers config' do
+    let(:cop_config) do
+      {
+        'PreferredMethods' => {
+          'raise_exception' => 'raise_error'
+        }
+      }
+    end
+
+    it 'registers an offense for `raise_exception`' do
+      expect_offense(<<~RUBY)
+        it 'raises an error' do
+          expect { subject }.to raise_exception(StandardError)
+                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Prefer `raise_error` over `raise_exception`.
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        it 'raises an error' do
+          expect { subject }.to raise_error(StandardError)
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Adds support for configuring preferred error matcher ([`raise_error` or `raise_exception`](https://rspec.info/features/3-13/rspec-expectations/built-in-matchers/raise-error/)) in `RSpec/Dialect`.

This can be useful to enforce a consistent matcher style in a project. I can't share the client project I'm working on, so I'll use Mastodon as a reference instead, which has, for example, both [`raise_error ActiveRecord::RecordNotFound`](https://github.com/search?q=repo%3Amastodon%2Fmastodon%20%22raise_error%20ActiveRecord%3A%3ARecordNotFound%22&type=code) and [`raise_exception ActiveRecord::RecordNotFound`](https://github.com/search?q=repo%3Amastodon%2Fmastodon%20%22raise_exception%20ActiveRecord%3A%3ARecordNotFound%22&type=code).

I also ran this cop on [real-world-rails](https://github.com/eliotsykes/real-world-rails) by configuring the cop to prefer `raise_error` over `raise_exception`, and I'm attaching the report below:
<details>
<summary>Report</summary>

```ruby
# ~/real-world-rails/apps/mastodon/spec/services/block_domain_service_spec.rb:36:45: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { bad_status_plain.reload }.to raise_exception ActiveRecord::RecordNotFound

# ~/real-world-rails/apps/mastodon/spec/services/block_domain_service_spec.rb:37:55: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { bad_status_with_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound

# ~/real-world-rails/apps/mastodon/spec/services/block_domain_service_spec.rb:38:43: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { bad_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound

# ~/real-world-rails/apps/mastodon/spec/services/purge_domain_service_spec.rb:19:36: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { account.reload }.to raise_exception ActiveRecord::RecordNotFound

# ~/real-world-rails/apps/mastodon/spec/services/purge_domain_service_spec.rb:20:41: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { status_plain.reload }.to raise_exception ActiveRecord::RecordNotFound

# ~/real-world-rails/apps/mastodon/spec/services/purge_domain_service_spec.rb:21:51: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { status_with_attachment.reload }.to raise_exception ActiveRecord::RecordNotFound

# ~/real-world-rails/apps/mastodon/spec/services/purge_domain_service_spec.rb:22:39: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { attachment.reload }.to raise_exception ActiveRecord::RecordNotFound

# ~/real-world-rails/apps/dev.to/spec/requests/admin/users_manage_spec.rb:72:41: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.find(user2.id) }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/dev.to/spec/requests/admin/users_manage_spec.rb:284:40: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.find(user.id) }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/dev.to/spec/requests/moderations_spec.rb:75:53: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { get "/mod/dsdsdsweweedsdseweww" }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/dev.to/spec/requests/moderations_spec.rb:81:14: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/discourse/spec/lib/backup_restore/shared_examples_for_backup_store.rb:253:71: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { store.download_file(filename, destination_path) }.to raise_exception(StandardError)

# ~/real-world-rails/apps/discourse/spec/lib/backup_restore/shared_examples_for_backup_store.rb:319:16: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
}.to raise_exception(BackupRestore::BackupStore::BackupFileExists)

# ~/real-world-rails/apps/discourse/spec/lib/backup_restore/shared_examples_for_backup_store.rb:333:67: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { store.generate_upload_url(backup1.filename) }.to raise_exception( ...

# ~/real-world-rails/apps/discourse/spec/services/push_notification_pusher_spec.rb:169:38: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { execute_push }.to_not raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/controllers/groups/milestones_controller_spec.rb:352:50: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Milestone.find(milestone.id) }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/controllers/projects/milestones_controller_spec.rb:274:50: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Milestone.find(milestone.id) }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/finders/container_repositories_finder_spec.rb:112:36: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { subject }.to raise_exception('invalid subject_type') }

# ~/real-world-rails/apps/gitlabhq/spec/finders/packages/group_packages_finder_spec.rb:258:34: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { subject }.to raise_exception(described_class::InvalidPackageTypeError) }

# ~/real-world-rails/apps/gitlabhq/spec/finders/packages/package_finder_spec.rb:22:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/finders/packages/package_finder_spec.rb:32:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/finders/template_finder_spec.rb:66:34: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { result }.to raise_exception(Gitlab::Template::Finders::RepoTemplateFinder::FileNotFoundError)

# ~/real-world-rails/apps/gitlabhq/spec/finders/template_finder_spec.rb:95:34: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { result }.to raise_exception(Gitlab::Template::Finders::RepoTemplateFinder::FileNotFoundError)

# ~/real-world-rails/apps/gitlabhq/spec/graphql/resolvers/container_repositories_resolver_spec.rb:86:36: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { subject }.to raise_exception('invalid subject_type') }

# ~/real-world-rails/apps/gitlabhq/spec/initializers/postgresql_cte_spec.rb:14:56: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { relation.update_all(attribute: 42) }.to raise_exception(ActiveRecord::ReadOnlyRecord)

# ~/real-world-rails/apps/gitlabhq/spec/lib/backup/options_spec.rb:94:45: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { described_class.new }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/backup/options_spec.rb:98:65: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { FactoryBot.build(:backup_options, :all) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:45:65: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.public_send(method, resource) }.to raise_exception(BulkImports::NetworkError)

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:56:63: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.public_send(method, resource) }.to raise_exception(BulkImports::NetworkError, 'Unsuccessful response 503 from /test. Body: Error')

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:254:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(BulkImports::Error, ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:266:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(BulkImports::Error, ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:277:50: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.instance_version }.to raise_exception(BulkImports::Error, 'Invalid source URL. Enter only the base URL of the source GitLab instance.')

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:287:50: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.instance_version }.to raise_exception(BulkImports::NetworkError)

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:307:61: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { subject.validate_instance_version! }.to raise_exception(BulkImports::Error) }

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:336:57: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.validate_import_scopes! }.to raise_exception(BulkImports::NetworkError)

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/clients/http_spec.rb:355:57: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.validate_import_scopes! }.to raise_exception(BulkImports::Error)

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/file_downloads/filename_fetch_spec.rb:14:59: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { dummy_instance.raise_error('text') }.to raise_exception(NotImplementedError) }

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/file_downloads/validations_spec.rb:14:59: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { dummy_instance.raise_error('text') }.to raise_exception(NotImplementedError) }

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/file_downloads/validations_spec.rb:18:48: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { dummy_instance.filepath }.to raise_exception(NotImplementedError) }

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/file_downloads/validations_spec.rb:22:56: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { dummy_instance.response_headers }.to raise_exception(NotImplementedError) }

# ~/real-world-rails/apps/gitlabhq/spec/lib/bulk_imports/file_downloads/validations_spec.rb:26:55: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { dummy_instance.file_size_limit }.to raise_exception(NotImplementedError) }

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/audit/auditor_spec.rb:297:50: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { auditor.audit(context) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/audit/auditor_spec.rb:319:50: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { auditor.audit(context) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/audit/auditor_spec.rb:341:50: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { auditor.audit(context) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/cache/helpers_spec.rb:71:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(ArgumentError, "presenter User is not supported")

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/checks/global_file_size_check_spec.rb:60:16: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception(Gitlab::GitAccess::ForbiddenError, ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/database/load_balancing/resolver_spec.rb:58:35: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception( ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/database/load_balancing/resolver_spec.rb:75:35: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception( ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/diff/highlight_spec.rb:120:35: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(RangeError)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/encrypted_configuration_spec.rb:16:39: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { configuration }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/git/repository_spec.rb:2443:44: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { imported_repo.fsck }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/github_import/attachments_downloader_spec.rb:40:42: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { downloader.perform }.to raise_exception( ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/github_import/attachments_downloader_spec.rb:51:42: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { downloader.perform }.to raise_exception( ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/github_import/attachments_downloader_spec.rb:62:42: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { downloader.perform }.to raise_exception( ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/github_import/attachments_downloader_spec.rb:102:42: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { downloader.perform }.to raise_exception( ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/github_import/importer/collaborator_importer_spec.rb:60:40: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { importer.execute }.to raise_exception( ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/import_export/import_failure_service_spec.rb:47:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(ActiveRecord::AssociationNotFoundError, /Association named 'import_failures' was not found on MergeRequest/)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/import_export/import_failure_service_spec.rb:93:41: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { perform_retry }.to raise_exception(exception)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/import_export/import_failure_service_spec.rb:107:41: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { perform_retry }.to raise_exception(exception)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/import_export/import_failure_service_spec.rb:119:37: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { perform_retry }.to raise_exception(exception)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/import_export/json/ndjson_writer_spec.rb:44:88: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.write_relation(exportable_path, relation, values[1]) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/instrumentation/redis_client_middleware_spec.rb:103:18: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception(Redis::CommandError)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/jwt_authenticatable_spec.rb:38:28: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { secret }.to raise_exception(Errno::ENOENT)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/jwt_authenticatable_spec.rb:44:28: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { secret }.to raise_exception(RuntimeError)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/metrics_spec.rb:163:47: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.increment }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/metrics_spec.rb:167:51: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.increment({}) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/metrics_spec.rb:171:54: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.increment({}, 1) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/metrics_spec.rb:181:52: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.observe({}, 2) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/metrics_spec.rb:191:48: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.set({}, 1) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/metrics_spec.rb:201:52: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.observe({}, 2) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/rack_attack/store_spec.rb:27:45: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { store.increment(key, 2) }.to raise_exception(described_class::InvalidAmount)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/request_forgery_protection_spec.rb:35:53: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { described_class.call(env) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/request_forgery_protection_spec.rb:50:55: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { described_class.call(env) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/request_forgery_protection_spec.rb:60:51: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { described_class.call(env) }.to raise_exception(ActionController::InvalidAuthenticityToken)

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/sanitizers/exif_spec.rb:107:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(RuntimeError, "failed to get exif tags: error")

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/sanitizers/exif_spec.rb:174:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(RuntimeError, "failed to get exif tags: error")

# ~/real-world-rails/apps/gitlabhq/spec/lib/gitlab/workhorse_spec.rb:346:34: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { subject }.to raise_exception('Unsupported action: download') }

# ~/real-world-rails/apps/gitlabhq/spec/lib/grafana/client_spec.rb:36:29: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception( ...

# ~/real-world-rails/apps/gitlabhq/spec/lib/grafana/client_spec.rb:64:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(Grafana::Client::Error, message)

# ~/real-world-rails/apps/gitlabhq/spec/lib/system_check/simple_executor_spec.rb:265:58: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.run_check(BugousCheck) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/models/concerns/from_set_operator_spec.rb:33:40: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { redefine_method }.to raise_exception(RuntimeError) }

# ~/real-world-rails/apps/gitlabhq/spec/models/concerns/reactive_caching_spec.rb:240:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { go! }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/models/concerns/reactive_caching_spec.rb:297:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { go! }.to raise_exception(ReactiveCaching::ExceededReactiveCacheLimit)

# ~/real-world-rails/apps/gitlabhq/spec/models/integration_spec.rb:919:13: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(described_class::UnknownType, /foo/)

# ~/real-world-rails/apps/gitlabhq/spec/models/integration_spec.rb:925:75: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { described_class.integration_name_to_type('asana') }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/models/integration_spec.rb:941:14: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception(described_class::UnknownType, /foo/)

# ~/real-world-rails/apps/gitlabhq/spec/models/project_spec.rb:417:64: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { project.update!(ci_cd_settings: nil) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/services/environments/stop_service_spec.rb:274:35: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/services/groups/auto_devops_service_spec.rb:17:14: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception(Gitlab::Access::AccessDeniedError)

# ~/real-world-rails/apps/gitlabhq/spec/services/merge_requests/merge_strategies/from_source_branch_spec.rb:28:15: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(MergeRequests::MergeStrategies::StrategyError, error_message)

# ~/real-world-rails/apps/gitlabhq/spec/services/merge_requests/merge_strategies/from_source_branch_spec.rb:41:15: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(MergeRequests::MergeStrategies::StrategyError, error_message)

# ~/real-world-rails/apps/gitlabhq/spec/services/merge_requests/merge_strategies/from_source_branch_spec.rb:55:15: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(MergeRequests::MergeStrategies::StrategyError, error_message)

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/finders/packages_shared_examples.rb:39:32: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
it { expect { subject }.to raise_exception(described_class::InvalidStatusError) }

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/lib/sentry/client_shared_examples.rb:29:27: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(ErrorTracking::SentryClient::Error, 'Sentry response status code: 302')

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/lib/sentry/client_shared_examples.rb:56:15: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(ErrorTracking::SentryClient::Error, message)

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/services/boards/boards_list_service_shared_examples.rb:43:39: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { service.execute }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/services/jira/requests/base_shared_examples.rb:64:27: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception(StandardError)

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/uploaders/upload_type_shared_examples.rb:8:49: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { uploader.cache!(fixture_file) }.to raise_exception(CarrierWave::IntegrityError)

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/uploaders/upload_type_shared_examples.rb:22:53: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { uploader.cache!(fixture_file) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/workers/auto_merge_from_event_shared_examples.rb:33:19: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/support/shared_examples/workers/concerns/git_garbage_collect_methods_shared_examples.rb:79:48: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.perform(*params) }.to raise_exception(Gitlab::Git::Repository::NoRepository)

# ~/real-world-rails/apps/gitlabhq/spec/workers/abuse/spam_abuse_events_worker_spec.rb:48:48: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { worker.perform(params) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/abuse/trust_score_worker_spec.rb:25:33: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { perform }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/bulk_imports/pipeline_batch_worker_spec.rb:195:50: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { worker.perform(batch.id) }.to raise_exception(StandardError)

# ~/real-world-rails/apps/gitlabhq/spec/workers/bulk_imports/pipeline_worker_spec.rb:498:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(BulkImports::Pipeline::ExpiredError)

# ~/real-world-rails/apps/gitlabhq/spec/workers/bulk_imports/pipeline_worker_spec.rb:509:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(BulkImports::Pipeline::ExpiredError)

# ~/real-world-rails/apps/gitlabhq/spec/workers/bulk_imports/pipeline_worker_spec.rb:522:15: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.to raise_exception(BulkImports::Pipeline::FailedError)

# ~/real-world-rails/apps/gitlabhq/spec/workers/group_export_worker_spec.rb:28:77: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.perform(non_existing_record_id, group.id, {}) }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/workers/group_export_worker_spec.rb:29:76: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.perform(user.id, non_existing_record_id, {}) }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/workers/group_import_worker_spec.rb:53:73: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.perform(non_existing_record_id, group.id) }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/workers/group_import_worker_spec.rb:54:72: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.perform(user.id, non_existing_record_id) }.to raise_exception(ActiveRecord::RecordNotFound)

# ~/real-world-rails/apps/gitlabhq/spec/workers/group_import_worker_spec.rb:65:60: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject.perform(user.id, group.id) }.to raise_exception(Gitlab::ImportExport::Error)

# ~/real-world-rails/apps/gitlabhq/spec/workers/issues/close_worker_spec.rb:58:19: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/mail_scheduler/notification_service_worker_spec.rb:30:76: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { worker.perform(method, key.to_global_id.to_s.succ) }.to raise_exception(ArgumentError)

# ~/real-world-rails/apps/gitlabhq/spec/workers/mail_scheduler/notification_service_worker_spec.rb:40:74: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { worker.perform(method, serialized_arguments) }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/merge_requests/close_issue_worker_spec.rb:27:19: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/merge_requests/create_approval_event_worker_spec.rb:32:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/merge_requests/create_approval_note_worker_spec.rb:29:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/merge_requests/create_pipeline_worker_spec.rb:58:35: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/merge_requests/execute_approval_hooks_worker_spec.rb:34:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/merge_requests/resolve_todos_after_approval_worker_spec.rb:33:17: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.not_to raise_exception

# ~/real-world-rails/apps/gitlabhq/spec/workers/projects/after_import_worker_spec.rb:69:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.to raise_exception('after import error')

# ~/real-world-rails/apps/openproject/spec/lib/chronic_duration_spec.rb:65:73: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
allow(described_class).to receive(:raise_exceptions).and_return(raise_exception)

# ~/real-world-rails/apps/openproject/spec/services/attachments/create_service_integration_spec.rb:98:21: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
.not_to raise_exception ActiveRecord::RecordInvalid

# ~/real-world-rails/apps/canvas-lms/spec/controllers/application_controller_spec.rb:1138:24: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/controllers/application_controller_spec.rb:1914:67: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { controller.send(:verify_authenticity_token) }.to raise_exception(ActionController::InvalidAuthenticityToken)

# ~/real-world-rails/apps/canvas-lms/spec/controllers/application_controller_spec.rb:1919:71: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { controller.send(:verify_authenticity_token) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/controllers/application_controller_spec.rb:1925:67: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { controller.send(:verify_authenticity_token) }.to raise_exception(ActionController::InvalidAuthenticityToken)

# ~/real-world-rails/apps/canvas-lms/spec/controllers/application_controller_spec.rb:1931:71: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { controller.send(:verify_authenticity_token) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:427:53: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.create!(name: "user u2") }.to raise_exception(ActiveModel::UnknownAttributeError)

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:433:57: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.create!(name: "user u2") }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:662:98: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.connection.add_index(:enrollments, :user_id, if_not_exists: true) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:666:108: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.connection.add_column(:enrollments, :user_id, :bigint, if_not_exists: true) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:670:102: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.connection.add_foreign_key(:enrollments, :users, if_not_exists: true) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:680:20: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:684:115: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.connection.remove_foreign_key(:discussion_topics, :conversations, if_exists: true) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:688:122: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.connection.remove_foreign_key(:enrollments, column: :associated_user_id, if_exists: true) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:696:104: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.connection.remove_index(:users, column: :non_existent, if_exists: true) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/initializers/active_record_spec.rb:700:96: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { User.connection.remove_index(:users, name: :lti_id, if_exists: true) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/integration/files_spec.rb:46:60: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Users::AccessVerifier.validate(qs) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/integration/files_spec.rb:86:60: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Users::AccessVerifier.validate(qs) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/integration/files_spec.rb:180:58: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Users::AccessVerifier.validate(qs) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/integration/files_spec.rb:210:55: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Users::AccessVerifier.validate(@qs) }.to raise_exception(Canvas::Security::TokenExpired)

# ~/real-world-rails/apps/canvas-lms/spec/integration/files_spec.rb:331:60: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Users::AccessVerifier.validate(qs) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/lib/assignment_override_applicator_spec.rb:1395:56: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { @overridden.save!(validate: false) }.to raise_exception ActiveRecord::ReadOnlyRecord

# ~/real-world-rails/apps/canvas-lms/spec/lib/atom_feed_helper_spec.rb:99:89: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { described_class.render_xml(title:, link:, entries: [BadKeyModel.new]) }.to raise_exception(/unknown key/)

# ~/real-world-rails/apps/canvas-lms/spec/lib/dates_overridable_spec.rb:220:55: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { overridable.multiple_due_dates? }.to raise_exception(DatesOverridable::NotOverriddenError)

# ~/real-world-rails/apps/canvas-lms/spec/lib/lti/messages/jwt_message_spec.rb:98:18: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/lib/lti/plagiarism_subscriptions_helper_spec.rb:104:63: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subscription_helper.create_subscription }.to raise_exception(Lti::PlagiarismSubscriptionsHelper::PlagiarismSubscriptionError, "Live events subscriptions service is not configured")

# ~/real-world-rails/apps/canvas-lms/spec/lib/lti/plagiarism_subscriptions_helper_spec.rb:114:63: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subscription_helper.create_subscription }.to raise_exception(Lti::PlagiarismSubscriptionsHelper::PlagiarismSubscriptionError)

# ~/real-world-rails/apps/canvas-lms/spec/lib/lti/plagiarism_subscriptions_helper_spec.rb:121:63: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subscription_helper.create_subscription }.to raise_exception(Lti::PlagiarismSubscriptionsHelper::PlagiarismSubscriptionError, "Plagiarism review tool is missing submission event service")

# ~/real-world-rails/apps/canvas-lms/spec/lib/lti/plagiarism_subscriptions_helper_spec.rb:128:63: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subscription_helper.create_subscription }.to raise_exception(Lti::PlagiarismSubscriptionsHelper::PlagiarismSubscriptionError, "Plagiarism review tool submission event service is missing endpoint")

# ~/real-world-rails/apps/canvas-lms/spec/lib/lti/plagiarism_subscriptions_helper_spec.rb:164:74: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subscription_helper.destroy_subscription("test") }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/lib/lti/plagiarism_subscriptions_helper_spec.rb:169:74: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subscription_helper.destroy_subscription("test") }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/lib/lti/variable_expander_spec.rb:1231:26: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/lib/messageable_user/calculator_spec.rb:863:97: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { @calculator.load_messageable_users([other_user], conversation_id: "") }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/lib/unzip_attachment_spec.rb:141:36: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { ua.process }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/models/attachment_spec.rb:1009:37: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { subject }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/models/context_spec.rb:382:14: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception ArgumentError

# ~/real-world-rails/apps/canvas-lms/spec/models/context_spec.rb:388:14: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception ArgumentError

# ~/real-world-rails/apps/canvas-lms/spec/models/course_spec.rb:5301:67: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { @course.sections_visible_to(@teacher).all }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/models/crocodoc_document_spec.rb:146:40: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { @crocodoc.upload }.to raise_exception(Canvas::Crocodoc::CutoffError)

# ~/real-world-rails/apps/canvas-lms/spec/models/crocodoc_document_spec.rb:153:40: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { @crocodoc.upload }.to raise_exception(Canvas::Crocodoc::TimeoutError)

# ~/real-world-rails/apps/canvas-lms/spec/models/developer_key_spec.rb:626:14: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception ActiveRecord::RecordInvalid

# ~/real-world-rails/apps/canvas-lms/spec/models/developer_key_spec.rb:809:16: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.to raise_exception("Validation failed: Scopes cannot contain not_a_valid_scope")

# ~/real-world-rails/apps/canvas-lms/spec/models/developer_key_spec.rb:817:20: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/models/folder_spec.rb:410:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { dup.save! }.to raise_exception(ActiveRecord::RecordNotUnique)

# ~/real-world-rails/apps/canvas-lms/spec/models/folder_spec.rb:418:31: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { dup.save! }.to raise_exception(ActiveRecord::RecordNotUnique)

# ~/real-world-rails/apps/canvas-lms/spec/models/importers/assignment_importer_spec.rb:776:18: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
end.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/models/message_spec.rb:374:38: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { @message.deliver }.to raise_exception("something went wrong")

# ~/real-world-rails/apps/canvas-lms/spec/models/message_spec.rb:379:38: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { @message.deliver }.to raise_exception(Timeout::Error)

# ~/real-world-rails/apps/canvas-lms/spec/models/quizzes/quiz_spec.rb:206:37: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { quiz.unpublish! }.to raise_exception(ActiveRecord::RecordInvalid)

# ~/real-world-rails/apps/canvas-lms/spec/models/users/access_verifier_spec.rb:48:68: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Users::AccessVerifier.validate(verifier) }.not_to raise_exception

# ~/real-world-rails/apps/canvas-lms/spec/models/users/access_verifier_spec.rb:93:66: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Users::AccessVerifier.validate(verifier) }.to raise_exception(Canvas::Security::TokenExpired)

# ~/real-world-rails/apps/canvas-lms/spec/models/users/access_verifier_spec.rb:100:64: C: [Correctable] RSpec/Dialect: Prefer raise_error over raise_exception.
expect { Users::AccessVerifier.validate(tampered) }.to raise_exception(Users::AccessVerifier::InvalidVerifier)
```
</details> 

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
