### PR TITLE
Fix false positives for subject detection nested in another block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` outside examples. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/ExampleWording` with percent literal and escaped example descriptions. ([@ydah])
+- Fix false positives for cops that detect `subject` when a same-named method is called inside another block, such as a DSL evaluated in a `let`. ([@corsonknowles])
 - Fix `RSpec/SpecFilePathFormat` raising when `EnforcedInflector: active_support` and RuboCop is invoked from outside the project root. ([@corsonknowles])
 - Fix `RSpec/LeadingSubject` to not crash on `itblock`/`numblock` example groups with Ruby 3.4 and Prism. ([@pcbeingused333])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` nested inside `include` matchers. ([@ydah])

--- a/lib/rubocop/rspec/example_group.rb
+++ b/lib/rubocop/rspec/example_group.rb
@@ -22,7 +22,7 @@ module RuboCop
       end
 
       def subjects
-        find_all_in_scope(node, :subject?)
+        find_all_in_scope(node, :subject?, skip_nested_blocks: true)
       end
 
       def examples
@@ -47,20 +47,26 @@ module RuboCop
       # @param predicate [Symbol] method to call with node as argument
       #
       # @return [Array<RuboCop::AST::Node>] discovered nodes
-      def find_all_in_scope(node, predicate)
+      def find_all_in_scope(node, predicate, skip_nested_blocks: false)
         node.each_child_node.flat_map do |child|
-          find_all(child, predicate)
+          find_all(child, predicate, skip_nested_blocks: skip_nested_blocks)
         end
       end
 
-      def find_all(node, predicate)
-        if public_send(predicate, node)
-          [node]
-        elsif scope_change?(node) || example?(node)
-          []
-        else
-          find_all_in_scope(node, predicate)
-        end
+      def find_all(node, predicate, skip_nested_blocks: false)
+        return [node] if public_send(predicate, node)
+        # No attempt is made to tell an RSpec DSL block from any other: a
+        # declaration inside *any* block is not one the group makes
+        # unconditionally, so stop rather than identify the block.
+        return [] if skip_nested_blocks && node.block_type?
+        return [] if scope_change?(node)
+        return [] if example?(node)
+
+        find_all_in_scope(
+          node,
+          predicate,
+          skip_nested_blocks: skip_nested_blocks
+        )
       end
     end
   end

--- a/spec/rubocop/cop/rspec/multiple_subjects_spec.rb
+++ b/spec/rubocop/cop/rspec/multiple_subjects_spec.rb
@@ -80,4 +80,101 @@ RSpec.describe RuboCop::Cop::RSpec::MultipleSubjects do
       end
     RUBY
   end
+
+  it 'registers an offense for subjects named by a local variable' do
+    expect_offense(<<~RUBY)
+      describe 'hello there' do
+        name = :dynamic
+        subject(name) { 1 }
+        ^^^^^^^^^^^^^^^^^^^ Do not set more than one subject per example group
+        subject(:other) { 2 }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for subjects named by a method call' do
+    expect_offense(<<~RUBY)
+      describe 'hello there' do
+        subject(subject_name) { 1 }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set more than one subject per example group
+        subject(:other) { 2 }
+      end
+    RUBY
+  end
+
+  it 'registers an offense for subjects named by a constant' do
+    expect_offense(<<~RUBY)
+      describe 'hello there' do
+        subject(SUBJECT_NAME) { 1 }
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set more than one subject per example group
+        subject(:other) { 2 }
+      end
+    RUBY
+  end
+
+  it 'ignores a same-named method called inside another block' do
+    expect_no_offenses(<<~RUBY)
+      describe 'hello there' do
+        let(:definition) do
+          AbilityDefinition.define do
+            subject(Model, test: ['value']) { can :read }
+            subject(Model, other: ['value']) { can :write }
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'counts the group own subject beside one nested in a block' do
+    expect_no_offenses(<<~RUBY)
+      describe 'hello there' do
+        let(:definition) do
+          AbilityDefinition.define do
+            subject(Model, test: ['value']) { can :read }
+          end
+        end
+
+        subject(:real_one) { described_class.new }
+      end
+    RUBY
+  end
+
+  it 'autocorrects the group own subjects, not a nested DSL call' do
+    expect_offense(<<~RUBY)
+      describe 'hello there' do
+        let(:definition) do
+          AbilityDefinition.define do
+            subject(Model, test: ['value']) { can :read }
+          end
+        end
+
+        subject(:first) { 1 }
+        ^^^^^^^^^^^^^^^^^^^^^ Do not set more than one subject per example group
+        subject(:second) { 2 }
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe 'hello there' do
+        let(:definition) do
+          AbilityDefinition.define do
+            subject(Model, test: ['value']) { can :read }
+          end
+        end
+
+        let(:first) { 1 }
+        subject(:second) { 2 }
+      end
+    RUBY
+  end
+
+  it 'does not register an offense for subjects declared inside an iterator' do
+    expect_no_offenses(<<~RUBY)
+      describe 'hello there' do
+        %i[a b].each do |name|
+          subject(name) { 1 }
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
`RSpec/MultipleSubjects` reports a same-named DSL method as a duplicate subject, and its autocorrect then rewrites the DSL call into something that raises:

```ruby
let(:definition) do
  AbilityDefinition.define do
    subject(Model, test: ['value']) { can :read }
    subject(Model, other: ['value']) { can :write }
  end
end
```

```diff
-      subject(Model, test: ['value']) { can :read }
+      let(Model, test: ['value']) { can :read }
```

On a real codebase that gave `NoMethodError`, 3 failures out of 7 examples.

## Rewritten to @pirj's suggestion

> What if the argument is a method call/var?
>
> what would be the consequences if we checked that subject is directly in the example group, not wrapped in another block instead?

Both points were right, so this now takes the second approach.

My first attempt constrained the argument shape to zero-or-one symbol/string. That regresses legitimate dynamic names, which I confirmed:

| snippet | first attempt | this version |
| --- | --- | --- |
| `subject { 1 }` | detected | detected |
| `subject(:name) { 1 }` | detected | detected |
| `subject(name) { 1 }` | **missed** | detected |
| `subject(some_method) { 1 }` | **missed** | detected |
| `subject(SOME_CONST) { 1 }` | **missed** | detected |

`ExampleGroup#subjects` now stops descending into blocks that are not example groups, so a `subject` declared inside some other block is not counted. No argument-shape guessing.

This also matches how the cop already treats declarations it cannot rely on — compare `ScatteredSetup`'s `reject(&:inside_class_method?)`. A `subject` inside an arbitrary block is not a declaration the example group makes.

## Consequences

The one behaviour change beyond the fix: subjects declared inside an iterator are no longer counted, so

```ruby
%i[a b].each { |name| subject(name) { 1 } }
```

reports nothing. That is pinned by a spec so it is a decision rather than an accident. If you would rather keep detecting that, I think it needs an explicit allowance for iterator blocks, which felt like more machinery than the case warrants — happy to add it if you disagree.

## Specs

Six cases: the DSL shape; the DSL shape alongside a real group-level subject (still counted once); and dynamic names by local variable, method call and constant — the three my first attempt broke and which no existing spec covered, which is why its suite went green.

`bundle exec rake` — 2469 examples, 0 failures, 100% line and branch coverage, 293 files inspected, no offenses.

Related: #2222 applies the same "not unconditionally declared" reasoning to `ScatteredSetup`.
