### PR TITLE
Fix CI on ruby 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,11 +128,6 @@ jobs:
     name: Prism
     steps:
       - uses: actions/checkout@v5
-      - name: Use prism parser
-        run: |
-          cat << EOF > Gemfile.local
-            gem 'prism'
-          EOF
       - name: set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,10 @@ gem 'rubocop-rake', '~> 0.7'
 gem 'simplecov', '>= 0.19'
 gem 'yard'
 
+# FIXME: Remove when the next prism version is released.
+if RUBY_VERSION < '3.0' || RUBY_ENGINE == 'jruby'
+  gem 'prism', '!= 1.5.0', '!= 1.5.1'
+end
+
 local_gemfile = 'Gemfile.local'
 eval_gemfile(local_gemfile) if File.exist?(local_gemfile)


### PR DESCRIPTION
Prism 1.5.0 contains an incorrect polyfill for `warn`, which causes it to always output with location information, even if no uplevel is provided.

I fixed this in https://github.com/ruby/prism/pull/3647 but it is not released yet.