### PR TITLE
Fix broken adoc comment in `RSpec/IncludeExamples`

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -2794,8 +2794,6 @@ unexpected behavior and side effects.
 
 Prefer using `it_behaves_like` instead.
 
-----
-
 [#safety-rspecincludeexamples]
 === Safety
 
@@ -2847,6 +2845,7 @@ context "broken example with it_behaves_like" do
     expect(service.call).to eq "mocked response"
   end
 end
+----
 
 [#examples-rspecincludeexamples]
 === Examples

--- a/lib/rubocop/cop/rspec/include_examples.rb
+++ b/lib/rubocop/cop/rspec/include_examples.rb
@@ -61,7 +61,7 @@ module RuboCop
       #       expect(service.call).to eq "mocked response"
       #     end
       #   end
-      # ----
+      #   ----
       #
       # @example
       #   # bad


### PR DESCRIPTION
I happened to read the documentation for a newly added cop `RSpec/IncludeExamples` and noticed that its adoc formatting was broken, so I attempted to fix it.

## Before

<img width="1368" height="398" alt="image" src="https://github.com/user-attachments/assets/5b561db3-a661-4e9f-a0dd-50751952a465" />

## After

<img width="1404" height="448" alt="image" src="https://github.com/user-attachments/assets/4aa77344-b4a2-4844-bc70-a2279d0d2e8b" />