### PR TITLE
Fix false negative for RSpec/DescribedClass with constant base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (Unreleased)
 
+- Fix a false negative for constants with constant base in `RSpec/DescribedClass`. ([@lovro-bikic])
+
 ## 3.8.0 (2025-11-12)
 
 - Add new cop `RSpec/LeakyLocalVariable`. ([@lovro-bikic])

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -1031,6 +1031,11 @@ end
 describe MyClass do
   subject { MyClass::CONSTANT }
 end
+
+# good
+describe MyClass do
+  subject { described_class::CONSTANT }
+end
 ----
 
 [#_enforcedstyle_-explicit_-rspecdescribedclass]

--- a/lib/rubocop/cop/rspec/described_class.rb
+++ b/lib/rubocop/cop/rspec/described_class.rb
@@ -50,6 +50,11 @@ module RuboCop
       #     subject { MyClass::CONSTANT }
       #   end
       #
+      #   # good
+      #   describe MyClass do
+      #     subject { described_class::CONSTANT }
+      #   end
+      #
       # @example `EnforcedStyle: explicit`
       #   # bad
       #   describe MyClass do
@@ -205,13 +210,15 @@ module RuboCop
         # @return [Array<Symbol>]
         # @example
         #   # nil represents base constant
-        #   collapse_namespace([], [:C])                # => [:C]
+        #   collapse_namespace([], [:C])                # => [nil, :C]
         #   collapse_namespace([:A, :B], [:C])          # => [:A, :B, :C]
         #   collapse_namespace([:A, :B], [:B, :C])      # => [:A, :B, :C]
         #   collapse_namespace([:A, :B], [nil, :C])     # => [nil, :C]
         #   collapse_namespace([:A, :B], [nil, :B, :C]) # => [nil, :B, :C]
         def collapse_namespace(namespace, const)
-          return const if namespace.empty? || const.first.nil?
+          return const if const.nil?
+
+          namespace = [nil] if namespace.empty?
 
           start = [0, (namespace.length - const.length)].max
           max = namespace.length


### PR DESCRIPTION
Currently, `RSpec/DescribedClass` won't register offenses when described class uses a constant base and the reference doesn't, and vice versa. For example:
```ruby
RSpec.describe MyClass do
  before do
    MyClass.foo # RSpec/DescribedClass registers an offense
    ::MyClass.foo # RSpec/DescribedClass does not register an offense currently
  end
end
```

This PR adds handling of constant bases to this cop.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).