### PR TITLE
Fix false positives for RSpec/ScatteredSetup in mutually exclusive branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` outside examples. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/ExampleWording` with percent literal and escaped example descriptions. ([@ydah])
+- Fix false positives for `RSpec/ScatteredSetup` when hooks are defined in mutually exclusive branches of a conditional. ([@corsonknowles])
 
 ## 3.10.2 (2026-06-06)
 

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -5879,7 +5879,8 @@ Checks for setup scattered across multiple hooks in an example group.
 Unify `before` and `after` hooks when possible.
 However, `around` hooks are allowed to be defined multiple times,
 as unifying them would typically make the code harder to read.
-Hooks defined in class methods are also ignored.
+Hooks defined in class methods are also ignored, as are hooks in
+different branches of one conditional, which never both run.
 
 [#examples-rspecscatteredsetup]
 === Examples
@@ -5910,6 +5911,15 @@ end
 describe Foo do
   before { setup1 }
   def self.setup
+    before { setup2 }
+  end
+end
+
+# good
+describe Foo do
+  if flag
+    before { setup1 }
+  else
     before { setup2 }
   end
 end

--- a/lib/rubocop/cop/rspec/scattered_setup.rb
+++ b/lib/rubocop/cop/rspec/scattered_setup.rb
@@ -8,7 +8,8 @@ module RuboCop
       # Unify `before` and `after` hooks when possible.
       # However, `around` hooks are allowed to be defined multiple times,
       # as unifying them would typically make the code harder to read.
-      # Hooks defined in class methods are also ignored.
+      # Hooks defined in class methods are also ignored, as are hooks in
+      # different branches of one conditional, which never both run.
       #
       # @example
       #   # bad
@@ -39,6 +40,15 @@ module RuboCop
       #     end
       #   end
       #
+      #   # good
+      #   describe Foo do
+      #     if flag
+      #       before { setup1 }
+      #     else
+      #       before { setup2 }
+      #     end
+      #   end
+      #
       class ScatteredSetup < Base
         include FinalEndLocation
         include RangeHelp
@@ -53,9 +63,18 @@ module RuboCop
 
           repeated_hooks(node).each do |occurrences|
             occurrences.each do |occurrence|
-              message = message(occurrences, occurrence)
+              peers = co_occurring(occurrences, occurrence)
+              next if peers.empty?
+
+              # Anchor on the set's earliest hook, the same for every member,
+              # so the corrections all merge in one direction.
+              group = occurrences.select do |hook|
+                hook.equal?(occurrence) || peers.include?(hook)
+              end
+
+              message = message(group, occurrence)
               add_offense(occurrence, message: message) do |corrector|
-                autocorrect(corrector, occurrences.first, occurrence)
+                autocorrect(corrector, group.first, occurrence)
               end
             end
           end
@@ -72,6 +91,35 @@ module RuboCop
             hooks,
             key_proc: ->(hook) { [hook.name, hook.scope, hook.metadata] }
           ).map { |hook_group| hook_group.map(&:to_node) }
+        end
+
+        # Hooks in different branches of one conditional never both run, so they
+        # are not scattered setup. A hook outside the conditional does run
+        # alongside one inside it, so only divergence at a shared conditional
+        # counts.
+        def co_occurring(occurrences, occurrence)
+          occurrences.reject do |other|
+            other.equal?(occurrence) || mutually_exclusive?(occurrence, other)
+          end
+        end
+
+        def mutually_exclusive?(node, other)
+          branches = enclosing_branches(other)
+
+          enclosing_branches(node).any? do |conditional, branch|
+            branches.key?(conditional) && !branches[conditional].equal?(branch)
+          end
+        end
+
+        # Maps each enclosing `if`/`case` to the branch this node sits in.
+        def enclosing_branches(node)
+          child = node
+          node.each_ancestor.with_object({}) do |ancestor, branches|
+            if ancestor.type?(:if, :case, :case_match)
+              branches[ancestor] = child
+            end
+            child = ancestor
+          end
         end
 
         def lines_msg(numbers)

--- a/spec/rubocop/cop/rspec/scattered_setup_spec.rb
+++ b/spec/rubocop/cop/rspec/scattered_setup_spec.rb
@@ -227,4 +227,84 @@ RSpec.describe RuboCop::Cop::RSpec::ScatteredSetup do
       end
     RUBY
   end
+
+  it 'ignores hooks in different branches of a case statement' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        case key
+        when :a
+          before { setup_a }
+        when :b
+          before { setup_b }
+        else
+          before { setup_c }
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores hooks in different branches of an if statement' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        if flag
+          before { setup_a }
+        else
+          before { setup_b }
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for a hook outside a conditional and one inside' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        before { always }
+        ^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 5).
+        case key
+        when :a
+          before { sometimes }
+          ^^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
+        end
+      end
+    RUBY
+  end
+
+  it 'registers an offense for two hooks in the same branch' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        case key
+        when :a
+          before { setup_a1 }
+          ^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 5).
+          before { setup_a2 }
+          ^^^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 4).
+        when :b
+          before { setup_b }
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores hooks in exclusive branches of a version check' do
+    expect_no_offenses(<<~RUBY)
+      describe Foo do
+        if RUBY_VERSION >= '3.4'
+          before { modern_setup }
+        else
+          before { legacy_setup }
+        end
+      end
+    RUBY
+  end
+
+  it 'still registers an offense for hooks distinguished only by position' do
+    expect_offense(<<~RUBY)
+      describe Foo do
+        before { first }
+        ^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 3).
+        before { second }
+        ^^^^^^^^^^^^^^^^^ Do not define multiple `before` hooks in the same example group (also defined on line 2).
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Hooks in different branches of one conditional never both run, so they are not scattered setup:

```ruby
describe Foo do
  if flag
    before { setup_a }
  else
    before { setup_b }
  end
end
```

The cop groups hooks by `[name, scope, metadata]` and reports every member of a group, so it reports both of these today even though no example ever executes both.

A hook *outside* a conditional does run alongside one inside it, so only divergence at a **shared** conditional exempts a pair. That distinction is what `co_occurring`/`mutually_exclusive?` implement, and it is covered by specs in both directions — including a hook outside a `case` plus one inside it, where both are still reported.

### Precedent

This is the same reasoning `RSpec/EmptyExampleGroup` already applies: it walks conditional branches rather than treating branch contents as unconditional code. This PR brings `ScatteredSetup` in line with that.

### Scope

The change only exempts hooks that *cannot* run together. Hooks that can — including two in the same branch, and any hook pair outside a conditional — are still reported, so this does not weaken the cop for anyone who prefers to keep separate hooks unified.

### On the "you could use metadata instead" framing

An earlier version of this description argued these branches were exempt because metadata could not express them. That was wrong, and I have removed it: hash-style metadata already avoids the offense, and `define_derived_metadata` can derive metadata from arbitrary load-time conditions. Both are real options.

But they are answers to a different question. Rewriting a group so the cop stops firing is always possible; the question this PR asks is whether the code *as written* is scattered setup. When two hooks sit in exclusive branches of one conditional, it is not — no example runs both — and the cop's own grouping key is simply blind to that.

### A real-world shape this matters for

The pattern that motivated this is not the two-line `if/else` above. In a large private codebase there is a spec that iterates an enum of several hundred members and, per member, dispatches on it:

```ruby
KINDS.each do |kind|
  describe kind.name do
    case kind
    when Kind::A
      before { seed_prerequisite_for_a }
      it_behaves_like 'a valid result'
    when Kind::B
      before { seed_prerequisite_for_b }
      it_behaves_like 'a valid result'
    when Kind::C
      it_behaves_like 'a valid result'
    # ... several hundred more
    end
  end
end
```

Seventeen of those branches carry a `before`. Exactly one branch is taken per member, so no two of those hooks ever run together — yet the cop reports all seventeen, each naming the other sixteen.

This is also why "move the `case` inside the `before`" does not generalize. The branches mix a runtime hook with **definition-time** DSL: `it_behaves_like` has to run when the group is defined, so it cannot move inside a hook. Restructuring would mean two parallel `case` statements over the same enum — one at group level for the example groups, one inside a `before` for the setup — duplicating a several-hundred-line dispatch and putting the two copies permanently out of sync risk. That is decisively worse than the status quo.

### Note on the existing autocorrect

Unrelated to the false positive, but worth flagging separately: this cop's autocorrect concatenates hook bodies, which silently reorders setup relative to `let!` declarations and other hooks. I hit a `Parser::ClobberingError` while working on this when corrections from several offenses in one group overlapped, which is why the corrector now anchors on a single stable hook per co-occurring set. Happy to open a separate issue for the reordering behaviour.