### PR TITLE
Fix false positives for RSpec/InstanceVariable in blocks that define methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix an error for `RSpec/ImplicitExpect` when the runner is separated from `is_expected` by whitespace. ([@viralpraxis])
 - Fix false positives for `RSpec/InstanceVariable` when an instance variable is used inside a `class_eval` or `module_eval` block. ([@corsonknowles])
+- Fix false positives for `RSpec/InstanceVariable` when an instance variable is used inside a block that defines methods, such as an anonymous controller. ([@corsonknowles])
 - Fix false positives for `RSpec/Pending` when using SimpleCov 1.x `skip` filters. ([@gee-forr])
 - Speed up loading rubocop-rspec by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
 - Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials. ([@ydah])

--- a/docs/modules/ROOT/pages/cops_rspec.adoc
+++ b/docs/modules/ROOT/pages/cops_rspec.adoc
@@ -3140,6 +3140,16 @@ describe MyClass do
   let(:foo) { [] }
   it { expect(foo).to be_empty }
 end
+
+# good - an instance variable of a class whose body the spec opens,
+# here through rspec-rails' `controller`
+describe MyController do
+  controller do
+    def index
+      render json: @resource
+    end
+  end
+end
 ----
 
 [#with-assignmentonly-configuration-rspecinstancevariable]

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -23,6 +23,16 @@ module RuboCop
       #     it { expect(foo).to be_empty }
       #   end
       #
+      #   # good - an instance variable of a class whose body the spec opens,
+      #   # here through rspec-rails' `controller`
+      #   describe MyController do
+      #     controller do
+      #       def index
+      #         render json: @resource
+      #       end
+      #     end
+      #   end
+      #
       # @example with AssignmentOnly configuration
       #   # rubocop.yml
       #   # RSpec/InstanceVariable:
@@ -87,10 +97,45 @@ module RuboCop
         private
 
         def valid_usage?(node)
-          node.each_ancestor(:block).any? do |block|
-            dynamic_class?(block) || reopened_class?(block) ||
-              custom_matcher?(block)
+          child = node
+
+          node.each_ancestor do |ancestor|
+            return true if opens_another_body?(ancestor, child)
+
+            child = ancestor
           end
+
+          false
+        end
+
+        # Only a block's body counts. An instance variable in the receiver, as
+        # in `@controller.instance_eval { ... }`, is read in the surrounding
+        # scope and is still the example's.
+        def opens_another_body?(node, child)
+          return false unless node.block_type? && node.body.equal?(child)
+
+          dynamic_class?(node) || reopened_class?(node) ||
+            custom_matcher?(node) || class_body?(node)
+        end
+
+        # A block that defines methods is opening some object's body, so the
+        # instance variables written inside it belong to that object rather
+        # than to the example. That covers any DSL yielding a class body --
+        # rspec-rails' `controller` among them -- without naming one.
+        def class_body?(node)
+          !example_scope?(node) && defines_method?(node.body)
+        end
+
+        def defines_method?(body)
+          statements = body.begin_type? ? body.children : [body]
+          statements.any?(&:any_def_type?)
+        end
+
+        # A `def` in an example group belongs to the example group, so the
+        # instance variables in it are the example's and stay flagged.
+        def example_scope?(node)
+          spec_group?(node) || example?(node) || hook?(node) ||
+            let?(node) || subject?(node) || include?(node)
         end
 
         def assignment_only?

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -99,6 +99,131 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
   end
 
   # Regression test for nevir/rubocop-rspec#115
+  it 'ignores an instance variable in a macro call beside a method' do
+    expect_no_offenses(<<~RUBY)
+      describe MyController do
+        controller(described_class) do
+          authorize_action proxy: -> { Thing.new(id: @employee.id) }
+
+          def index
+            head :ok
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores an instance variable inside a block of an unknown DSL' do
+    expect_no_offenses(<<~RUBY)
+      describe MyMailer do
+        mailer do
+          def welcome
+            mail(from: @signature)
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores an instance variable inside a dynamic module' do
+    expect_no_offenses(<<~RUBY)
+      describe MyClass do
+        let(:context) do
+          Module.new do
+            def self.warnings
+              @warnings ||= []
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'flags an instance variable in a helper method of an example group' do
+    expect_offense(<<~RUBY)
+      describe MyClass do
+        before { @user = create(:user) }
+
+        def sign_in_as_user
+          session[:id] = @user.id
+                         ^^^^^ Avoid instance variables - use let, a method call, or a local variable (if possible).
+        end
+      end
+    RUBY
+  end
+
+  it 'flags an instance variable in an example beside a method definition' do
+    expect_offense(<<~RUBY)
+      describe MyClass do
+        def helper
+          :ok
+        end
+
+        before { @foo = [] }
+
+        it { expect(@foo).to be_empty }
+                    ^^^^ Avoid instance variables - use let, a method call, or a local variable (if possible).
+      end
+    RUBY
+  end
+
+  it 'flags an instance variable that is the receiver of a class-body block' do
+    expect_offense(<<~RUBY)
+      describe 'Index overriding' do
+        before do
+          @controller = Admin::PostsController.new
+          @controller.instance_eval do
+          ^^^^^^^^^^^ Avoid instance variables - use let, a method call, or a local variable (if possible).
+            def index
+              super
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores an instance variable inside an anonymous controller' do
+    expect_no_offenses(<<~RUBY)
+      describe MyController do
+        controller do
+          def index
+            render json: @resource
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores an instance variable in an anonymous controller with a parent' do
+    expect_no_offenses(<<~RUBY)
+      describe MyController do
+        controller(ApplicationController) do
+          def show
+            @thing ||= Thing.new
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'flags instance variables in examples beside an anonymous controller' do
+    expect_offense(<<~RUBY)
+      describe MyController do
+        controller do
+          def index
+            render json: @resource
+          end
+        end
+
+        before { @thing = 1 }
+
+        it { expect(@thing).to eq(1) }
+                    ^^^^^^ Avoid instance variables - use let, a method call, or a local variable (if possible).
+      end
+    RUBY
+  end
+
   it 'ignores instance variables outside of specs' do
     expect_no_offenses(<<~RUBY, 'lib/source_code.rb')
       feature do


### PR DESCRIPTION
`RSpec/InstanceVariable` already exempts `Class.new` and `class_eval` blocks, on the reasoning that such a block opens another object's body — the instance variables in it belong to that object, not to the example.

We added reopened class support here: 
* https://github.com/rubocop/rubocop-rspec/pull/2225

(split from this PR).

Rewritten to exempt that shape **generally**, by the property the exempt blocks share — *the block defines methods* — instead of naming the methods that yield a class body. rspec-rails' `controller` is then covered without this gem knowing anything about it, other than in example comments:

```ruby
describe MyController do
  controller do
    def index
      render json: @resource
    end
  end
end
```

`@resource` is the controller's own instance variable, typically set by a `before_action` or via `controller.instance_variable_set`. Rewriting it as a `let` isn't possible — it isn't the example's state.

### This replaces the `controller` matcher (addressing the open/closed concern)

@pirj — your point was that `controller` is rspec-rails DSL and shouldn't be hardcoded here. There is no `controller` in the implementation now; the only mention is in a doc example. So this needs neither a config hook nor a cross-gem extension mechanism, and `rubocop-rspec_rails` needs no change.

It also covers other DSLs of the same shape for free: 
* ActiveAdmin's `register`,
*  a `mailer do` helper, 
* `Module.new`, 
*`Struct.new` 
The oop no longer has to enumerate each such case.

```ruby
def valid_usage?(node)
  child = node

  node.each_ancestor do |ancestor|
    return true if opens_another_body?(ancestor, child)

    child = ancestor
  end

  false
end

def class_body?(node)
  !example_scope?(node) && defines_method?(node)
end
```

### Two guards, both specced

**A `def` in an example group is the example group's**, so instance variables in one stay flagged. This is what keeps the generalization from swallowing real offenses — without it, any `describe` containing a helper method would exempt its whole body:

```ruby
describe MyClass do
  before { @user = create(:user) }

  def sign_in_as_user
    session[:id] = @user.id
                   ^^^^^ Avoid instance variables - use let, a method call, or a local variable (if possible).
  end
end
```

**Only the block's body counts.** An instance variable in the *receiver* is read in the surrounding scope, so it stays flagged:

```ruby
before do
  @controller = Admin::PostsController.new
  @controller.instance_eval do
  ^^^^^^^^^^^ Avoid instance variables - use let, a method call, or a local variable (if possible).
    def index
      super
    end
  end
end
```

Worth noting this is a latent bug in the existing `reopened_class?` from #2225 as well: `@klass.class_eval { ... }` exempts the receiver `@klass` today, because the block is an ancestor of it. The `node.body.equal?(child)` check fixes that for all four exemptions at once. I found it because the generic predicate made it reachable from a real spec (an ActiveAdmin `instance_eval` case), not by reading the code.

`dynamic_class?` and `reopened_class?` are kept rather than folded in: they also exempt blocks that open a body *without* defining methods, such as `Class.new { @foo }`.

### Verification

Unit: 28 examples, 0 failures (11 new). Full suite 2479 examples, 0 failures. `rubocop lib spec` 286 files, no offenses. `rake confirm_documentation` and `documentation_syntax_check` clean.

Behaviour, measured rather than argued — I ran this cop and the previous `controller`-matcher version over **8,103 real spec files** (a large private Rails monolith, with its custom `RSpec/Language` example-group aliases registered), comparing the full offense sets:

| | files with offenses | offenses |
|---|---|---|
| `controller` matcher (previous revision) | 71 | 1074 |
| this revision | 71 | 1074 |

The sets are **byte-identical**. So dropping the Rails-specific matcher costs nothing on real code: the same 8 anonymous-controller instance variables are exempted, and no genuine offense is silenced. For scale, 1943 of the instance variables the cop visits in that corpus are decided by an example group, example or hook and stay flagged; 119 are exempted by `Class.new` (108), `controller` (8) and `class_eval` (3).

One correction to my earlier comment on this PR: I had guessed this would also fix instance variables in literal `class` bodies in spec files. It doesn't, and it shouldn't — `on_top_level_group` only searches inside a top-level example group, and such a class is a sibling of the group, so the cop never visits it. No behaviour there to change.

### Found via

A controller spec where `@_mock_partner` is read by a private method on the anonymous controller and set with `controller.instance_variable_set`. It accounted for 8 of the 98 `RSpec/InstanceVariable` offenses I measured in that codebase, and it was the only group of the set that wasn't a genuine instance-variable-to-`let` conversion.
