### PR TITLE
Use project index to fix RSpec/LetSetup shared-code false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` outside examples. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/ExampleWording` with percent literal and escaped example descriptions. ([@ydah])
+- Fix false positives for `RSpec/LetSetup` when a `let!` is referenced from shared examples or contexts defined in another file, by consulting the project-wide index when `AllCops/UseProjectIndex` is enabled. ([@bquorning])
 
 ## 3.10.2 (2026-06-06)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3646,6 +3646,17 @@ end
 
 Checks unreferenced `let!` calls being used for test setup.
 
+A `let!` that is defined in a `shared_context`/`shared_examples` block,
+or in an example group that includes shared examples, may be referenced
+from the shared code rather than from the example group itself. Whether
+such a reference is present cannot be determined from a single file,
+because the shared code is often defined elsewhere. When
+`AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+the cop consults the project-wide index for these `let!` calls and does
+not flag one whose name is referenced anywhere in the project. Without
+the index it falls back to the file-local check, which may report such a
+`let!` as unused.
+
 [#examples-rspecletsetup]
 === Examples
 

--- a/lib/rubocop/cop/rspec/let_setup.rb
+++ b/lib/rubocop/cop/rspec/let_setup.rb
@@ -5,6 +5,17 @@ module RuboCop
     module RSpec
       # Checks unreferenced `let!` calls being used for test setup.
       #
+      # A `let!` that is defined in a `shared_context`/`shared_examples` block,
+      # or in an example group that includes shared examples, may be referenced
+      # from the shared code rather than from the example group itself. Whether
+      # such a reference is present cannot be determined from a single file,
+      # because the shared code is often defined elsewhere. When
+      # `AllCops/UseProjectIndex` is enabled and the `rubydex` gem is installed,
+      # the cop consults the project-wide index for these `let!` calls and does
+      # not flag one whose name is referenced anywhere in the project. Without
+      # the index it falls back to the file-local check, which may report such a
+      # `let!` as unused.
+      #
       # @example
       #   # bad
       #   let!(:my_widget) { create(:widget) }
@@ -38,6 +49,8 @@ module RuboCop
       #   end
       #
       class LetSetup < Base
+        include SharedCodeReference
+
         MSG = 'Do not use `let!` to setup objects not referenced in tests.'
 
         # @!method example_or_shared_group_or_including?(node)
@@ -72,8 +85,10 @@ module RuboCop
         def unused_let_bang(node)
           child_let_bang(node) do |method_send, method_name|
             next if overrides_outer_let_bang?(node, method_name)
+            next if method_called?(node, method_name.to_sym)
+            next if referenced_via_shared_code?(node, method_name)
 
-            yield(method_send) unless method_called?(node, method_name.to_sym)
+            yield(method_send)
           end
         end
 

--- a/lib/rubocop/cop/rspec/mixin.rb
+++ b/lib/rubocop/cop/rspec/mixin.rb
@@ -16,6 +16,7 @@ module RuboCop
       autoload :Metadata, "#{__dir__}/mixin/metadata"
       autoload :Namespace, "#{__dir__}/mixin/namespace"
       autoload :RepeatedItems, "#{__dir__}/mixin/repeated_items"
+      autoload :SharedCodeReference, "#{__dir__}/mixin/shared_code_reference"
       autoload :SkipOrPending, "#{__dir__}/mixin/skip_or_pending"
       autoload :TopLevelGroup, "#{__dir__}/mixin/top_level_group"
       autoload :Variable, "#{__dir__}/mixin/variable"

--- a/lib/rubocop/cop/rspec/mixin/shared_code_reference.rb
+++ b/lib/rubocop/cop/rspec/mixin/shared_code_reference.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module RSpec
+      # Checks whether a node could be referenced from shared code (a
+      # `shared_context`/`shared_examples` block, or code that includes one)
+      # that frequently lives in another file, and consults the project-wide
+      # index to resolve such cross-file references.
+      module SharedCodeReference
+        extend NodePattern::Macros
+
+        include RuboCop::RSpec::Language
+        include ProjectIndexHelp
+
+        def self.included(klass)
+          klass.class_eval do
+            class << self
+              # The reference-name set is a property of the index, not of
+              # the cop instance, so all per-file instances share one
+              # computation. A single-entry cache (instead of a hash keyed
+              # by index) avoids retaining stale graphs in long-lived
+              # processes.
+              attr_accessor :cached_reference_names
+            end
+          end
+        end
+
+        private
+
+        # @!method shared_group_or_including?(node)
+        def_node_matcher :shared_group_or_including?, <<~PATTERN
+          (block {
+            (send #rspec? #SharedGroups.all ...)
+            (send nil? #Includes.all ...)
+          } ...)
+        PATTERN
+
+        # @!method includes_shared_code?(node)
+        def_node_search :includes_shared_code?, <<~PATTERN
+          (send nil? #Includes.all ...)
+        PATTERN
+
+        # @!method includes_call?(node)
+        def_node_matcher :includes_call?, <<~PATTERN
+          (send nil? #Includes.all ...)
+        PATTERN
+
+        # A `let!` connected to shared examples or contexts may be referenced
+        # from the shared code, which frequently lives in another file. The
+        # project-wide index resolves references across files, so consult it
+        # for these `let!` calls rather than reporting a false positive.
+        def referenced_via_shared_code?(node, method_name)
+          return false unless project_index
+          return false unless shared_code_connected?(node)
+
+          project_index_reference_names.include?(method_name.to_s)
+        end
+
+        # Whether the node could be referenced from shared code: it lives in
+        # a shared group, in a group that includes shared examples/contexts,
+        # or in a descendant of such a group (descendants inherit the `let!`
+        # via RSpec's `let` inheritance).
+        def shared_code_connected?(node)
+          return true if shared_group_or_including?(node)
+          return true if includes_shared_code?(node)
+
+          # An ancestor's include only connects `node` if the include lives
+          # in the ancestor's own scope. An include nested inside a sibling
+          # descendant (e.g. another context) cannot reach `node`'s `let!`.
+          node.each_ancestor(:block).any? do |ancestor|
+            shared_group_or_including?(ancestor) ||
+              own_scope_includes?(ancestor)
+          end
+        end
+
+        def own_scope_includes?(node)
+          node.each_child_node.any? do |child|
+            include_call_node?(child) ||
+              (!rspec_scope?(child) && own_scope_includes?(child))
+          end
+        end
+
+        # Handles block-form inclusions (e.g. `include_context 'x' do ... end`),
+        # whose send node `rspec_scope?` would otherwise treat as a boundary.
+        def include_call_node?(node)
+          includes_call?(node) ||
+            (node.block_type? && includes_call?(node.send_node))
+        end
+
+        # An ordinary Ruby block (e.g. `variants.each { include_context ... }`)
+        # does not open a new RSpec scope, so an `include` nested inside it
+        # still runs in the enclosing example group's scope. Only stop
+        # recursing at nodes that establish their own RSpec scope, since an
+        # `include` inside one of those cannot affect the outer scope.
+        def rspec_scope?(node)
+          return false unless node.block_type?
+
+          example_or_shared_group_or_including?(node) || example?(node) ||
+            hook?(node)
+        end
+
+        def project_index_reference_names
+          index, names = self.class.cached_reference_names
+          return names if index.equal?(project_index)
+
+          compute_project_index_reference_names.tap do |computed|
+            self.class.cached_reference_names = [project_index, computed]
+          end
+        end
+
+        def compute_project_index_reference_names
+          project_index.method_references.to_set do |reference|
+            reference.name.delete_suffix('()')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rspec/let_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/let_setup_spec.rb
@@ -257,4 +257,230 @@ RSpec.describe RuboCop::Cop::RSpec::LetSetup do
       end
     RUBY
   end
+
+  context 'with a project index', :project_index do
+    let(:foo_spec_path) { File.expand_path('spec/foo_spec.rb') }
+    let(:shared_path) { File.expand_path('spec/support/shared.rb') }
+
+    def index(sources)
+      build_index(sources.transform_keys { |path| "file://#{path}" })
+    end
+
+    def reference_names_for(source)
+      cop = described_class.new
+      cop.project_index = index(foo_spec_path => source)
+      [cop, cop.send(:project_index_reference_names)]
+    end
+
+    it 'does not flag let! referenced from shared examples in another file' do
+      source = <<~RUBY
+        describe Foo do
+          context 'ctx' do
+            let!(:user) { create(:user) }
+            include_examples 'shared example'
+          end
+        end
+      RUBY
+      shared = <<~RUBY
+        RSpec.shared_examples 'shared example' do
+          it { expect(user).to be_present }
+        end
+      RUBY
+      cop.project_index = index(foo_spec_path => source, shared_path => shared)
+
+      expect_no_offenses(source, foo_spec_path)
+    end
+
+    it 'does not flag let! referenced from a shared context in another file' do
+      source = <<~RUBY
+        describe Foo do
+          context 'ctx' do
+            let!(:record) { create(:record) }
+            include_context 'a local record'
+          end
+        end
+      RUBY
+      shared = <<~RUBY
+        RSpec.shared_context 'a local record' do
+          before { record.sync }
+        end
+      RUBY
+      cop.project_index = index(foo_spec_path => source, shared_path => shared)
+
+      expect_no_offenses(source, foo_spec_path)
+    end
+
+    it 'does not flag let! defined in a shared context and referenced ' \
+       'from the file that includes it' do
+      shared = <<~RUBY
+        RSpec.shared_context 'a local record' do
+          let!(:record) { create(:record) }
+        end
+      RUBY
+      other = <<~RUBY
+        describe Foo do
+          include_context 'a local record'
+          it { expect(record).to be_present }
+        end
+      RUBY
+      cop.project_index =
+        index(shared_path => shared, foo_spec_path => other)
+
+      expect_no_offenses(shared, shared_path)
+    end
+
+    it 'does not flag let! referenced from a shared context included ' \
+       "inside an ancestor's ordinary Ruby block" do
+      source = <<~RUBY
+        describe Foo do
+          %w[a b].each { |variant| include_context "shared \#{variant}" }
+
+          context 'ctx' do
+            let!(:record) { create(:record) }
+          end
+        end
+      RUBY
+      shared = <<~RUBY
+        RSpec.shared_context 'shared a' do
+          before { record.sync }
+        end
+      RUBY
+      cop.project_index = index(foo_spec_path => source, shared_path => shared)
+
+      expect_no_offenses(source, foo_spec_path)
+    end
+
+    it 'does not flag let! referenced from a shared context included ' \
+       "via an ancestor's block-form inclusion" do
+      source = <<~RUBY
+        describe Foo do
+          include_context 'shared' do
+            let(:variant) { 'a' }
+          end
+
+          context 'ctx' do
+            let!(:record) { create(:record) }
+          end
+        end
+      RUBY
+      shared = <<~RUBY
+        RSpec.shared_context 'shared' do
+          before { record.sync }
+        end
+      RUBY
+      cop.project_index = index(foo_spec_path => source, shared_path => shared)
+
+      expect_no_offenses(source, foo_spec_path)
+    end
+
+    it 'still flags let! never referenced anywhere in the project' do
+      source = <<~RUBY
+        describe Foo do
+          context 'ctx' do
+            let!(:user) { create(:user) }
+            ^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+            include_examples 'shared example'
+          end
+        end
+      RUBY
+      shared = <<~RUBY
+        RSpec.shared_examples 'shared example' do
+          it { expect(1).to eq(1) }
+        end
+      RUBY
+      cop.project_index = index(foo_spec_path => source, shared_path => shared)
+
+      expect_offense(source, foo_spec_path)
+    end
+
+    it 'still flags let! not connected to shared code ' \
+       'even when a sibling context includes it' do
+      source = <<~RUBY
+        describe Foo do
+          context 'without shared code' do
+            let!(:user) { create(:user) }
+            ^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+          end
+
+          context 'with shared code' do
+            include_examples 'shared example'
+          end
+        end
+      RUBY
+      shared = <<~RUBY
+        RSpec.shared_examples 'shared example' do
+          it { expect(user).to be_present }
+        end
+      RUBY
+      cop.project_index = index(foo_spec_path => source, shared_path => shared)
+
+      expect_offense(source, foo_spec_path)
+    end
+
+    it 'still flags unused let! not connected to shared code ' \
+       'even when the name is used elsewhere' do
+      source = <<~RUBY
+        describe Foo do
+          let!(:user) { create(:user) }
+          ^^^^^^^^^^^ Do not use `let!` to setup objects not referenced in tests.
+
+          it 'does not use user' do
+            expect(baz).to eq(qux)
+          end
+        end
+      RUBY
+      other = <<~RUBY
+        describe Bar do
+          it { expect(user).to be_present }
+        end
+      RUBY
+      bar_spec_path = File.expand_path('spec/bar_spec.rb')
+      cop.project_index =
+        index(foo_spec_path => source, bar_spec_path => other)
+
+      expect_offense(source, foo_spec_path)
+    end
+
+    describe 'the reference-name cache' do
+      it 'is computed once per index and shared across cop instances' do
+        source = <<~RUBY
+          describe Foo do
+            it { expect(user).to be_present }
+          end
+        RUBY
+        project_index = index(foo_spec_path => source)
+
+        first_cop = described_class.new
+        first_cop.project_index = project_index
+        first_cop_names = first_cop.send(:project_index_reference_names)
+
+        second_cop = described_class.new
+        second_cop.project_index = project_index
+        second_cop_names = second_cop.send(:project_index_reference_names)
+
+        expect(second_cop_names).to be(first_cop_names)
+      end
+
+      it 'replaces the cached entry when the index changes, rather than ' \
+         'accumulating it', :aggregate_failures do
+        _, first_cop_names = reference_names_for(<<~RUBY)
+          describe Foo do
+            it { expect(user).to be_present }
+          end
+        RUBY
+
+        second_cop, second_cop_names = reference_names_for(<<~RUBY)
+          describe Foo do
+            it { expect(1).to eq(1) }
+          end
+        RUBY
+
+        expect(second_cop_names).not_to eq(first_cop_names)
+
+        index_object, cached = described_class.cached_reference_names
+        expect(index_object).to be(second_cop.project_index)
+        expect(cached).to be(second_cop_names)
+      end
+    end
+  end
 end

--- a/spec/support/project_index.rb
+++ b/spec/support/project_index.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Helpers for examples tagged with `:project_index`. The `before` hook skips
+# the example when the project-index gem cannot be loaded for the current Ruby;
+# the included module builds an in-memory index from a `uri => source` hash so
+# that index-aware cop logic can be exercised directly.
+module ProjectIndexSpecHelpers
+  def build_index(sources)
+    graph = Rubydex::Graph.new
+    sources.each { |uri, source| graph.index_source(uri, source, 'ruby') }
+    graph.resolve
+    graph
+  end
+end
+
+RSpec.configure do |config|
+  config.include ProjectIndexSpecHelpers, :project_index
+
+  config.before(:each, :project_index) do
+    unless RuboCop::ProjectIndexLoader.available?
+      minimum = RuboCop::ProjectIndexLoader::MINIMUM_RUBY_VERSION
+      reason = if RuboCop::ProjectIndexLoader.supported_ruby?
+                 'rubydex gem is not installed.'
+               else
+                 "rubydex requires Ruby #{minimum} or later."
+               end
+      skip reason
+    end
+  end
+end


### PR DESCRIPTION
`RSpec/LetSetup` has long flagged a `let!` as unused when its only reference lives in a `shared_examples`/`shared_context` block defined in another file, since single-file analysis can't see the reference (#830).

RuboCop 1.89's Rubydex-backed project index resolves references across files. For a `let!` connected to shared code, the cop now consults the project-wide index and skips the offense if the name is referenced anywhere in the project. The index is consulted only for these shared-code cases, not for every `let!`, since common `let` names recur across spec files and a blanket check would suppress nearly every offense. Without `AllCops/UseProjectIndex` enabled, behavior is unchanged.

Fixes #830.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Updated documentation.
- [x] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [x] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).