### PR TITLE
Exclude all cops from inspecting factorybot files, except if explicit…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 - Add support for error matchers (`raise_exception` and `raise_error`) to `RSpec/Dialect`. ([@lovro-bikic])
 - Don't register offenses for `RSpec/DescribedClass` within `Data.define` blocks. ([@lovro-bikic])
 - Add autocorrection support for `RSpec/IteratedExpectation` for single expectations. ([@lovro-bikic])
-- Exclude all cops from inspecting factorybot files, except if explicitly included ([@Mth0158])
 - Exclude all cops from inspecting factorybot files, except if explicitly included. ([@Mth0158])
 
 ## 3.6.0 (2025-04-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for error matchers (`raise_exception` and `raise_error`) to `RSpec/Dialect`. ([@lovro-bikic])
 - Don't register offenses for `RSpec/DescribedClass` within `Data.define` blocks. ([@lovro-bikic])
 - Add autocorrection support for `RSpec/IteratedExpectation` for single expectations. ([@lovro-bikic])
+- Exclude all cops from inspecting factorybot files, except if explicitly included ([@Mth0158])
 
 ## 3.6.0 (2025-04-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Don't register offenses for `RSpec/DescribedClass` within `Data.define` blocks. ([@lovro-bikic])
 - Add autocorrection support for `RSpec/IteratedExpectation` for single expectations. ([@lovro-bikic])
 - Exclude all cops from inspecting factorybot files, except if explicitly included ([@Mth0158])
+- Exclude all cops from inspecting factorybot files, except if explicitly included. ([@Mth0158])
 
 ## 3.6.0 (2025-04-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1028,6 +1028,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@mlarraz]: https://github.com/mlarraz
 [@mockdeep]: https://github.com/mockdeep
 [@mothonmars]: https://github.com/MothOnMars
+[@Mth0158]: https://github.com/Mth0158
 [@mvz]: https://github.com/mvz
 [@naveg]: https://github.com/naveg
 [@nc-holodakg]: https://github.com/nc-holodakg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1028,7 +1028,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@mlarraz]: https://github.com/mlarraz
 [@mockdeep]: https://github.com/mockdeep
 [@mothonmars]: https://github.com/MothOnMars
-[@Mth0158]: https://github.com/Mth0158
+[@mth0158]: https://github.com/Mth0158
 [@mvz]: https://github.com/mvz
 [@naveg]: https://github.com/naveg
 [@nc-holodakg]: https://github.com/nc-holodakg

--- a/config/default.yml
+++ b/config/default.yml
@@ -9,8 +9,6 @@ RSpec:
   Exclude:
     - "**/spec/factories.rb"
     - "**/spec/factories/**/*.rb"
-    - "**/test/factories.rb"
-    - "**/test/factories/**/*.rb"
     - "**/features/support/factories/**/*.rb"
   Language:
     inherit_mode:
@@ -116,14 +114,7 @@ RSpec:
 Metrics/BlockLength:
   inherit_mode:
     merge:
-      - Include
       - Exclude
-  Include:
-    - "**/spec/factories.rb"
-    - "**/spec/factories/**/*.rb"
-    - "**/test/factories.rb"
-    - "**/test/factories/**/*.rb"
-    - "**/features/support/factories/**/*.rb"
   Exclude:
     - "**/*_spec.rb"
     - "**/spec/**/*"

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,12 @@ RSpec:
   Include:
     - "**/*_spec.rb"
     - "**/spec/**/*"
+  Exclude:
+    - "**/spec/factories.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/test/factories.rb"
+    - "**/test/factories/**/*.rb"
+    - "**/features/support/factories/**/*.rb"
   Language:
     inherit_mode:
       merge:
@@ -110,7 +116,14 @@ RSpec:
 Metrics/BlockLength:
   inherit_mode:
     merge:
+      - Include
       - Exclude
+  Include:
+    - "**/spec/factories.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/test/factories.rb"
+    - "**/test/factories/**/*.rb"
+    - "**/features/support/factories/**/*.rb"
   Exclude:
     - "**/*_spec.rb"
     - "**/spec/**/*"
@@ -816,6 +829,15 @@ RSpec/RemoveConst:
   Enabled: true
   VersionAdded: '2.26'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RemoveConst
+  inherit_mode:
+    merge:
+      - Include
+  Include:
+    - "**/spec/factories.rb"
+    - "**/spec/factories/**/*.rb"
+    - "**/test/factories.rb"
+    - "**/test/factories/**/*.rb"
+    - "**/features/support/factories/**/*.rb"
 
 RSpec/RepeatedDescription:
   Description: Check for repeated description strings in example groups.

--- a/config/default.yml
+++ b/config/default.yml
@@ -829,15 +829,6 @@ RSpec/RemoveConst:
   Enabled: true
   VersionAdded: '2.26'
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RemoveConst
-  inherit_mode:
-    merge:
-      - Include
-  Include:
-    - "**/spec/factories.rb"
-    - "**/spec/factories/**/*.rb"
-    - "**/test/factories.rb"
-    - "**/test/factories/**/*.rb"
-    - "**/features/support/factories/**/*.rb"
 
 RSpec/RepeatedDescription:
   Description: Check for repeated description strings in example groups.


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rspec/issues/2093

@pirj as discussed

Reading the code, thanks to your help, I noticed that it might be preferable to exclude `factorybot` files from inspection. From my understanding, all the cops, except 2 (`Metrics/BlockLength` and `RSpec/RemoveConst`), are relevant for inspecting these files.

I have included the 2 that are relevant apply to `factorybot` with the include `inherit_method`.

Unsure about how to add tests for these? I read the test and decided it was not necessary to add some but let me know what you expect if so?

Let me know what you think.