### PR TITLE
Enhances RSpec/MultipleExpectations message to suggest aggregate_failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix a false positive for `RSpec/ReceiveNever` cop when `allow(...).to receive(...).never`. ([@ydah])
 - Fix detection of nameless doubles with methods in `RSpec/VerifiedDoubles`. ([@ushi-as])
 - Improve an offense message for `RSpec/RepeatedExample` cop. ([@ydah])
+- Improve `RSpec/MultipleExpectations` message to suggest using `aggregate_failures`. ([@svgr-slth])
 - Let `RSpec/SpecFilePathFormat` leverage ActiveSupport inflections when configured. ([@corsonknowles], [@bquorning])
 
 ## 3.7.0 (2025-09-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Fix a false positive for `RSpec/ReceiveNever` cop when `allow(...).to receive(...).never`. ([@ydah])
 - Fix detection of nameless doubles with methods in `RSpec/VerifiedDoubles`. ([@ushi-as])
 - Improve an offense message for `RSpec/RepeatedExample` cop. ([@ydah])
-- Improve `RSpec/MultipleExpectations` message to suggest using `aggregate_failures`. ([@svgr-slth])
+- Improve `RSpec/MultipleExpectations` message to contextually suggest using `aggregate_failures` when appropriate. ([@svgr-slth])
 - Let `RSpec/SpecFilePathFormat` leverage ActiveSupport inflections when configured. ([@corsonknowles], [@bquorning])
 
 ## 3.7.0 (2025-09-01)

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -67,7 +67,8 @@ module RuboCop
       #   end
       #
       class MultipleExpectations < Base
-        MSG = 'Example has too many expectations [%<total>d/%<max>d].'
+        MSG = 'Example has too many expectations [%<total>d/%<max>d]. ' \
+              'Consider using `aggregate_failures` if these expectations are logically related.'
 
         ANYTHING = ->(_node) { true }
         TRUE_NODE = lambda(&:true_type?)

--- a/lib/rubocop/cop/rspec/multiple_expectations.rb
+++ b/lib/rubocop/cop/rspec/multiple_expectations.rb
@@ -67,11 +67,13 @@ module RuboCop
       #   end
       #
       class MultipleExpectations < Base
-        MSG = 'Example has too many expectations [%<total>d/%<max>d]. ' \
-              'Consider using `aggregate_failures` if these expectations are logically related.'
+        MSG = 'Example has too many expectations [%<total>d/%<max>d].'
+        MSG_SUGGEST_AGGREGATE = 'Example has too many expectations [%<total>d/%<max>d]. ' \
+                                'Consider using `aggregate_failures` if these expectations are logically related.'
 
         ANYTHING = ->(_node) { true }
         TRUE_NODE = lambda(&:true_type?)
+        FALSE_NODE = lambda(&:false_type?)
 
         exclude_limit 'Max'
 
@@ -102,7 +104,8 @@ module RuboCop
 
           self.max = expectations_count
 
-          flag_example(node, expectation_count: expectations_count)
+          flag_example(node, expectation_count: expectations_count,
+                             aggregate_failures_disabled: aggregate_failures_disabled?(node))
         end
 
         private
@@ -112,6 +115,13 @@ module RuboCop
           return false unless node_with_aggregate_failures
 
           aggregate_failures?(node_with_aggregate_failures, TRUE_NODE)
+        end
+
+        def aggregate_failures_disabled?(example_node)
+          node_with_aggregate_failures = find_aggregate_failures(example_node)
+          return false unless node_with_aggregate_failures
+
+          aggregate_failures?(node_with_aggregate_failures, FALSE_NODE)
         end
 
         def find_aggregate_failures(example_node)
@@ -130,11 +140,12 @@ module RuboCop
           end
         end
 
-        def flag_example(node, expectation_count:)
+        def flag_example(node, expectation_count:, aggregate_failures_disabled:)
+          message_template = aggregate_failures_disabled ? MSG : MSG_SUGGEST_AGGREGATE
           add_offense(
             node.send_node,
             message: format(
-              MSG,
+              message_template,
               total: expectation_count,
               max: max_expectations
             )

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -34,7 +34,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect_any_instance_of twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             expect_any_instance_of(Foo).to receive(:bar)
             expect_any_instance_of(Foo).to receive(:baz)
           end
@@ -46,7 +46,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect_any_instance_of twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             is_expected.to receive(:bar)
             is_expected.to receive(:baz)
           end
@@ -58,7 +58,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect with block twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             expect { something }.to change(Foo.count)
             expect { something }.to change(Bar.count)
           end
@@ -83,7 +83,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'has multiple aggregate_failures calls' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             aggregate_failures do
             end
             aggregate_failures do
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo, aggregate_failures: true do
           it 'uses expect twice', aggregate_failures: false do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect twice', aggregate_failures: false do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -167,7 +167,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo, aggregate_failures: false do
           it 'uses expect twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -179,7 +179,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
+          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -228,7 +228,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect three times' do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [3/2].
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [3/2]. Consider using `aggregate_failures` if these expectations are logically related.
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
             expect(qux).to eq(bar)

--- a/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_expectations_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo, aggregate_failures: true do
           it 'uses expect twice', aggregate_failures: false do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -155,7 +155,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo do
           it 'uses expect twice', aggregate_failures: false do
-          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end
@@ -167,7 +167,7 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleExpectations do
       expect_offense(<<~RUBY)
         describe Foo, aggregate_failures: false do
           it 'uses expect twice' do
-          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.
+          ^^^^^^^^^^^^^^^^^^^^^^ Example has too many expectations [2/1].
             expect(foo).to eq(bar)
             expect(baz).to eq(bar)
           end


### PR DESCRIPTION
# Summary

This PR improves the RSpec/MultipleExpectations cop error message to proactively suggest using aggregate_failures as an alternative to splitting specs.

Before:
```Example has too many expectations [2/1].```

After:
```Example has too many expectations [2/1]. Consider using `aggregate_failures` if these expectations are logically related.```

# Motivation

Developers often encounter this cop and default to splitting specs without realizing aggregate_failures is available. This enhancement educates users at the point of encounter, improving both developer experience and test suite quality.

# Changes

Updated error message in RSpec::MultipleExpectations cop
Updated all test cases to expect the new message format

Fixes #2131 