### PR TITLE
Add `AllowedIdentifiers` configuration option to `RSpec/RedundantPredicateMatcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix a false positive for `RSpec/LetSetup` when `let!` used in outer scope. ([@ydah])
 - Fix a false positive for `RSpec/ReceiveNever` cop when `allow(...).to receive(...).never`. ([@ydah])
 - Fix detection of nameless doubles with methods in `RSpec/VerifiedDoubles`. ([@ushi-as])
+- Add `AllowedIdentifiers` configuration option to `RSpec/RedundantPredicateMatcher`. ([@ydah])
 
 ## 3.7.0 (2025-09-01)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -818,7 +818,9 @@ RSpec/RedundantAround:
 RSpec/RedundantPredicateMatcher:
   Description: Checks for redundant predicate matcher.
   Enabled: true
+  AllowedIdentifiers: []
   VersionAdded: '2.26'
+  VersionChanged: "<next>"
   Reference: https://www.rubydoc.info/gems/rubocop-rspec/RuboCop/Cop/RSpec/RedundantPredicateMatcher
 
 RSpec/RemoveConst:

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5174,10 +5174,30 @@ end
 | Yes
 | Always
 | 2.26
-| -
+| <next>
 |===
 
 Checks for redundant predicate matcher.
+
+This cop checks for the following matchers:
+- `be_all`
+- `be_cover`
+- `be_end_with`
+- `be_eql`
+- `be_equal`
+- `be_exist`
+- `be_exists`
+- `be_include`
+- `be_match`
+- `be_respond_to`
+- `be_start_with`
+
+This cop can be configured with `AllowedIdentifiers` option
+to allow specific predicate matchers.
+
+@ example `AllowedIdentifiers: ['be_exist']`
+  # good
+  expect(foo).to be_exist(bar)
 
 [#examples-rspecredundantpredicatematcher]
 === Examples
@@ -5194,6 +5214,17 @@ expect(foo).to exist(bar)
 expect(foo).not_to include(bar)
 expect(foo).to all be(bar)
 ----
+
+[#configurable-attributes-rspecredundantpredicatematcher]
+=== Configurable attributes
+
+|===
+| Name | Default value | Configurable values
+
+| AllowedIdentifiers
+| `[]`
+| Array
+|===
 
 [#references-rspecredundantpredicatematcher]
 === References

--- a/lib/rubocop/cop/rspec/redundant_predicate_matcher.rb
+++ b/lib/rubocop/cop/rspec/redundant_predicate_matcher.rb
@@ -5,6 +5,22 @@ module RuboCop
     module RSpec
       # Checks for redundant predicate matcher.
       #
+      # This cop checks for the following matchers:
+      # - `be_all`
+      # - `be_cover`
+      # - `be_end_with`
+      # - `be_eql`
+      # - `be_equal`
+      # - `be_exist`
+      # - `be_exists`
+      # - `be_include`
+      # - `be_match`
+      # - `be_respond_to`
+      # - `be_start_with`
+      #
+      # This cop can be configured with `AllowedIdentifiers` option
+      # to allow specific predicate matchers.
+      #
       # @example
       #   # bad
       #   expect(foo).to be_exist(bar)
@@ -16,7 +32,12 @@ module RuboCop
       #   expect(foo).not_to include(bar)
       #   expect(foo).to all be(bar)
       #
+      # @ example `AllowedIdentifiers: ['be_exist']`
+      #   # good
+      #   expect(foo).to be_exist(bar)
+      #
       class RedundantPredicateMatcher < Base
+        include AllowedIdentifiers
         extend AutoCorrector
 
         MSG = 'Use `%<good>s` instead of `%<bad>s`.'
@@ -30,6 +51,8 @@ module RuboCop
           return unless replaceable_arguments?(node)
 
           method_name = node.method_name.to_s
+          return if allowed_identifiers?(method_name)
+
           replaced = replaced_method_name(method_name)
           add_offense(node, message: message(method_name,
                                              replaced)) do |corrector|
@@ -60,6 +83,14 @@ module RuboCop
           else
             name
           end
+        end
+
+        def allowed_identifiers?(name)
+          allowed_identifiers.include?(name)
+        end
+
+        def allowed_identifiers
+          cop_config.fetch('AllowedIdentifiers', [])
         end
       end
     end

--- a/spec/rubocop/cop/rspec/redundant_predicate_matcher_spec.rb
+++ b/spec/rubocop/cop/rspec/redundant_predicate_matcher_spec.rb
@@ -156,4 +156,30 @@ RSpec.describe RuboCop::Cop::RSpec::RedundantPredicateMatcher do
       expect(foo).to end_with(bar)
     RUBY
   end
+
+  context 'when AllowedIdentifiers is set' do
+    let(:cop_config) do
+      {
+        'AllowedIdentifiers' => %w[be_exist be_respond_to]
+      }
+    end
+
+    it 'does not register an offense for allowed identifier' do
+      expect_no_offenses(<<~RUBY)
+        expect(foo).to be_exist(bar)
+        expect(foo).to be_respond_to(bar)
+      RUBY
+    end
+
+    it 'registers an offense for non-allowed identifier' do
+      expect_offense(<<~RUBY)
+        expect(foo).to be_include(bar)
+                       ^^^^^^^^^^^^^^^ Use `include` instead of `be_include`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        expect(foo).to include(bar)
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes: #2012

Another solution of https://github.com/rubocop/rubocop-rspec/pull/2121

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [x] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
