### PR TITLE
Fix `RSpec/SpecFilePathFormat` raising when run from outside the project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix incorrect autocorrection for `RSpec/DescribedClass` when using nested example groups with `EnforcedStyle: explicit`. ([@ydah])
 - Fix `RSpec/MatchWithSimpleRegex` to ignore `match` outside examples. ([@ydah])
 - Fix incorrect autocorrection for `RSpec/ExampleWording` with percent literal and escaped example descriptions. ([@ydah])
+- Fix `RSpec/SpecFilePathFormat` raising when `EnforcedInflector: active_support` and RuboCop is invoked from outside the project root. ([@corsonknowles])
 
 ## 3.10.2 (2026-06-06)
 

--- a/lib/rubocop/cop/rspec/spec_file_path_format.rb
+++ b/lib/rubocop/cop/rspec/spec_file_path_format.rb
@@ -74,12 +74,10 @@ module RuboCop
             ActiveSupport::Inflector.underscore(string)
           end
 
-          def self.prepare_availability(config)
+          def self.prepare_availability(inflector_path)
             return if @prepared
 
             @prepared = true
-
-            inflector_path = config.fetch('InflectorPath')
 
             unless File.exist?(inflector_path)
               raise "The configured `InflectorPath` #{inflector_path} does " \
@@ -104,11 +102,18 @@ module RuboCop
         def inflector
           case cop_config.fetch('EnforcedInflector')
           when 'active_support'
-            ActiveSupportInflector.prepare_availability(cop_config)
+            ActiveSupportInflector.prepare_availability(inflector_path)
             ActiveSupportInflector
           when 'default'
             DefaultInflector
           end
+        end
+
+        def inflector_path
+          File.expand_path(
+            cop_config.fetch('InflectorPath'),
+            config.base_dir_for_path_parameters
+          )
         end
 
         def ensure_correct_file_path(send_node, class_name, arguments)

--- a/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
+++ b/spec/rubocop/cop/rspec/spec_file_path_format_spec.rb
@@ -379,10 +379,16 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
       }
     end
 
+    # The cop resolves `InflectorPath` against the config's base
+    # directory, which is the working directory in these specs.
+    let(:inflector_path) do
+      File.expand_path(cop_config['InflectorPath'])
+    end
+
     context 'when ActiveSupport inflections are available' do
       before do
         allow(File).to receive(:exist?)
-          .with(cop_config['InflectorPath']).and_return(true)
+          .with(inflector_path).and_return(true)
 
         allow(described_class::ActiveSupportInflector).to receive(:require)
           .with('active_support/inflector')
@@ -390,7 +396,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
                    Module.new { def self.underscore(_); end })
 
         allow(described_class::ActiveSupportInflector).to receive(:require)
-          .with('./config/initializers/inflections.rb')
+          .with(File.expand_path('./config/initializers/inflections.rb'))
         allow(ActiveSupport::Inflector).to receive(:underscore)
           .with('PvPClass').and_return('pvp_class')
         allow(ActiveSupport::Inflector).to receive(:underscore)
@@ -431,18 +437,18 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
     describe 'errors during preparation' do
       it 'shows an error when the configured inflector file does not exist' do
         allow(File).to receive(:exist?)
-          .with(cop_config['InflectorPath']).and_return(false)
+          .with(inflector_path).and_return(false)
 
         expect do
           inspect_source('describe PvPClass do; end', 'pv_p_class_spec.rb')
-        end.to raise_error('The configured `InflectorPath` ./config' \
-                           '/initializers/inflections.rb does not exist.')
+        end.to raise_error("The configured `InflectorPath` #{inflector_path} " \
+                           'does not exist.')
       end
 
       it 'lets LoadError pass all the way up when ActiveSupport loading ' \
          'raises an error' do
         allow(File).to receive(:exist?)
-          .with(cop_config['InflectorPath']).and_return(true)
+          .with(inflector_path).and_return(true)
 
         allow(described_class::ActiveSupportInflector).to receive(:require)
           .with('active_support/inflector').and_raise(LoadError)
@@ -465,9 +471,10 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
         allow(File).to receive(:exist?).and_call_original
         # Ensure default path is not checked when custom path is configured
         allow(File).to receive(:exist?)
-          .with('./config/initializers/inflections.rb').and_return(false)
+          .with(File.expand_path('./config/initializers/inflections.rb'))
+          .and_return(false)
         allow(File).to receive(:exist?)
-          .with(cop_config['InflectorPath']).and_return(true)
+          .with(inflector_path).and_return(true)
 
         allow(described_class::ActiveSupportInflector).to receive(:require)
           .with('active_support/inflector')
@@ -475,7 +482,7 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
                    Module.new { def self.underscore(_); end })
 
         allow(described_class::ActiveSupportInflector).to receive(:require)
-          .with(cop_config['InflectorPath'])
+          .with(inflector_path)
         allow(ActiveSupport::Inflector).to receive(:underscore)
           .with('HTTPClient').and_return('http_client')
       end
@@ -489,7 +496,41 @@ RSpec.describe RuboCop::Cop::RSpec::SpecFilePathFormat, :config do
         expect(File).to have_received(:exist?)
           .with('/custom/path/to/inflections.rb')
         expect(File).not_to have_received(:exist?)
-          .with('./config/initializers/inflections.rb')
+          .with(File.expand_path('./config/initializers/inflections.rb'))
+      end
+    end
+
+    context 'when RuboCop is invoked from outside the project root' do
+      let(:project_root) { '/somewhere/else' }
+
+      before do
+        allow(config).to receive(:base_dir_for_path_parameters)
+          .and_return(project_root)
+
+        allow(File).to receive(:exist?).and_call_original
+        allow(File).to receive(:exist?)
+          .with("#{project_root}/config/initializers/inflections.rb")
+          .and_return(true)
+
+        allow(described_class::ActiveSupportInflector).to receive(:require)
+          .with('active_support/inflector')
+        stub_const('ActiveSupport::Inflector',
+                   Module.new { def self.underscore(_); end })
+
+        allow(described_class::ActiveSupportInflector).to receive(:require)
+          .with("#{project_root}/config/initializers/inflections.rb")
+        allow(ActiveSupport::Inflector).to receive(:underscore)
+          .with('HTTPClient').and_return('http_client')
+      end
+
+      it 'resolves a relative `InflectorPath` against the config directory ' \
+         'rather than the working directory', :aggregate_failures do
+        expect_no_offenses(<<~RUBY, 'http_client_spec.rb')
+          describe HTTPClient do; end
+        RUBY
+
+        expect(File).to have_received(:exist?)
+          .with("#{project_root}/config/initializers/inflections.rb")
       end
     end
   end


### PR DESCRIPTION
## Problem

`InflectorPath` is a path parameter, but it is the only one RuboCop does not resolve against the config's base directory. Both the existence check and the `require` see the raw configured value:

```ruby
inflector_path = config.fetch('InflectorPath')

unless File.exist?(inflector_path)
  raise "The configured `InflectorPath` #{inflector_path} does not exist."
end
```

So the default `./config/initializers/inflections.rb` is resolved against the **process working directory**. With `EnforcedInflector: active_support`, that means the cop raises whenever RuboCop is invoked from anywhere but the project root — an editor integration that runs it from the file's own folder, or a Git worktree. It surfaces as a RuboCop error with no offense reported, which reads like a bug in the cop rather than a path that could not be found.

## Fix

Resolve it with `config.base_dir_for_path_parameters` — the same anchor `Include` and `Exclude` already use, so `InflectorPath` now behaves like every other path parameter. Relative paths are anchored to the directory of the `.rubocop.yml` that set them; absolute paths are unaffected, since `File.expand_path` is a no-op for them.

`prepare_availability` now takes the resolved path rather than the whole `cop_config`, which also narrows its interface to the one value it actually used.

## Tests

A new example pins the behaviour: with the config's base directory pointing somewhere other than the working directory, the cop checks `<config dir>/config/initializers/inflections.rb`. It fails on `master` and passes with this change.

The existing `InflectorPath` examples stubbed `File.exist?` with the raw relative value, so they are updated to the resolved path.

## Verification

- `bundle exec rspec spec/rubocop/cop/rspec/spec_file_path_format_spec.rb` — 60 examples, 0 failures
- `bundle exec rubocop` — clean on both changed files
- Full suite: 2466 examples, 2 failures — both in `context_wording_spec.rb`, and both reproduce on an unmodified `master` in my environment (they involve Japanese `とき` patterns and look locale-related), so they are unrelated to this change.