### PR TITLE
Add SupportedMethods configuration to `RSpec/RedundantPredicateMatcher` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -818,7 +818,20 @@ RSpec/RedundantAround:
 RSpec/RedundantPredicateMatcher:
   Description: Checks for redundant predicate matcher.
   Enabled: true
+  SupportedMethods:
+    be_all: all
+    be_cover: cover
+    be_end_with: end_with
+    be_eql: eql
+    be_equal: equal
+    be_exist: exist
+    be_exists: exist
+    be_include: include
+    be_match: match
+    be_respond_to: respond_to
+    be_start_with: start_with
   VersionAdded: '2.26'
+  VersionChanged: "<<next>>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RedundantPredicateMatcher
 
 RSpec/RemoveConst:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5155,10 +5155,13 @@ end
 | Yes
 | Always
 | 2.26
-| -
+| <<next>>
 |===
 
 Checks for redundant predicate matcher.
+
+This cop configures the mapping of redundant predicate matchers
+and their preferable alternatives via `SupportedMethods` option.
 
 [#examples-rspecredundantpredicatematcher]
 === Examples
@@ -5173,6 +5176,19 @@ expect(foo).to be_all(bar)
 # good
 expect(foo).to exist(bar)
 expect(foo).not_to include(bar)
+expect(foo).to all be(bar)
+----
+
+[#_supportedmethods_-_be_exist_-exist_-be_include_-include__-rspecredundantpredicatematcher]
+==== `SupportedMethods: {be_exist: exist, be_include: include}`
+
+[source,ruby]
+----
+# good
+expect(foo).to exist(bar)
+expect(foo).not_to include(bar)
+
+# bad
 expect(foo).to all be(bar)
 ----
 

--- a/spec/rubocop/cop/rspec/redundant_predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/redundant_predicate_matcher_spec.rb
@@ -156,4 +156,27 @@ RSpec.describe RuboCop::Cop::RSpec::RedundantPredicateMatcher do
       expect(foo).to end_with(bar)
     RUBY
   end
+
+  context 'when `SupportedMethods` is customized' do
+    let(:cop_config) do
+      { 'SupportedMethods' => { 'be_include' => 'include' } }
+    end
+
+    it 'registers an offense when using `be_include`' do
+      expect_offense(<<~RUBY)
+        expect(foo).to be_include(bar, baz)
+                       ^^^^^^^^^^^^^^^^^^^^ Use `include` instead of `be_include`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(foo).to include(bar, baz)
+      RUBY
+    end
+
+    it 'does not register an offense when using `be_exist`' do
+      expect_no_offenses(<<~RUBY)
+        expect(foo).to be_exist("bar.txt")
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
This PR add SupportedMethods configuration to `RSpec/RedundantPredicateMatcher` cop. 
Fixes: https://github.com/rubocop/rubocop-rspec/issues/2012

This change involves trade-offs. Previously, we could specify replaceable method names in a hard-coded manner, which allowed us to use RESTRICT_ON_SEND. However, now that the decision is based on values set in the config, RESTRICT_ON_SEND can no longer be used. Additionally, since `be_all` requires special internal processing, it's difficult to create this cop generically with Config, leaving special handling for `be_all` inside the implementation.

However, this change enables the `ResultPredictedMatcher` cop to determine which cops trigger violations through Config. For example, when using Cucumber, this allows you to exclude only `match` from violations. As mentioned earlier though, this change involves trade-offs, so if these trade-offs are unacceptable, we need to discard this change. I think it's fine to discard it if necessary.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
