### PR TITLE
improve structure and headings of Usage section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,10 @@ Read all the details in our [Upgrade to Version 2.x](https://docs.rubocop.org/ru
 
 ## Usage
 
-### Local Configuration
-
 You need to tell RuboCop to load the RSpec extension. There are three
 ways to do this:
 
-#### RuboCop configuration file
+### RuboCop configuration file
 
 Put this into your `.rubocop.yml`.
 
@@ -67,13 +65,13 @@ cops together with the standard cops.
 > [!NOTE]
 > The plugin system is supported in RuboCop 1.72+. In earlier versions, use `require` instead of `plugins`.
 
-#### Command line
+### Command line
 
 ```bash
 rubocop --plugin rubocop-rspec
 ```
 
-#### Rake task
+### Rake task
 
 ```ruby
 RuboCop::RakeTask.new do |task|

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ Read all the details in our [Upgrade to Version 2.x](https://docs.rubocop.org/ru
 
 ## Usage
 
+### Local Configuration
+
 You need to tell RuboCop to load the RSpec extension. There are three
 ways to do this:
 
-### RuboCop configuration file
+#### RuboCop configuration file
 
 Put this into your `.rubocop.yml`.
 
@@ -65,13 +67,13 @@ cops together with the standard cops.
 > [!NOTE]
 > The plugin system is supported in RuboCop 1.72+. In earlier versions, use `require` instead of `plugins`.
 
-### Command line
+#### Command line
 
 ```bash
 rubocop --plugin rubocop-rspec
 ```
 
-### Rake task
+#### Rake task
 
 ```ruby
 RuboCop::RakeTask.new do |task|
@@ -79,7 +81,9 @@ RuboCop::RakeTask.new do |task|
 end
 ```
 
-### Code Climate
+### External Services
+
+#### Code Climate
 
 rubocop-rspec is available on Code Climate as part of the rubocop engine. [Learn More](https://marketing.codeclimate.com/changelog/55a433bbe30ba00852000fac/).
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,6 @@ RuboCop::RakeTask.new do |task|
 end
 ```
 
-### External Services
-
-#### Code Climate
-
-rubocop-rspec is available on Code Climate as part of the rubocop engine. [Learn More](https://marketing.codeclimate.com/changelog/55a433bbe30ba00852000fac/).
-
 ## Documentation
 
 You can read more about RuboCop RSpec in its [official manual](https://docs.rubocop.org/rubocop-rspec).


### PR DESCRIPTION
Fixes https://github.com/rubocop/rubocop-rspec/issues/2216 .

Remove the obsolete Code Climate section from `README.md`.

- Removed the Code Climate section under `Usage` as its code quality product was extracted into a separate service and is no longer needed in the Readme.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests. (N/A - Documentation changes only)
- [x] Updated documentation.
- [ ] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes. (N/A - Documentation changes only)
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:
N/A - Documentation changes only

If you have modified an existing cop's configuration options:
N/A - Documentation changes only