### PR TITLE
Fix offenses for InternalAffairs/NodePatternGroups cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (Unreleased)
 
 - Add new cop `RSpec/LeakyLocalVariable`. ([@lovro-bikic])
+- Bump RuboCop requirement to +1.81. ([@ydah])
 
 ## 3.7.0 (2025-09-01)
 

--- a/lib/rubocop/cop/rspec/context_wording.rb
+++ b/lib/rubocop/cop/rspec/context_wording.rb
@@ -67,7 +67,7 @@ module RuboCop
 
         # @!method context_wording(node)
         def_node_matcher :context_wording, <<~PATTERN
-          (block (send #rspec? { :context :shared_context } $({str dstr xstr} ...) ...) ...)
+          (block (send #rspec? { :context :shared_context } $(any_str ...) ...) ...)
         PATTERN
 
         def on_block(node) # rubocop:disable InternalAffairs/NumblockHandler

--- a/lib/rubocop/cop/rspec/mixin/final_end_location.rb
+++ b/lib/rubocop/cop/rspec/mixin/final_end_location.rb
@@ -7,7 +7,7 @@ module RuboCop
       module FinalEndLocation
         def final_end_location(start_node)
           heredoc_endings =
-            start_node.each_node(:str, :dstr, :xstr)
+            start_node.each_node(:any_str)
               .select(&:heredoc?)
               .map { |node| node.loc.heredoc_end }
 

--- a/lib/rubocop/cop/rspec/mixin/variable.rb
+++ b/lib/rubocop/cop/rspec/mixin/variable.rb
@@ -13,7 +13,7 @@ module RuboCop
         # @!method variable_definition?(node)
         def_node_matcher :variable_definition?, <<~PATTERN
           (send nil? {#Subjects.all #Helpers.all}
-            $({sym str dsym dstr} ...) ...)
+            $({any_sym str dstr} ...) ...)
         PATTERN
       end
     end

--- a/lib/rubocop/cop/rspec/predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/predicate_matcher.rb
@@ -181,9 +181,7 @@ module RuboCop
         end
 
         def heredoc_argument?(matcher)
-          matcher.arguments.select do |arg|
-            arg.type?(:str, :dstr, :xstr)
-          end.any?(&:heredoc?)
+          matcher.arguments.select(&:any_str_type?).any?(&:heredoc?)
         end
 
         # @!method predicate_matcher?(node)

--- a/lib/rubocop/cop/rspec/sort_metadata.rb
+++ b/lib/rubocop/cop/rspec/sort_metadata.rb
@@ -30,7 +30,7 @@ module RuboCop
 
         # @!method match_ambiguous_trailing_metadata?(node)
         def_node_matcher :match_ambiguous_trailing_metadata?, <<~PATTERN
-          (send _ _ _ ... !{hash sym str dstr xstr})
+          (send _ _ _ ... !{hash sym any_str})
         PATTERN
 
         def on_metadata(args, hash)

--- a/lib/rubocop/cop/rspec/variable_definition.rb
+++ b/lib/rubocop/cop/rspec/variable_definition.rb
@@ -69,7 +69,7 @@ module RuboCop
         end
 
         def symbol?(node)
-          node.type?(:sym, :dsym)
+          node.any_sym_type?
         end
       end
     end

--- a/rubocop-rspec.gemspec
+++ b/rubocop-rspec.gemspec
@@ -39,5 +39,5 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'lint_roller', '~> 1.1'
-  spec.add_dependency 'rubocop', '~> 1.72', '>= 1.72.1'
+  spec.add_dependency 'rubocop', '~> 1.81'
 end


### PR DESCRIPTION
Fix offenses for InternalAffairs/NodePatternGroups cop

This cop was added by the following PR.
- https://github.com/rubocop/rubocop/pull/13762


```
Offenses:

lib/rubocop/cop/rspec/context_wording.rb:70:63: C: [Corrected] InternalAffairs/NodePatternGroups: Replace str, dstr, xstr in node pattern union with any_str.
          (block (send #rspec? { :context :shared_context } $({str dstr xstr} ...) ...) ...)
                                                              ^^^^^^^^^^^^^^^
lib/rubocop/cop/rspec/mixin/final_end_location.rb:10:34: C: [Corrected] InternalAffairs/NodeTypeGroup: Use :any_str instead of individually listing group types.
            start_node.each_node(:str, :dstr, :xstr)
                                 ^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rspec/mixin/variable.rb:16:15: C: [Corrected] InternalAffairs/NodePatternGroups: Replace sym, dsym in node pattern union with any_sym.
            $({sym str dsym dstr} ...) ...)
              ^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rspec/predicate_matcher.rb:184:36: C: [Corrected] Style/SymbolProc: Pass &:any_str_type? as an argument to select instead of a block.
          matcher.arguments.select do |arg| ...
                                   ^^^^^^^^
lib/rubocop/cop/rspec/predicate_matcher.rb:185:23: C: [Corrected] InternalAffairs/NodeTypeGroup: Use :any_str instead of individually listing group types.
            arg.type?(:str, :dstr, :xstr)
                      ^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rspec/sort_metadata.rb:33:28: C: [Corrected] InternalAffairs/NodePatternGroups: Replace str, dstr, xstr in node pattern union with any_str.
          (send _ _ _ ... !{hash sym str dstr xstr})
                           ^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rspec/variable_definition.rb:72:22: C: [Corrected] InternalAffairs/NodeTypeGroup: Use :any_sym instead of individually listing group types.
          node.type?(:sym, :dsym)
                     ^^^^^^^^^^^

282 files inspected, 7 offenses detected, 7 offenses corrected
```
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [-] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
