### PR TITLE
Fix false positive in `RSpec/LetSetup` cop when `let!` variables are used in blocks declared in an outer context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix false positive in `RSpec/LetSetup` cop when `let!` variables are used in blocks declared in an outer context. ([@ydah])
+
 ## 3.8.0 (2025-11-12)
 
 - Add new cop `RSpec/LeakyLocalVariable`. ([@lovro-bikic])


### PR DESCRIPTION
Fixes: #2136 

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [-] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
