### PR TITLE
Enhance documentation for autocorrect safety in ExampleWording cop

### DIFF
--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1946,12 +1946,25 @@ Checks for common mistakes in example descriptions.
 This cop will correct docstrings that begin with 'should' and 'it'.
 This cop will also look for insufficient examples and call them out.
 
-The autocorrect is experimental - use with care! It can be configured
-with CustomTransform (e.g. have => has) and IgnoredWords (e.g. only).
-
 Use the DisallowedExamples setting to prevent unclear or insufficient
 descriptions. Please note that this config will not be treated as
 case sensitive.
+
+[#safety-rspecexamplewording]
+=== Safety
+
+The autocorrect is experimental - use with care! It can be configured
+with CustomTransform (e.g. have => has) and IgnoredWords (e.g. only).
+
+While the autocorrect will not break your code (it only modifies test
+description strings, not the actual test logic), it may produce
+grammatically incorrect English in some cases. Always review the diff
+when using autocorrect to ensure the descriptions remain natural and
+accurate.
+
+This is not classified as an unsafe autocorrect because it does not
+affect code behavior, but manual review of changes is strongly
+recommended.
 
 [#examples-rspecexamplewording]
 === Examples

--- a/lib/rubocop/cop/rspec/example_wording.rb
+++ b/lib/rubocop/cop/rspec/example_wording.rb
@@ -10,8 +10,19 @@ module RuboCop
       #
       # @see http://betterspecs.org/#should
       #
-      # The autocorrect is experimental - use with care! It can be configured
-      # with CustomTransform (e.g. have => has) and IgnoredWords (e.g. only).
+      # @safety
+      #   The autocorrect is experimental - use with care! It can be configured
+      #   with CustomTransform (e.g. have => has) and IgnoredWords (e.g. only).
+      #
+      #   While the autocorrect will not break your code (it only modifies test
+      #   description strings, not the actual test logic), it may produce
+      #   grammatically incorrect English in some cases. Always review the diff
+      #   when using autocorrect to ensure the descriptions remain natural and
+      #   accurate.
+      #
+      #   This is not classified as an unsafe autocorrect because it does not
+      #   affect code behavior, but manual review of changes is strongly
+      #   recommended.
       #
       # Use the DisallowedExamples setting to prevent unclear or insufficient
       # descriptions. Please note that this config will not be treated as


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rspec/issues/2058

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [-] Added tests.
- [x] Updated documentation.
- [-] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
