### PR TITLE
Fix a false positive for `RSpec/ReceiveNever` cop when `allow(...).to receive(...).never`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add new cop `RSpec/LeakyLocalVariable`. ([@lovro-bikic])
 - Bump RuboCop requirement to +1.81. ([@ydah])
 - Fix a false positive for `RSpec/LetSetup` when `let!` used in outer scope. ([@ydah])
+- Fix a false positive for `RSpec/ReceiveNever` cop when `allow(...).to receive(...).never`. ([@ydah])
 
 ## 3.7.0 (2025-09-01)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5106,6 +5106,11 @@ end
 
 Prefer `not_to receive(...)` over `receive(...).never`.
 
+This cop only flags usage with `expect`. It ignores `allow` because
+`allow(...).to receive(...).never` is a valid way to ensure a method
+is not called, while `allow(...).not_to receive(...)` would have
+different semantics.
+
 [#examples-rspecreceivenever]
 === Examples
 
@@ -5116,6 +5121,9 @@ expect(foo).to receive(:bar).never
 
 # good
 expect(foo).not_to receive(:bar)
+
+# not flagged by this cop
+allow(foo).to receive(:bar).never
 ----
 
 [#references-rspecreceivenever]

--- a/lib/rubocop/cop/rspec/receive_never.rb
+++ b/lib/rubocop/cop/rspec/receive_never.rb
@@ -5,12 +5,20 @@ module RuboCop
     module RSpec
       # Prefer `not_to receive(...)` over `receive(...).never`.
       #
+      # This cop only flags usage with `expect`. It ignores `allow` because
+      # `allow(...).to receive(...).never` is a valid way to ensure a method
+      # is not called, while `allow(...).not_to receive(...)` would have
+      # different semantics.
+      #
       # @example
       #   # bad
       #   expect(foo).to receive(:bar).never
       #
       #   # good
       #   expect(foo).not_to receive(:bar)
+      #
+      #   # not flagged by this cop
+      #   allow(foo).to receive(:bar).never
       #
       class ReceiveNever < Base
         extend AutoCorrector
@@ -20,8 +28,20 @@ module RuboCop
         # @!method method_on_stub?(node)
         def_node_search :method_on_stub?, '(send nil? :receive ...)'
 
+        # @!method expect_to_receive?(node)
+        def_node_matcher :expect_to_receive?, <<~PATTERN
+          (send
+            {
+              (send #rspec? {:expect :expect_any_instance_of} ...)
+              (block (send #rspec? :expect) ...)
+              (send nil? :is_expected)
+            }
+            :to ...)
+        PATTERN
+
         def on_send(node)
           return unless node.method?(:never) && method_on_stub?(node)
+          return unless used_with_expect?(node)
 
           add_offense(node.loc.selector) do |corrector|
             autocorrect(corrector, node)
@@ -29,6 +49,12 @@ module RuboCop
         end
 
         private
+
+        def used_with_expect?(node)
+          node.each_ancestor(:send).any? do |ancestor|
+            expect_to_receive?(ancestor)
+          end
+        end
 
         def autocorrect(corrector, node)
           corrector.replace(node.parent.loc.selector, 'not_to')

--- a/spec/rubocop/cop/rspec/receive_never_spec.rb
+++ b/spec/rubocop/cop/rspec/receive_never_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::RSpec::ReceiveNever do
-  it 'flags usage of `never`' do
+  it 'registers an offense for expect(...).to receive(...).never' do
     expect_offense(<<~RUBY)
       expect(foo).to receive(:bar).never
                                    ^^^^^ Use `not_to receive` instead of `never`.
@@ -12,44 +12,174 @@ RSpec.describe RuboCop::Cop::RSpec::ReceiveNever do
     RUBY
   end
 
-  it 'flags usage of `never` after `with`' do
+  it 'registers an offense with multiple method calls' do
     expect_offense(<<~RUBY)
-      expect(foo).to receive(:bar).with(baz).never
-                                             ^^^^^ Use `not_to receive` instead of `never`.
+      expect(foo).to receive(:bar).with(1).never
+                                           ^^^^^ Use `not_to receive` instead of `never`.
     RUBY
 
     expect_correction(<<~RUBY)
-      expect(foo).not_to receive(:bar).with(baz)
+      expect(foo).not_to receive(:bar).with(1)
     RUBY
   end
 
-  it 'flags usage of `never` with `is_expected`' do
-    expect_offense(<<~RUBY)
-      is_expected.to receive(:bar).with(baz).never
-                                             ^^^^^ Use `not_to receive` instead of `never`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      is_expected.not_to receive(:bar).with(baz)
-    RUBY
-  end
-
-  it 'flags usage of `never` with `expect_any_instance_of`' do
-    expect_offense(<<~RUBY)
-      expect_any_instance_of(Foo).to receive(:bar).with(baz).never
-                                                             ^^^^^ Use `not_to receive` instead of `never`.
-    RUBY
-
-    expect_correction(<<~RUBY)
-      expect_any_instance_of(Foo).not_to receive(:bar).with(baz)
-    RUBY
-  end
-
-  it 'allows method called `never`' do
+  it 'does not register an offense for allow(...).to receive(...).never' do
     expect_no_offenses(<<~RUBY)
-      expect(foo).to receive(:bar).with(Value.never)
-      expect(foo.never).to eq(bar.never)
-      is_expected.to be never
+      allow(foo).to receive(:bar).never
+    RUBY
+  end
+
+  it 'does not register an offense for ' \
+     'allow(...).to receive(...).with(...).never' do
+    expect_no_offenses(<<~RUBY)
+      allow(foo).to receive(:bar).with(1).never
+    RUBY
+  end
+
+  it 'registers an offense for expect with RSpec prefix' do
+    expect_offense(<<~RUBY)
+      RSpec.expect(foo).to receive(:bar).never
+                                         ^^^^^ Use `not_to receive` instead of `never`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.expect(foo).not_to receive(:bar)
+    RUBY
+  end
+
+  it 'does not register an offense for allow with RSpec prefix' do
+    expect_no_offenses(<<~RUBY)
+      RSpec.allow(foo).to receive(:bar).never
+    RUBY
+  end
+
+  it 'registers an offense for expect_any_instance_of' do
+    expect_offense(<<~RUBY)
+      expect_any_instance_of(Foo).to receive(:bar).never
+                                                   ^^^^^ Use `not_to receive` instead of `never`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect_any_instance_of(Foo).not_to receive(:bar)
+    RUBY
+  end
+
+  it 'does not register an offense for allow_any_instance_of' do
+    expect_no_offenses(<<~RUBY)
+      allow_any_instance_of(Foo).to receive(:bar).never
+    RUBY
+  end
+
+  it 'registers an offense for is_expected' do
+    expect_offense(<<~RUBY)
+      is_expected.to receive(:bar).never
+                                   ^^^^^ Use `not_to receive` instead of `never`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      is_expected.not_to receive(:bar)
+    RUBY
+  end
+
+  it 'registers an offense with complex expect block' do
+    expect_offense(<<~RUBY)
+      expect { foo }.to receive(:bar).never
+                                      ^^^^^ Use `not_to receive` instead of `never`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect { foo }.not_to receive(:bar)
+    RUBY
+  end
+
+  it 'does not register an offense for allow with complex block' do
+    expect_no_offenses(<<~RUBY)
+      allow { foo }.to receive(:bar).never
+    RUBY
+  end
+
+  it 'does not register an offense for expect(...).not_to receive(...)' do
+    expect_no_offenses(<<~RUBY)
+      expect(foo).not_to receive(:bar)
+    RUBY
+  end
+
+  it 'does not register an offense when never is used without receive' do
+    expect_no_offenses(<<~RUBY)
+      expect(foo).to never_call_this_method
+    RUBY
+  end
+
+  it 'registers an offense for multiline expect' do
+    expect_offense(<<~RUBY)
+      expect(foo)
+        .to receive(:bar)
+        .never
+         ^^^^^ Use `not_to receive` instead of `never`.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(foo)
+        .not_to receive(:bar)
+      #{'  '}
+    RUBY
+  end
+
+  it 'does not register an offense for multiline allow' do
+    expect_no_offenses(<<~RUBY)
+      allow(foo)
+        .to receive(:bar)
+        .never
+    RUBY
+  end
+
+  it 'handles nested expectations correctly' do
+    expect_offense(<<~RUBY)
+      expect(foo).to receive(:bar) do
+        expect(baz).to receive(:qux).never
+                                     ^^^^^ Use `not_to receive` instead of `never`.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      expect(foo).to receive(:bar) do
+        expect(baz).not_to receive(:qux)
+      end
+    RUBY
+  end
+
+  it 'does not flag allow in nested context when outer is expect' do
+    expect_no_offenses(<<~RUBY)
+      expect(foo).to receive(:bar) do
+        allow(baz).to receive(:qux).never
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when .never is used without receive' do
+    expect_no_offenses(<<~RUBY)
+      expect(foo).to something.never
+    RUBY
+  end
+
+  it 'does not register an offense when .never is used on a non-stub method' do
+    expect_no_offenses(<<~RUBY)
+      expect(foo.bar).to be.never
+    RUBY
+  end
+
+  it 'does not register an offense when .never is called directly without ' \
+     'receive chain' do
+    expect_no_offenses(<<~RUBY)
+      foo.never
+    RUBY
+  end
+
+  it 'does not register an offense when receive is present but never is ' \
+     'on a different chain' do
+    expect_no_offenses(<<~RUBY)
+      expect(foo).to receive(:bar)
+      something.never
     RUBY
   end
 end


### PR DESCRIPTION
Fixes: #1755 

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
