### PR TITLE
Fix RSpec/LeadingSubject to not move a subject above another subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix `RSpec/LeadingSubject` to not move a subject above another subject, avoiding an autocorrect clash with `RSpec/MultipleSubjects` that could remove a subject used in tests. ([@pcbeingused333])
 - Fix false positives for `RSpec/Pending` when using SimpleCov 1.x `skip` filters. ([@gee-forr])
 - Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
@@ -1095,6 +1096,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@oshiro3]: https://github.com/oshiro3
 [@patrickomatic]: https://github.com/patrickomatic
 [@paydaylight]: https://github.com/paydaylight
+[@pcbeingused333]: https://github.com/pcbeingused333
 [@philcoggins]: https://github.com/PhilCoggins
 [@pirj]: https://github.com/pirj
 [@pocke]: https://github.com/pocke

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -47,7 +47,7 @@ module RuboCop
         private
 
         def check_previous_nodes(node)
-          offender = first_offender(node)
+          offender = preceding_offender(node)
           return unless offender
 
           msg = format(MSG, offending: offender.method_name)
@@ -57,21 +57,24 @@ module RuboCop
           end
         end
 
-        def first_offender(node)
+        # The declaration that makes this `subject` non-leading. Used only to
+        # build the offense message and to decide whether to report an offense;
+        # where the `subject` actually moves is decided by `move_target`.
+        def preceding_offender(node)
           preceding_siblings(node).find { |sibling| offending?(sibling) }
         end
 
-        # A subject may move above preceding `let`s/hooks, but never above
-        # another subject. Returns the earliest node to move in front of, or
-        # `nil` when a preceding subject blocks it (a later pass handles it).
+        # A `subject` may move above preceding `let`s/hooks, but never above
+        # another `subject`. Walking preceding siblings in reverse, we stop at
+        # the nearest `subject` and return the topmost offender after it, or
+        # `nil` when a `subject` blocks the move (a later pass moves this one
+        # once the `subject` above it has moved).
         def move_target(node)
           target = nil
-          preceding_siblings(node).each do |sibling|
-            if subject?(sibling)
-              target = nil
-            elsif target.nil? && offending?(sibling)
-              target = sibling
-            end
+          preceding_siblings(node).reverse_each do |sibling|
+            break if subject?(sibling)
+
+            target = sibling if offending?(sibling)
           end
           target
         end

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -47,26 +47,39 @@ module RuboCop
         private
 
         def check_previous_nodes(node)
-          offending_node(node) do |offender|
-            msg = format(MSG, offending: offender.method_name)
-            add_offense(node, message: msg) do |corrector|
-              autocorrect(corrector, node, offender)
-            end
+          offender = first_offender(node)
+          return unless offender
+
+          msg = format(MSG, offending: offender.method_name)
+          add_offense(node, message: msg) do |corrector|
+            target = move_target(node)
+            autocorrect(corrector, node, target) if target
           end
         end
 
-        def offending_node(node)
-          offender = nil
-          parent(node).each_child_node do |sibling|
-            break if sibling.equal?(node)
+        def first_offender(node)
+          preceding_siblings(node).find { |sibling| offending?(sibling) }
+        end
 
+        # A subject may move above preceding `let`s/hooks, but never above
+        # another subject. Returns the earliest node to move in front of, or
+        # `nil` when a preceding subject blocks it (a later pass handles it).
+        def move_target(node)
+          target = nil
+          preceding_siblings(node).each do |sibling|
             if subject?(sibling)
-              offender = nil
-            elsif offender.nil? && offending?(sibling)
-              offender = sibling
+              target = nil
+            elsif target.nil? && offending?(sibling)
+              target = sibling
             end
           end
-          yield offender if offender
+          target
+        end
+
+        def preceding_siblings(node)
+          parent(node).each_child_node.take_while do |sibling|
+            !sibling.equal?(node)
+          end
         end
 
         def parent(node)

--- a/lib/rubocop/cop/rspec/leading_subject.rb
+++ b/lib/rubocop/cop/rspec/leading_subject.rb
@@ -56,11 +56,17 @@ module RuboCop
         end
 
         def offending_node(node)
-          parent(node).each_child_node.find do |sibling|
+          offender = nil
+          parent(node).each_child_node do |sibling|
             break if sibling.equal?(node)
 
-            yield sibling if offending?(sibling)
+            if subject?(sibling)
+              offender = nil
+            elsif offender.nil? && offending?(sibling)
+              offender = sibling
+            end
           end
+          yield offender if offender
         end
 
         def parent(node)

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -294,10 +294,10 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
     expect_offense(<<~RUBY)
       RSpec.describe User do
         let(:foo) { bar }
-
         subject(:a) { first }
         ^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `let` declarations.
         subject(:b) { second }
+        ^^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `let` declarations.
       end
     RUBY
 
@@ -306,7 +306,6 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
         subject(:a) { first }
         subject(:b) { second }
         let(:foo) { bar }
-
       end
     RUBY
   end

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -289,4 +289,25 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
   end
+
+  it 'does not move a subject above another subject' do
+    expect_offense(<<~RUBY)
+      RSpec.describe User do
+        let(:foo) { bar }
+
+        subject(:a) { first }
+        ^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `let` declarations.
+        subject(:b) { second }
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe User do
+        subject(:a) { first }
+        subject(:b) { second }
+        let(:foo) { bar }
+
+      end
+    RUBY
+  end
 end

--- a/spec/rubocop/cop/rspec/leading_subject_spec.rb
+++ b/spec/rubocop/cop/rspec/leading_subject_spec.rb
@@ -309,4 +309,37 @@ RSpec.describe RuboCop::Cop::RSpec::LeadingSubject do
       end
     RUBY
   end
+
+  it 'reports but does not move a subject blocked by a preceding subject' do
+    # `subject(:b)` is offending (a `before` precedes it), but on the first
+    # pass `move_target` is `nil` because `subject(:a)` blocks the move. Once
+    # `subject(:a)` has moved above the hook, a later pass moves `subject(:b)`.
+    expect_offense(<<~RUBY)
+      RSpec.describe User do
+        before { prepare }
+        subject(:a) { first }
+        ^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `before` declarations.
+        subject(:b) { second }
+        ^^^^^^^^^^^^^^^^^^^^^^ Declare `subject` above any other `before` declarations.
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      RSpec.describe User do
+        subject(:a) { first }
+        subject(:b) { second }
+        before { prepare }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for consecutive leading subjects' do
+    expect_no_offenses(<<~RUBY)
+      RSpec.describe User do
+        subject(:a) { first }
+        subject(:b) { second }
+        let(:foo) { bar }
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #1835.

`RSpec/LeadingSubject` moved every subject above preceding `let`s/hooks without regard for other subjects, so with multiple subjects it could swap their relative order. Combined with `RSpec/MultipleSubjects` autocorrect, that removed the subject actually used in the example.

Following the discussion on #1835, `LeadingSubject` now treats another subject as a boundary — a subject still moves above preceding `let`s/hooks, but never above another subject — so the subjects keep their relative order. With the order preserved, `MultipleSubjects` renames only the overridden subject and the example keeps working.

Added a regression spec.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [ ] Updated documentation.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
