### PR TITLE
Fix false positives for RSpec/InstanceVariable in reopened classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix false positives for `RSpec/InstanceVariable` when an instance variable is used inside a `class_eval` or `module_eval` block. ([@corsonknowles])
 - Fix false positives for `RSpec/Pending` when using SimpleCov 1.x `skip` filters. ([@gee-forr])
 - Speed up loading rubocop-rspec by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
 - Fix false positives for `RSpec/SpecFilePathFormat` when matching spec partials. ([@ydah])

--- a/lib/rubocop/cop/rspec/instance_variable.rb
+++ b/lib/rubocop/cop/rspec/instance_variable.rb
@@ -56,6 +56,11 @@ module RuboCop
           (block (send (const nil? :Class) :new ...) ...)
         PATTERN
 
+        # @!method reopened_class?(node)
+        def_node_matcher :reopened_class?, <<~PATTERN
+          (block (send _ {:class_eval :module_eval} ...) ...)
+        PATTERN
+
         # @!method custom_matcher?(node)
         def_node_matcher :custom_matcher?, <<~PATTERN
           (block {
@@ -83,7 +88,8 @@ module RuboCop
 
         def valid_usage?(node)
           node.each_ancestor(:block).any? do |block|
-            dynamic_class?(block) || custom_matcher?(block)
+            dynamic_class?(block) || reopened_class?(block) ||
+              custom_matcher?(block)
           end
         end
 

--- a/spec/rubocop/cop/rspec/instance_variable_spec.rb
+++ b/spec/rubocop/cop/rspec/instance_variable_spec.rb
@@ -66,6 +66,38 @@ RSpec.describe RuboCop::Cop::RSpec::InstanceVariable do
     RUBY
   end
 
+  it 'ignores an instance variable inside a class_eval block' do
+    expect_no_offenses(<<~RUBY)
+      describe MyMailer do
+        let(:mailer_class) { Class.new(ApplicationMailer) }
+
+        before do
+          mailer_class.class_eval do
+            def welcome
+              mail(from: @signature)
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
+  it 'ignores an instance variable inside a module_eval block' do
+    expect_no_offenses(<<~RUBY)
+      describe MyConcern do
+        let(:concern) { Module.new }
+
+        before do
+          concern.module_eval do
+            def call
+              @context.fetch(:value)
+            end
+          end
+        end
+      end
+    RUBY
+  end
+
   # Regression test for nevir/rubocop-rspec#115
   it 'ignores instance variables outside of specs' do
     expect_no_offenses(<<~RUBY, 'lib/source_code.rb')


### PR DESCRIPTION
Extracted from #2224 at @pirj's request — that PR's anonymous-controller half is Rails-specific and still open on the question of how to extend a cop from another gem, whereas this half is plain Ruby and independent of it.

`dynamic_class?` matches `Class.new` **with a block**, so it already exempts:

```ruby
let(:object) do
  Class.new(OtherClass) do
    def serialize
      @resource.to_json
    end
  end
end
```

But the equivalent two-step shape — build the anonymous class, then reopen it — is not matched, so it gets flagged:

```ruby
let(:mailer_class) { Class.new(ApplicationMailer) }

before do
  mailer_class.class_eval do
    def welcome
      mail(from: @signature)
    end
  end
end
```

`@signature` there belongs to the mailer instance, not the example. It is typically set by the class under test or assigned via `instance_variable_set`, so the cop's suggested rewrite to a `let` does not apply — the ivar isn't the example's to own.

This exempts `class_eval` and `module_eval` blocks for exactly the reason `Class.new { }` is already exempt: the block opens another object's body, so ivars inside it are that object's, not the example group's. The receiver is left unconstrained (`(send _ {:class_eval :module_eval} ...)`) since the class being reopened is usually held in a `let` or a local rather than named inline.

## Verification

- `spec/rubocop/cop/rspec/instance_variable_spec.rb`: 19 examples, 0 failures (adds one example per method — `class_eval` and `module_eval`).
- `spec/project`: 20 examples, 0 failures.
- `bundle exec rubocop lib spec`: 286 files, no offenses.