### PR TITLE
[Fix #2145] Fix RSpec/LeadingSubject crash on itblock/numblock groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` outside examples. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/ExampleWording` with percent literal and escaped example descriptions. ([@ydah])
+- Fix `RSpec/LeadingSubject` to not crash on `itblock`/`numblock` example groups with Ruby 3.4 and Prism. ([@pcbeingused333])
 
 ## 3.10.2 (2026-06-06)
 
@@ -1095,6 +1096,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@oshiro3]: https://github.com/oshiro3
 [@patrickomatic]: https://github.com/patrickomatic
 [@paydaylight]: https://github.com/paydaylight
+[@pcbeingused333]: https://github.com/pcbeingused333
 [@philcoggins]: https://github.com/PhilCoggins
 [@pirj]: https://github.com/pirj
 [@pocke]: https://github.com/pocke

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -64,7 +64,7 @@ module RuboCop
         end
 
         def parent(node)
-          node.each_ancestor(:block).first.body
+          node.each_ancestor(:any_block).first.body
         end
 
         def autocorrect(corrector, node, sibling)

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -289,4 +289,15 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
   end
+
+  context 'when Ruby 3.4', :ruby34 do
+    it 'does not crash when the example group is an `itblock`' do
+      expect_no_offenses(<<~RUBY)
+        RSpec.describe User do
+          subject { described_class.new }
+          it
+        end
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Fixes #2145.

`RSpec/LeadingSubject` raised `NoMethodError: undefined method 'body' for nil` when the enclosing example group is parsed as an `itblock`/`numblock` node — i.e. Ruby 3.4's implicit `it` block parameter under the Prism parser. `#parent` used `node.each_ancestor(:block).first.body`, and since `each_ancestor(:block)` doesn't match `itblock`/`numblock` nodes, `.first` returned `nil`.

This widens the ancestor lookup to `:any_block` so it also matches `numblock`/`itblock` groups, resolving the crash. Added a regression spec under a `:ruby34` context.
______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [x] Updated documentation.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
