### PR TITLE
Fix a false positive for `RSpec/ExcessiveDocstringSpacing` when receivers are not RSpec methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Don't register offenses for `RSpec/DescribedClass` within `Data.define` blocks. ([@lovro-bikic])
 - Add autocorrection support for `RSpec/IteratedExpectation` for single expectations. ([@lovro-bikic])
 - Exclude all cops from inspecting factorybot files, except if explicitly included. ([@Mth0158])
+- Fix a false positive for `RSpec/ExcessiveDocstringSpacing` when receivers are not RSpec methods. ([@ydah])
 
 ## 3.6.0 (2025-04-18)
 

--- a/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
+++ b/lib/rubocop/cop/rspec/excessive_docstring_spacing.rb
@@ -30,7 +30,7 @@ module RuboCop
 
         # @!method example_description(node)
         def_node_matcher :example_description, <<~PATTERN
-          (send _ {#Examples.all #ExampleGroups.all} ${
+          (send #rspec? {#Examples.all #ExampleGroups.all} ${
             $str
             $(dstr ({str dstr `sym} ...) ...)
           } ...)

--- a/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
+++ b/spec/rubocop/cop/rspec/excessive_docstring_spacing_spec.rb
@@ -772,4 +772,14 @@ RSpec.describe RuboCop::Cop::RSpec::ExcessiveDocstringSpacing do
       end
     RUBY
   end
+
+  it 'does not register an offense when receiver is not non-RSpec' do
+    expect_no_offenses(<<~RUBY)
+      it 'does something' do
+        Foo.describe('  does something')
+        Bar.context('  does something')
+        Baz.it('  does something')
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rspec/issues/2103

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
