### PR TITLE
Fix `RSpec/MatchWithSimpleRegex` to ignore match nested inside include matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
+- Fix `RSpec/MatchWithSimpleRegex` to ignore `match` nested inside `include` matchers. ([@ydah])
 
 ## 3.10.2 (2026-06-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` outside examples. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/ExampleWording` with percent literal and escaped example descriptions. ([@ydah])
 - Fix `RSpec/LeadingSubject` to not crash on `itblock`/`numblock` example groups with Ruby 3.4 and Prism. ([@pcbeingused333])
+- Fix `RSpec/MatchWithSimpleRegex` to ignore `match` nested inside `include` matchers. ([@ydah])
 
 ## 3.10.2 (2026-06-06)
 

--- a/lib/rubocop/cop/rspec/match_with_simple_regex.rb
+++ b/lib/rubocop/cop/rspec/match_with_simple_regex.rb
@@ -38,7 +38,14 @@ module RuboCop
           (send nil? :match $regexp)
         PATTERN
 
+        # @!method include_matcher_argument?(node)
+        def_node_matcher :include_matcher_argument?, <<~PATTERN
+          ^(send nil? :include ...)
+        PATTERN
+
         def on_send(node)
+          return if include_matcher_argument?(node)
+
           match_with_regexp?(node) do |regexp|
             next unless simple_regexp?(regexp)
 

--- a/lib/rubocop/cop/rspec/match_with_simple_regex.rb
+++ b/lib/rubocop/cop/rspec/match_with_simple_regex.rb
@@ -40,8 +40,14 @@ module RuboCop
           (send nil? :match $regexp)
         PATTERN
 
+        # @!method include_matcher_argument?(node)
+        def_node_matcher :include_matcher_argument?, <<~PATTERN
+          ^(send nil? :include ...)
+        PATTERN
+
         def on_send(node)
           return unless inside_example?(node)
+          return if include_matcher_argument?(node)
 
           match_with_regexp?(node) do |regexp|
             next unless simple_regexp?(regexp)

--- a/spec/rubocop/cop/rspec/match_with_simple_regex_spec.rb
+++ b/spec/rubocop/cop/rspec/match_with_simple_regex_spec.rb
@@ -48,6 +48,14 @@ RSpec.describe RuboCop::Cop::RSpec::MatchWithSimpleRegex, :config do
     RUBY
   end
 
+  it 'does not register an offense when using match within an ' \
+     'include matcher' do
+    expect_no_offenses(<<~RUBY)
+      expect(errors).to include(match(/message/))
+      expect(errors).to include(match(/message/), match(/warning/))
+    RUBY
+  end
+
   it 'does not register an offense when using match with anchor at start' do
     expect_no_offenses(<<~RUBY)
       expect('foobar').to match(/^foo/)

--- a/spec/rubocop/cop/rspec/match_with_simple_regex_spec.rb
+++ b/spec/rubocop/cop/rspec/match_with_simple_regex_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe RuboCop::Cop::RSpec::MatchWithSimpleRegex, :config do
     RUBY
   end
 
+  it 'does not register an offense when using match within an ' \
+     'include matcher' do
+    expect_no_offenses(<<~RUBY)
+      it do
+        expect(errors).to include(match(/message/))
+        expect(errors).to include(match(/message/), match(/warning/))
+      end
+    RUBY
+  end
+
   it 'does not register an offense when using match with anchor at start' do
     expect_no_offenses(<<~RUBY)
       it do


### PR DESCRIPTION
Fix `RSpec/MatchWithSimpleRegex` to ignore `match` when it is already nested inside `include` matcher arguments.

Before this change, `include(match(/message/))` was detected and autocorrected to `include(include('message'))`. The nested `include` form is valid matcher composition, but it is not clearer than the original expression and goes against the cop's purpose.

This keeps the direct `expect(body).to match(/message/)` correction, while leaving nested `include(match(...))` unchanged.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [ ] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).
