### PR TITLE
Fix an error for `RSpec/ImplicitExpect` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master (Unreleased)
 
+- Fix an error for `RSpec/ImplicitExpect` when the runner is separated from `is_expected` by whitespace. ([@viralpraxis])
 - Fix false positives for `RSpec/InstanceVariable` when an instance variable is used inside a `class_eval` or `module_eval` block. ([@corsonknowles])
 - Fix false positives for `RSpec/Pending` when using SimpleCov 1.x `skip` filters. ([@gee-forr])
 - Speed up loading rubocop-rspec by lazily loading only the cops needed for a run. This requires RuboCop 1.89.0+. ([@koic])
@@ -1136,6 +1137,7 @@ Compatibility release so users can upgrade RuboCop to 0.51.0. No new features.
 [@topalovic]: https://github.com/topalovic
 [@twalpole]: https://github.com/twalpole
 [@ushi-as]: https://github.com/ushi-as
+[@viralpraxis]: https://github.com/viralpraxis
 [@vzvu3k6k]: https://github.com/vzvu3k6k
 [@walf443]: https://github.com/walf443
 [@yasu551]: https://github.com/yasu551

--- a/lib/rubocop/cop/rspec/implicit_expect.rb
+++ b/lib/rubocop/cop/rspec/implicit_expect.rb
@@ -49,7 +49,7 @@ module RuboCop
         def on_send(node)
           return unless (source_range = offending_expect(node))
 
-          expectation_source = source_range.source
+          expectation_source = source_range.source.gsub(/\s+/, '')
 
           if expectation_source.start_with?(style.to_s)
             correct_style_detected

--- a/spec/rubocop/cop/rspec/implicit_expect_spec.rb
+++ b/spec/rubocop/cop/rspec/implicit_expect_spec.rb
@@ -97,4 +97,33 @@ RSpec.describe RuboCop::Cop::RSpec::ImplicitExpect do
                     'it { should be_truthy }',
                     'should'
   end
+
+  context 'when the runner is separated from `is_expected`' do
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'should' }
+    end
+
+    it 'flags a chain split over lines' do
+      expect_offense(<<~RUBY)
+        is_expected
+        ^^^^^^^^^^^ Prefer `should` over `is_expected.to`.
+          .to be_truthy
+      RUBY
+
+      expect_correction(<<~RUBY)
+        should be_truthy
+      RUBY
+    end
+
+    it 'flags spaces around the dot' do
+      expect_offense(<<~RUBY)
+        is_expected . to be_truthy
+        ^^^^^^^^^^^^^^^^ Prefer `should` over `is_expected.to`.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        should be_truthy
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
An MRE:

```bash
$ bundle exec rubocop --debug --stdin a_spec.rb -a --config <(cat <<'YAML'
plugins:
  - rubocop-rspec
AllCops:
  DisabledByDefault: true
  SuggestExtensions: false
RSpec/ImplicitExpect:
  Enabled: true
  EnforcedStyle: should
YAML
) <<'RUBY'
is_expected
  .to be_truthy
RUBY
configuration from /proc/self/fd/11
Plugin configuration from config/default.yml
Inspecting 1 file
Scanning a_spec.rb
An error occurred while RSpec/ImplicitExpect cop was inspecting a_spec.rb:1:0.
lib/rubocop/cop/rspec/implicit_expect.rb:95:in 'Hash#fetch': key not found: "is_expected\n  .to" (KeyError)
Did you mean?  "is_expected.to"
               "is_expected.not_to"
	from lib/rubocop/cop/rspec/implicit_expect.rb:95:in 'RuboCop::Cop::RSpec::ImplicitExpect#replacement_source'
	from lib/rubocop/cop/rspec/implicit_expect.rb:89:in 'RuboCop::Cop::RSpec::ImplicitExpect#offense_message'
	from lib/rubocop/cop/rspec/implicit_expect.rb:59:in 'RuboCop::Cop::RSpec::ImplicitExpect#on_send'
	from lib/rubocop/cop/commissioner.rb:145:in 'Kernel#public_send'
	from lib/rubocop/cop/commissioner.rb:145:in 'block (2 levels) in RuboCop::Cop::Commissioner#trigger_restricted_cops'
```

Found by `rubocop-nightly`.

______________________________________________________________________

Before submitting the PR make sure the following are checked:

- [X] Feature branch is up-to-date with `master` (if not - rebase it).
- [X] Squashed related commits together.
- [X] Added tests.
- [X] Updated documentation.
- [X] Added an entry to the `CHANGELOG.md` if the new code introduces user-observable changes.
- [X] The build (`bundle exec rake`) passes (be sure to run this locally, since it may produce updated documentation that you will need to commit).

If you have created a new cop:

- [ ] Added the new cop to `config/default.yml`.
- [ ] The cop is configured as `Enabled: pending` in `config/default.yml`.
- [ ] The cop is configured as `Enabled: true` in `.rubocop.yml`.
- [ ] The cop documents examples of good and bad code.
- [ ] The tests assert both that bad code is reported and that good code is not reported.
- [ ] Set `VersionAdded: "<<next>>"` in `default/config.yml`.

If you have modified an existing cop's configuration options:

- [ ] Set `VersionChanged: "<<next>>"` in `config/default.yml`.
