### PR TITLE
RSpec/VerifiedDoubles: fix detection of nameless doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bump RuboCop requirement to +1.81. ([@ydah])
 - Fix a false positive for `RSpec/LetSetup` when `let!` used in outer scope. ([@ydah])
 - Fix a false positive for `RSpec/ReceiveNever` cop when `allow(...).to receive(...).never`. ([@ydah])
+- Fix detection of nameless doubles with methods in `RSpec/VerifiedDoubles`. ([@ushi-as])
 
 ## 3.7.0 (2025-09-01)
 
@@ -1082,6 +1083,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@tmaier]: https://github.com/tmaier
 [@topalovic]: https://github.com/topalovic
 [@twalpole]: https://github.com/twalpole
+[@ushi-as]: https://github.com/ushi-as
 [@vzvu3k6k]: https://github.com/vzvu3k6k
 [@walf443]: https://github.com/walf443
 [@yasu551]: https://github.com/yasu551

--- a/lib/rubocop/cop/rspec/verified_doubles.rb
+++ b/lib/rubocop/cop/rspec/verified_doubles.rb
@@ -78,7 +78,7 @@ module RuboCop
 
         def on_send(node)
           unverified_double(node) do |name, *_args|
-            return if name.nil? && cop_config['IgnoreNameless']
+            return if (name.nil? || hash?(name)) && cop_config['IgnoreNameless']
             return if symbol?(name) && cop_config['IgnoreSymbolicNames']
 
             add_offense(node)
@@ -89,6 +89,10 @@ module RuboCop
 
         def symbol?(name)
           name&.sym_type?
+        end
+
+        def hash?(arg)
+          arg.hash_type?
         end
       end
     end

--- a/spec/rubocop/cop/rspec/verified_doubles_spec.rb
+++ b/spec/rubocop/cop/rspec/verified_doubles_spec.rb
@@ -64,12 +64,29 @@ RSpec.describe RuboCop::Cop::RSpec::VerifiedDoubles do
         end
       RUBY
     end
+
+    it 'flags doubles that have no name but methods specified' do
+      expect_offense(<<~RUBY)
+        it do
+          foo = double(call: :bar)
+                ^^^^^^^^^^^^^^^^^^ Prefer using verifying doubles over normal doubles.
+        end
+      RUBY
+    end
   end
 
   it 'ignores doubles that have no name specified' do
     expect_no_offenses(<<~RUBY)
       it do
         foo = double
+      end
+    RUBY
+  end
+
+  it 'ignores doubles that have no name but methods specified' do
+    expect_no_offenses(<<~RUBY)
+      it do
+        foo = double(call: :bar)
       end
     RUBY
   end


### PR DESCRIPTION
The detection of nameless doubles is broken, when methods are specified. This PR fixes it.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
