### PR TITLE
Fix a false positive for `RSpec/LetSetup` when `let!` used in outer scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add new cop `RSpec/LeakyLocalVariable`. ([@lovro-bikic])
 - Bump RuboCop requirement to +1.81. ([@ydah])
+- Fix a false positive for `RSpec/LetSetup` when `let!` used in outer scope. ([@ydah])
 
 ## 3.7.0 (2025-09-01)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3562,6 +3562,17 @@ before { create(:widget) }
 it 'counts widgets' do
   expect(Widget.count).to eq(1)
 end
+
+# good
+describe 'a widget' do
+  let!(:my_widget) { create(:widget) }
+  context 'when visiting its page' do
+    let!(:my_widget) { create(:widget, name: 'Special') }
+    it 'counts widgets' do
+      expect(Widget.count).to eq(1)
+    end
+  end
+end
 ----
 
 [#references-rspecletsetup]

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -137,4 +137,124 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
       end
     RUBY
   end
+
+  it 'ignores let! that overrides outer scope let!' do
+    expect_no_offenses(<<~RUBY)
+      describe User, type: :model do
+        let!(:user) { create(:user) }
+
+        it 'is valid' do
+          expect(user).to be_valid
+        end
+
+        context 'with no direct usage' do
+          let!(:user) { create(:user, :special) }
+
+          it 'creates something' do
+            expect(SomeModel.count).to eq(2)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores let! overriding outer scope across multiple nesting levels' do
+    expect_no_offenses(<<~RUBY)
+      describe User do
+        let!(:user) { create(:user) }
+
+        it 'uses user' do
+          expect(user).to be_valid
+        end
+
+        context 'level 1' do
+          context 'level 2' do
+            let!(:user) { create(:user, :admin) }
+
+            it 'creates admin user' do
+              expect(User.count).to eq(2)
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'still flags unused let! when outer scope has different name' do
+    expect_offense(<<~RUBY)
+      describe User do
+        let!(:user) { create(:user) }
+
+        it 'uses user' do
+          expect(user).to be_valid
+        end
+
+        context 'different variable' do
+          let!(:admin) { create(:user, :admin) }
+          ^^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+
+          it 'creates admin user' do
+            expect(User.count).to eq(2)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'allows let! override when outer let! is used elsewhere' do
+    expect_no_offenses(<<~RUBY)
+      describe User do
+        let!(:user) { create(:user) }
+
+        it 'uses user' do
+          expect(user).to be_valid
+        end
+
+        context 'special case' do
+          let!(:user) { create(:user, :special) }
+
+          it 'setup only' do
+            expect(User.count).to eq(2)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'does not consider non-RSpec blocks as outer scope' do
+    expect_offense(<<~RUBY)
+      describe User do
+        [1, 2, 3].each do |i|
+          let!(:user) { create(:user, id: i) }
+          ^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+
+          it 'creates user' do
+            expect(User.count).to eq(3)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'correctly identifies override through mixed block types' do
+    expect_no_offenses(<<~RUBY)
+      describe User do
+        let!(:user) { create(:user) }
+
+        it 'uses user' do
+          expect(user).to be_valid
+        end
+
+        [true, false].each do |flag|
+          context "when flag is \#{flag}" do
+            let!(:user) { create(:user, flag: flag) }
+
+            it 'setup only' do
+              expect(User.count).to be > 0
+            end
+          end
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes: https://github.com/rubocop/rubocop-rspec/issues/2075

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
